### PR TITLE
Initialize Go + Echo v5 backend with golangci-lint

### DIFF
--- a/.claude/rules/general.md
+++ b/.claude/rules/general.md
@@ -36,12 +36,12 @@ AWS マネージドサービスを利用する。
 
 ### ci.yml — push to main / pull_request
 
-frontend-ci と backend-ci を**並列ジョブ**で実行。各ジョブ内は lint → test の順で直列（lint 失敗で早期終了）。
+frontend と backend を**並列ジョブ**で実行。各ジョブ内は lint → test の順で直列（lint 失敗で早期終了）。
 
 | Job | Steps |
 |-----|-------|
-| frontend-ci | Biome (lint + format) → tsc (型チェック) → Vitest (unit test) |
-| backend-ci | golangci-lint → go test (unit) → testcontainers + PG (integration) |
+| frontend | Biome (lint + format) → tsc (型チェック) → Vitest (unit test) |
+| backend | golangci-lint → go test (unit) → testcontainers + PG (integration) |
 
 ### e2e.yml — pull_request (main へのマージ時のみ)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,24 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  backend-ci:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          working-directory: backend
+
+      - name: Build
+        run: go build ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  frontend-ci:
+  frontend:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -31,7 +31,7 @@ jobs:
       - name: Build
         run: npm run build
 
-  backend-ci:
+  backend:
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,4 @@
 [tools]
 node = "24"
 go = "1.26"
+golangci-lint = "2"

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,5 @@
+module github.com/IsaoTakahashi/pantry-panel/backend
+
+go 1.26.2
+
+require github.com/labstack/echo/v5 v5.1.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,2 @@
+github.com/labstack/echo/v5 v5.1.0 h1:MvIRydoN+p9cx/zq8Lff6YXqUW2ZaEsOMISzEGSMrBI=
+github.com/labstack/echo/v5 v5.1.0/go.mod h1:SyvlSdObGjRXeQfCCXW/sybkZdOOQZBmpKF0bvALaeo=

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+)
+
+func main() {
+	e := echo.New()
+
+	e.GET("/", func(c *echo.Context) error {
+		return c.String(http.StatusOK, "Healthy")
+	})
+
+	if err := e.Start(":8080"); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- `backend/` に Go + Echo v5 プロジェクトを作成
- `GET /` で `Healthy` を返す仮エンドポイントを実装
- golangci-lint を mise 経由で導入
- CI に backend-ci ジョブを追加（golangci-lint + go build）

Closes #10

## Test plan
- [ ] `go run main.go` でサーバーが起動し、`curl http://localhost:8080/` で `Healthy` が返る
- [ ] `golangci-lint run ./...` が 0 issues で pass する
- [ ] CI の frontend-ci / backend-ci がともに green

🤖 Generated with [Claude Code](https://claude.com/claude-code)