### PR TITLE
Add documentation references to backend rules

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -26,6 +26,15 @@
 
 - **golangci-lint** — Go の標準的なリンターアグリゲータ。
 
+## ドキュメント参照
+
+| ツール | URL | 備考 |
+|--------|-----|------|
+| Echo | https://echo.labstack.com/docs | 公式ドキュメント（llms.txt 未提供） |
+| pgx | https://pkg.go.dev/github.com/jackc/pgx/v5 | Go Packages API リファレンス |
+| testcontainers-go | https://golang.testcontainers.org/ | 公式ドキュメント |
+| golangci-lint | https://golangci-lint.run/docs/ | 公式ドキュメント |
+
 ## リアルタイム同期フロー
 
 1. REST API でデータ更新を受け付ける


### PR DESCRIPTION
## Summary
- backend.md にドキュメント参照セクションを追加（Echo, pgx, testcontainers-go, golangci-lint）
- frontend.md の既存ドキュメント参照は最新であることを確認済み（変更なし）

## Background
frontend.md には既にドキュメント参照テーブルがあったが、backend.md にはなかった。backend で利用しているFW・ライブラリの公式ドキュメントURLを同じ形式で追加し、仕様の把握を容易にする。