### PR TITLE
Add CI unit test and E2E workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+      - name: Unit test
+        run: npm test
+
       - name: Build
         run: npm run build
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,67 @@
+name: E2E
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: pantry
+          POSTGRES_PASSWORD: pantry
+          POSTGRES_DB: pantry_panel
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U pantry -d pantry_panel"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+        working-directory: frontend
+
+      - name: Start backend
+        run: go run . &
+        working-directory: backend
+        env:
+          DATABASE_URL: postgres://pantry:pantry@localhost:5432/pantry_panel?sslmode=disable
+
+      - name: Wait for backend
+        run: |
+          for i in $(seq 1 30); do
+            if curl -s http://localhost:8080/health > /dev/null 2>&1; then
+              echo "Backend is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Backend failed to start"
+          exit 1
+
+      - name: Run E2E tests
+        run: npx playwright test
+        working-directory: frontend


### PR DESCRIPTION
Closes #15

## Summary
- `ci.yml` に Frontend の unit テスト（Vitest）ステップを追加
- `e2e.yml` を新規作成し、Backend + DB + Frontend を起動して Playwright E2E テストを実行

## Changes
- `.github/workflows/ci.yml` — Frontend ジョブに `npm test` ステップ追加
- `.github/workflows/e2e.yml` — PostgreSQL サービスコンテナ + Backend + Playwright E2E テスト

## Test plan
- [x] CI workflow: frontend ジョブで Biome → tsc → Vitest → Build が pass すること
- [x] CI workflow: backend ジョブで golangci-lint → go test → Build が pass すること
- [x] E2E workflow: PostgreSQL + Backend + Frontend 起動後に Playwright テストが pass すること