### PR TITLE
Fix create item modal UX: cancel button and state reset

### DIFF
--- a/frontend/src/components/CreateItemModal.test.tsx
+++ b/frontend/src/components/CreateItemModal.test.tsx
@@ -67,4 +67,48 @@ describe("CreateItemModal", () => {
       expect(screen.getByText("その商品は登録済みです")).toBeInTheDocument();
     });
   });
+
+  it("キャンセルボタンを押すと onClose が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <CreateItemModal isOpen={true} onClose={onClose} onCreate={vi.fn()} />,
+    );
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("キャンセル後に再度開くと入力がリセットされる", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <CreateItemModal isOpen={true} onClose={vi.fn()} onCreate={vi.fn()} />,
+    );
+    await user.type(screen.getByLabelText("名前"), "醤油");
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+    rerender(
+      <CreateItemModal isOpen={false} onClose={vi.fn()} onCreate={vi.fn()} />,
+    );
+    rerender(
+      <CreateItemModal isOpen={true} onClose={vi.fn()} onCreate={vi.fn()} />,
+    );
+    expect(screen.getByLabelText("名前")).toHaveValue("");
+  });
+
+  it("送信成功後に再度開くと入力がリセットされる", async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const { rerender } = render(
+      <CreateItemModal isOpen={true} onClose={vi.fn()} onCreate={onCreate} />,
+    );
+    await user.type(screen.getByLabelText("名前"), "醤油");
+    await user.selectOptions(screen.getByLabelText("カテゴリ"), "調味料");
+    await user.click(screen.getByRole("button", { name: "追加" }));
+    rerender(
+      <CreateItemModal isOpen={false} onClose={vi.fn()} onCreate={onCreate} />,
+    );
+    rerender(
+      <CreateItemModal isOpen={true} onClose={vi.fn()} onCreate={onCreate} />,
+    );
+    expect(screen.getByLabelText("名前")).toHaveValue("");
+  });
 });

--- a/frontend/src/components/CreateItemModal.tsx
+++ b/frontend/src/components/CreateItemModal.tsx
@@ -17,11 +17,19 @@ export default function CreateItemModal({
   const [name, setName] = useState("");
   const [category, setCategory] = useState("");
   const [error, setError] = useState<string | null>(null);
+
+  const handleClose = () => {
+    setName("");
+    setCategory("");
+    setError(null);
+    onClose();
+  };
+
   if (!isOpen) return null;
   return (
     <div
       role="dialog"
-      className={`fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 ${"block"}`}
+      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50"
     >
       <div className="bg-white p-6 rounded shadow-md w-80">
         <h2 className="text-xl font-bold mb-4">商品を追加</h2>
@@ -29,10 +37,14 @@ export default function CreateItemModal({
           onSubmit={(e) => {
             e.preventDefault();
             onCreate(name, category)
-              .then(onClose)
+              .then(handleClose)
               .catch((err) => {
-                if (err.message.includes("409")) {
-                  setError(err.message);
+                const error =
+                  err instanceof Error ? err : new Error(String(err));
+                if (error.message.includes("409")) {
+                  setError("その商品は登録済みです");
+                } else {
+                  setError(error.message || "エラーが発生しました");
                 }
               });
           }}
@@ -74,14 +86,23 @@ export default function CreateItemModal({
               ))}
             </select>
           </div>
-          <button
-            disabled={!name || !category}
-            type="submit"
-            className="w-full bg-blue-500 text-white py-2 rounded disabled:bg-gray-300"
-          >
-            追加
-          </button>
-          {error && <p className="text-red-500 mt-2">その商品は登録済みです</p>}
+          <div className="flex gap-2">
+            <button
+              disabled={!name || !category}
+              type="submit"
+              className="w-full mt-2 bg-blue-500 text-white py-2 rounded disabled:bg-gray-300"
+            >
+              追加
+            </button>
+            <button
+              type="button"
+              onClick={handleClose}
+              className="w-full mt-2 bg-gray-500 text-white py-2 rounded"
+            >
+              キャンセル
+            </button>
+          </div>
+          {error && <p className="text-red-500 mt-2">{error}</p>}
         </form>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add cancel button to close the modal without submitting
- Reset modal state (name, category, error) on close so reopening shows empty inputs
- Improve error display to show actual error message instead of always showing "登録済み"

## Test plan
- [x] `npx vitest run src/components/CreateItemModal.test.tsx` — 9 tests pass
- [x] Click cancel button closes the modal
- [x] After cancelling or submitting, reopening the modal shows empty inputs
- [x] 409 error shows "その商品は登録済みです", other errors show their message

🤖 Generated with [Claude Code](https://claude.com/claude-code)