### PR TITLE
Add E2E test for stock items CRUD flow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,6 +44,12 @@ jobs:
         run: npx playwright install chromium
         working-directory: frontend
 
+      - name: Apply DB migrations
+        run: |
+          for f in backend/db/migrations/*.sql; do
+            psql "postgres://pantry:pantry@localhost:5432/pantry_panel?sslmode=disable" -f "$f"
+          done
+
       - name: Start backend
         run: go run . &
         working-directory: backend

--- a/frontend/e2e/stock-items.spec.ts
+++ b/frontend/e2e/stock-items.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+test("商品を登録して削除できる", async ({ page }) => {
+  const itemName = `醤油-${Date.now()}`;
+
+  await page.goto("/stock-items");
+
+  // 商品登録
+  await page.getByRole("button", { name: "商品を追加" }).click();
+  await page.getByLabel("名前").fill(itemName);
+  await page.getByLabel("カテゴリ").selectOption("調味料");
+  await page.getByRole("button", { name: "追加", exact: true }).click();
+
+  // 登録した商品が表示されていることを確認
+  await expect(page.getByText(itemName)).toBeVisible();
+
+  // 商品を削除
+  page.once("dialog", (dialog) => dialog.accept());
+  await page
+    .getByRole("article", { name: itemName })
+    .getByRole("button", { name: "削除" })
+    .click();
+
+  // 商品が削除されていることを確認
+  await expect(page.getByText(itemName)).not.toBeVisible();
+});

--- a/frontend/src/components/ItemCard.tsx
+++ b/frontend/src/components/ItemCard.tsx
@@ -8,7 +8,10 @@ export default function ItemCard({
   onDelete: (id: string) => void;
 }) {
   return (
-    <div className="flex items-center gap-4 rounded-lg border bg-white p-4 shadow-sm transition-shadow hover:shadow-md">
+    <article
+      aria-label={item.name}
+      className="flex items-center gap-4 rounded-lg border bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
+    >
       <div className="flex-1">
         <span className="inline-block bg-[#ebfffc] text-[#00947e] text-xs px-2 py-0.5 rounded-full mb-1">
           {item.category}
@@ -24,6 +27,6 @@ export default function ItemCard({
           削除
         </button>
       )}
-    </div>
+    </article>
   );
 }


### PR DESCRIPTION
## Summary
- Add Playwright E2E test for stock items create → list → delete flow
- Add `role="article"` and `aria-label` to ItemCard so the test can scope queries to a specific item
- Apply DB migrations in the e2e CI workflow before starting the backend (psql loop)

## Phase 1 task group 8 をクローズします
- 8.1 手動結合確認 (済)
- 8.2 E2E テスト追加 (本 PR)
- 8.3 CI で E2E が pass することを確認 (本 PR の CI で確認)

## Test plan
- [x] ローカルで `npx playwright test` が pass
- [x] `npx vitest run` で全 unit テスト pass (38/38)
- [x] `npx biome check` クリーン
- [x] CI の e2e job が pass することを確認