### PR TITLE
Refactor frontend tests for consistency

### DIFF
--- a/frontend/src/app/health/page.test.tsx
+++ b/frontend/src/app/health/page.test.tsx
@@ -1,24 +1,27 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchHealth } from "@/lib/api";
 import HealthPage from "./page";
 
-vi.mock("@/lib/api", () => ({
-  fetchHealth: vi.fn(),
-}));
-
-const mockFetchHealth = vi.mocked(fetchHealth);
+vi.mock("@/lib/api");
 
 describe("HealthPage", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("初期表示でloading状態が表示される", () => {
-    mockFetchHealth.mockReturnValue(new Promise(() => {})); // 永遠に解決しないPromiseを返す
+    vi.mocked(fetchHealth).mockReturnValue(new Promise(() => {})); // 永遠に解決しないPromiseを返す
     render(<HealthPage />);
 
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
   it("fetch成功後にok状態が表示される", async () => {
-    mockFetchHealth.mockResolvedValue({ status: "ok", db: "connected" });
+    vi.mocked(fetchHealth).mockResolvedValue({
+      status: "ok",
+      db: "connected",
+    });
     render(<HealthPage />);
 
     await waitFor(() => {
@@ -28,7 +31,10 @@ describe("HealthPage", () => {
   });
 
   it("fetch失敗後にerror状態が表示される", async () => {
-    mockFetchHealth.mockResolvedValue({ status: "error", db: "disconnected" });
+    vi.mocked(fetchHealth).mockResolvedValue({
+      status: "error",
+      db: "disconnected",
+    });
     render(<HealthPage />);
 
     await waitFor(() => {
@@ -38,7 +44,7 @@ describe("HealthPage", () => {
   });
 
   it("fetchで例外が発生した場合にerror状態が表示される", async () => {
-    mockFetchHealth.mockRejectedValue(new Error("Network error"));
+    vi.mocked(fetchHealth).mockRejectedValue(new Error("Network error"));
     render(<HealthPage />);
 
     await waitFor(() => {

--- a/frontend/src/components/ItemCard.test.tsx
+++ b/frontend/src/components/ItemCard.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import ItemCard from "@/components/ItemCard";
 import type { StockItem } from "@/types/stockItem";
+import ItemCard from "./ItemCard";
 
 const baseItem: StockItem = {
   id: "1",

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -7,11 +7,11 @@ import {
   updateStockItem,
 } from "./api";
 
-describe("fetchHealth", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
+describe("fetchHealth", () => {
   it("正常レスポンスで HealthResponse を返す", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ status: "ok", db: "connected" }), {
@@ -41,10 +41,6 @@ describe("fetchHealth", () => {
 });
 
 describe("fetchStockItems", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("正常レスポンスで StockItem[] を返す", async () => {
     const items = [
       {
@@ -75,10 +71,6 @@ describe("fetchStockItems", () => {
 });
 
 describe("createStockItem", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("正常レスポンスで StockItem を返す", async () => {
     const item = {
       id: "1",
@@ -109,10 +101,6 @@ describe("createStockItem", () => {
 });
 
 describe("updateStockItem", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("正常レスポンスで StockItem を返す", async () => {
     const item = {
       id: "1",
@@ -141,25 +129,31 @@ describe("updateStockItem", () => {
     ).rejects.toThrow("HTTP 404");
   });
 
-  describe("deleteStockItem", () => {
-    afterEach(() => {
-      vi.restoreAllMocks();
-    });
+  it("409レスポンスでthrowされる", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(null, { status: 409 }),
+    );
 
-    it("正常レスポンスで void を返す", async () => {
-      vi.spyOn(global, "fetch").mockResolvedValue(
-        new Response(null, { status: 204 }),
-      );
+    await expect(updateStockItem("1", { name: "醤油" })).rejects.toThrow(
+      "HTTP 409",
+    );
+  });
+});
 
-      await expect(deleteStockItem("1")).resolves.toBeUndefined();
-    });
+describe("deleteStockItem", () => {
+  it("正常レスポンスで void を返す", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
 
-    it("404レスポンスでthrowされる", async () => {
-      vi.spyOn(global, "fetch").mockResolvedValue(
-        new Response(null, { status: 404 }),
-      );
+    await expect(deleteStockItem("1")).resolves.toBeUndefined();
+  });
 
-      await expect(deleteStockItem("999")).rejects.toThrow("HTTP 404");
-    });
+  it("404レスポンスでthrowされる", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(null, { status: 404 }),
+    );
+
+    await expect(deleteStockItem("999")).rejects.toThrow("HTTP 404");
   });
 });


### PR DESCRIPTION
## Summary
- Fix nested `describe` block in `api.test.ts` (deleteStockItem was inside updateStockItem)
- Add `updateStockItem` 409 case for symmetry with `createStockItem`
- Consolidate `afterEach(vi.restoreAllMocks)` to top-level in `api.test.ts`
- Unify `vi.mock("@/lib/api")` style (auto-mock) and add missing `afterEach` cleanup in `health/page.test.tsx`
- Use relative import in `ItemCard.test.tsx` to match other co-located test files

## Test plan
- [x] `npx vitest run` — all 47 tests pass
- [x] `npx biome check src/` — clean
- [x] `npx tsc --noEmit` — no errors