### PR TITLE
Add frontend API client and types for stock items

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchHealth } from "./api";
+import {
+  createStockItem,
+  deleteStockItem,
+  fetchHealth,
+  fetchStockItems,
+  updateStockItem,
+} from "./api";
 
 describe("fetchHealth", () => {
   afterEach(() => {
@@ -31,5 +37,129 @@ describe("fetchHealth", () => {
     );
 
     await expect(fetchHealth()).rejects.toThrow("Failed to fetch");
+  });
+});
+
+describe("fetchStockItems", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("正常レスポンスで StockItem[] を返す", async () => {
+    const items = [
+      {
+        id: "1",
+        name: "醤油",
+        category: "調味料",
+        imageUrl: null,
+        wantToBuy: false,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ];
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(items), { status: 200 }),
+    );
+
+    const result = await fetchStockItems();
+    expect(result).toEqual(items);
+  });
+
+  it("エラーレスポンスでthrowされる", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(null, { status: 500 }),
+    );
+
+    await expect(fetchStockItems()).rejects.toThrow("HTTP 500");
+  });
+});
+
+describe("createStockItem", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("正常レスポンスで StockItem を返す", async () => {
+    const item = {
+      id: "1",
+      name: "醤油",
+      category: "調味料",
+      imageUrl: null,
+      wantToBuy: false,
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    };
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(item), { status: 201 }),
+    );
+
+    const result = await createStockItem({ name: "醤油", category: "調味料" });
+    expect(result).toEqual(item);
+  });
+
+  it("409レスポンスでthrowされる", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(null, { status: 409 }),
+    );
+
+    await expect(
+      createStockItem({ name: "醤油", category: "調味料" }),
+    ).rejects.toThrow("HTTP 409");
+  });
+});
+
+describe("updateStockItem", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("正常レスポンスで StockItem を返す", async () => {
+    const item = {
+      id: "1",
+      name: "醤油",
+      category: "調味料",
+      imageUrl: null,
+      wantToBuy: false,
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    };
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(item), { status: 200 }),
+    );
+
+    const result = await updateStockItem("1", { name: "こいくち醤油" });
+    expect(result).toEqual(item);
+  });
+
+  it("404レスポンスでthrowされる", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(null, { status: 404 }),
+    );
+
+    await expect(
+      updateStockItem("999", { name: "こいくち醤油" }),
+    ).rejects.toThrow("HTTP 404");
+  });
+
+  describe("deleteStockItem", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("正常レスポンスで void を返す", async () => {
+      vi.spyOn(global, "fetch").mockResolvedValue(
+        new Response(null, { status: 204 }),
+      );
+
+      await expect(deleteStockItem("1")).resolves.toBeUndefined();
+    });
+
+    it("404レスポンスでthrowされる", async () => {
+      vi.spyOn(global, "fetch").mockResolvedValue(
+        new Response(null, { status: 404 }),
+      );
+
+      await expect(deleteStockItem("999")).rejects.toThrow("HTTP 404");
+    });
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,9 @@
 import type { HealthResponse } from "@/types/health";
+import type {
+  CreateStockItemRequest,
+  StockItem,
+  UpdateStockItemRequest,
+} from "@/types/stockItem";
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080";
@@ -11,4 +16,60 @@ async function fetchHealth(): Promise<HealthResponse> {
   return response.json();
 }
 
-export { fetchHealth };
+async function fetchStockItems(): Promise<StockItem[]> {
+  const response = await fetch(`${API_BASE_URL}/api/stock-items`);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+async function createStockItem(
+  req: CreateStockItemRequest,
+): Promise<StockItem> {
+  const response = await fetch(`${API_BASE_URL}/api/stock-items`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(req),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+async function updateStockItem(
+  id: string,
+  req: UpdateStockItemRequest,
+): Promise<StockItem> {
+  const response = await fetch(`${API_BASE_URL}/api/stock-items/${id}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(req),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+async function deleteStockItem(id: string): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/api/stock-items/${id}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+}
+
+export {
+  createStockItem,
+  deleteStockItem,
+  fetchHealth,
+  fetchStockItems,
+  updateStockItem,
+};

--- a/frontend/src/types/stockItem.ts
+++ b/frontend/src/types/stockItem.ts
@@ -1,0 +1,31 @@
+type StockItem = {
+  id: string;
+  name: string;
+  category: string;
+  imageUrl: string | null;
+  wantToBuy: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type CreateStockItemRequest = {
+  name: string;
+  category: string;
+};
+
+type UpdateStockItemRequest = {
+  name?: string;
+  category?: string;
+  wantToBuy?: boolean;
+};
+
+type ErrorResponse = {
+  message: string;
+};
+
+export type {
+  CreateStockItemRequest,
+  ErrorResponse,
+  StockItem,
+  UpdateStockItemRequest,
+};

--- a/openspec/changes/phase1-stock-items-crud/tasks.md
+++ b/openspec/changes/phase1-stock-items-crud/tasks.md
@@ -21,9 +21,9 @@
 
 ## 4. Frontend — API クライアント・型定義
 
-- [ ] 4.1 TypeScript の型定義を作成する（StockItem, CreateStockItemRequest 等）
-- [ ] 4.2 API クライアント関数を実装する（fetchStockItems, createStockItem, deleteStockItem）
-- [ ] 4.3 API クライアントのテストを設計・実装する
+- [x] 4.1 TypeScript の型定義を作成する（StockItem, CreateStockItemRequest 等）
+- [x] 4.2 API クライアント関数を実装する（fetchStockItems, createStockItem, deleteStockItem）
+- [x] 4.3 API クライアントのテストを設計・実装する
 
 ## 5. Frontend — 商品一覧ページ
 


### PR DESCRIPTION
## Summary
- StockItem / CreateStockItemRequest / UpdateStockItemRequest / ErrorResponse の型定義追加
- API クライアント関数追加（fetchStockItems, createStockItem, updateStockItem, deleteStockItem）
- API クライアントのユニットテスト追加（11テスト）

Phase 1 タスク 4（Frontend API クライアント・型定義）に対応。

## Test plan
- [x] Vitest unit tests pass locally (11 tests)
- [ ] CI passes (Biome lint + tsc + Vitest)