### PR TITLE
Add wantToBuy toggle to item cards (Phase 2 E)

### DIFF
--- a/frontend/src/app/stock-items/page.test.tsx
+++ b/frontend/src/app/stock-items/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import StockItemsPage from "@/app/stock-items/page";
@@ -88,7 +88,10 @@ describe("StockItemsPage", () => {
       expect(screen.getByText("醤油")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "削除" }));
+    const shoyuArticle = screen.getByRole("article", { name: "醤油" });
+    await user.click(
+      within(shoyuArticle).getByRole("button", { name: "削除" }),
+    );
 
     await waitFor(() => {
       expect(deleteStockItem).toHaveBeenCalledWith("1");
@@ -109,7 +112,10 @@ describe("StockItemsPage", () => {
       expect(screen.getByText("醤油")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "削除" }));
+    const shoyuArticle = screen.getByRole("article", { name: "醤油" });
+    await user.click(
+      within(shoyuArticle).getByRole("button", { name: "削除" }),
+    );
 
     expect(deleteStockItem).not.toHaveBeenCalled();
     expect(screen.getByText("醤油")).toBeInTheDocument();
@@ -142,6 +148,40 @@ describe("StockItemsPage", () => {
         category: "調味料",
       });
       expect(screen.getByText("濃口醤油")).toBeInTheDocument();
+    });
+  });
+
+  it("トグルボタンをクリックするとwantToBuyが反転し一覧が更新される", async () => {
+    const { fetchStockItems, updateStockItem } = await import("@/lib/api");
+    const toggledItems = [{ ...mockItems[0], wantToBuy: true }, mockItems[1]];
+    vi.mocked(fetchStockItems)
+      .mockResolvedValueOnce(mockItems)
+      .mockResolvedValueOnce(toggledItems);
+    vi.mocked(updateStockItem).mockResolvedValue(toggledItems[0]);
+
+    const user = userEvent.setup();
+    render(<StockItemsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("醤油")).toBeInTheDocument();
+    });
+
+    const shoyuArticle = screen.getByRole("article", { name: "醤油" });
+    await user.click(
+      within(shoyuArticle).getByRole("button", { name: "want to buy" }),
+    );
+
+    await waitFor(() => {
+      expect(updateStockItem).toHaveBeenCalledWith("1", {
+        wantToBuy: true,
+      });
+    });
+
+    await waitFor(() => {
+      const updatedShoyuArticle = screen.getByRole("article", { name: "醤油" });
+      expect(
+        within(updatedShoyuArticle).getByRole("button", { name: "削除" }),
+      ).toBeDisabled();
     });
   });
 });

--- a/frontend/src/app/stock-items/page.tsx
+++ b/frontend/src/app/stock-items/page.tsx
@@ -40,6 +40,12 @@ export default function StockItemsPage() {
     setItems(data);
   };
 
+  const handleToggleWantToBuy = async (item: StockItem) => {
+    await updateStockItem(item.id, { wantToBuy: !item.wantToBuy });
+    const data = await fetchStockItems();
+    setItems(data);
+  };
+
   const handleDelete = async (id: string) => {
     if (!window.confirm("この商品を削除しますか？")) return;
     await deleteStockItem(id);
@@ -102,6 +108,7 @@ export default function StockItemsPage() {
                     item={item}
                     onDelete={handleDelete}
                     onEdit={handleOpenEdit}
+                    onToggleWantToBuy={handleToggleWantToBuy}
                   />
                 ))}
               </div>

--- a/frontend/src/components/ItemCard.test.tsx
+++ b/frontend/src/components/ItemCard.test.tsx
@@ -16,34 +16,67 @@ const baseItem: StockItem = {
 
 describe("ItemCard", () => {
   it("商品名とカテゴリが表示される", () => {
-    render(<ItemCard item={baseItem} onEdit={vi.fn()} onDelete={vi.fn()} />);
+    render(
+      <ItemCard
+        item={baseItem}
+        onEdit={vi.fn()}
+        onToggleWantToBuy={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
     expect(screen.getByText("醤油")).toBeInTheDocument();
     expect(screen.getByText("調味料")).toBeInTheDocument();
   });
 
   it("wantToBuy=false のとき削除ボタンが表示される", () => {
-    render(<ItemCard item={baseItem} onEdit={vi.fn()} onDelete={vi.fn()} />);
+    render(
+      <ItemCard
+        item={baseItem}
+        onEdit={vi.fn()}
+        onToggleWantToBuy={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
     expect(screen.getByRole("button", { name: "削除" })).toBeInTheDocument();
   });
 
-  it("wantToBuy=true のとき削除ボタンが表示されない", () => {
+  it("wantToBuy=true のとき削除ボタンが disabled になる", () => {
     const item = { ...baseItem, wantToBuy: true };
-    render(<ItemCard item={item} onEdit={vi.fn()} onDelete={vi.fn()} />);
-    expect(
-      screen.queryByRole("button", { name: "削除" }),
-    ).not.toBeInTheDocument();
+    render(
+      <ItemCard
+        item={item}
+        onEdit={vi.fn()}
+        onToggleWantToBuy={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "削除" })).toBeDisabled();
   });
 
   it("削除ボタンをクリックするとonDeleteが呼ばれる", async () => {
     const onDelete = vi.fn();
-    render(<ItemCard item={baseItem} onEdit={vi.fn()} onDelete={onDelete} />);
+    render(
+      <ItemCard
+        item={baseItem}
+        onEdit={vi.fn()}
+        onToggleWantToBuy={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
     await userEvent.click(screen.getByRole("button", { name: "削除" }));
     expect(onDelete).toHaveBeenCalledWith("1");
   });
 
   it("カードをクリックすると onEdit が呼ばれる", async () => {
     const onEdit = vi.fn();
-    render(<ItemCard item={baseItem} onEdit={onEdit} onDelete={vi.fn()} />);
+    render(
+      <ItemCard
+        item={baseItem}
+        onEdit={onEdit}
+        onToggleWantToBuy={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
     // 商品名 "醤油" を含む button を取得 (削除ボタンと区別)
     await userEvent.click(screen.getByRole("button", { name: /醤油/ }));
     expect(onEdit).toHaveBeenCalledWith(baseItem);
@@ -52,7 +85,14 @@ describe("ItemCard", () => {
   it("削除ボタンをクリックしても onEdit は呼ばれない", async () => {
     const onEdit = vi.fn();
     const onDelete = vi.fn();
-    render(<ItemCard item={baseItem} onEdit={onEdit} onDelete={onDelete} />);
+    render(
+      <ItemCard
+        item={baseItem}
+        onEdit={onEdit}
+        onToggleWantToBuy={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
     await userEvent.click(screen.getByRole("button", { name: "削除" }));
     expect(onDelete).toHaveBeenCalledWith("1");
     expect(onEdit).not.toHaveBeenCalled();
@@ -60,10 +100,61 @@ describe("ItemCard", () => {
 
   it("Enter キーで onEdit が発火する", async () => {
     const onEdit = vi.fn();
-    render(<ItemCard item={baseItem} onEdit={onEdit} onDelete={vi.fn()} />);
+    render(
+      <ItemCard
+        item={baseItem}
+        onEdit={onEdit}
+        onToggleWantToBuy={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
     const editButton = screen.getByRole("button", { name: /醤油/ });
     editButton.focus();
     await userEvent.keyboard("{Enter}");
     expect(onEdit).toHaveBeenCalledWith(baseItem);
+  });
+
+  it("wantToBuy=falseのときトグルボタンがaria-pressed=falseで表示される", () => {
+    render(
+      <ItemCard
+        item={baseItem}
+        onEdit={vi.fn()}
+        onToggleWantToBuy={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    const toggle = screen.getByRole("button", { name: "want to buy" });
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("wantToBuy=trueのときトグルボタンがaria-pressed=trueで表示され、削除ボタンはdisabledになる", () => {
+    const item = { ...baseItem, wantToBuy: true };
+    render(
+      <ItemCard
+        item={item}
+        onEdit={vi.fn()}
+        onToggleWantToBuy={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    const toggle = screen.getByRole("button", { name: "want to buy" });
+    expect(toggle).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "削除" })).toBeDisabled();
+  });
+
+  it("トグルボタンをクリックすると onToggleWantToBuy が呼ばれ、onEdit は呼ばれない", async () => {
+    const onToggleWantToBuy = vi.fn();
+    const onEdit = vi.fn();
+    render(
+      <ItemCard
+        item={baseItem}
+        onEdit={onEdit}
+        onToggleWantToBuy={onToggleWantToBuy}
+        onDelete={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "want to buy" }));
+    expect(onToggleWantToBuy).toHaveBeenCalledWith(baseItem);
+    expect(onEdit).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/ItemCard.tsx
+++ b/frontend/src/components/ItemCard.tsx
@@ -3,10 +3,16 @@ import type { StockItem } from "@/types/stockItem";
 type ItemCardProps = {
   item: StockItem;
   onEdit: (item: StockItem) => void;
+  onToggleWantToBuy: (item: StockItem) => void;
   onDelete: (id: string) => void;
 };
 
-export default function ItemCard({ item, onEdit, onDelete }: ItemCardProps) {
+export default function ItemCard({
+  item,
+  onEdit,
+  onToggleWantToBuy,
+  onDelete,
+}: ItemCardProps) {
   return (
     <article
       aria-label={item.name}
@@ -22,15 +28,27 @@ export default function ItemCard({ item, onEdit, onDelete }: ItemCardProps) {
         </span>
         <h3 className="text-lg font-bold text-gray-900">{item.name}</h3>
       </button>
-      {!item.wantToBuy && (
-        <button
-          type="button"
-          className="rounded bg-[#ff3860] hover:bg-[#ff2b56] px-3 py-1.5 text-white text-sm font-medium"
-          onClick={() => onDelete(item.id)}
-        >
-          削除
-        </button>
-      )}
+      <button
+        type="button"
+        aria-label="want to buy"
+        aria-pressed={item.wantToBuy}
+        onClick={() => onToggleWantToBuy(item)}
+        className={
+          item.wantToBuy
+            ? "rounded bg-[#00d1b2] hover:bg-[#00c4a7] px-3 py-1.5 text-white text-sm font-medium"
+            : "rounded bg-gray-200 hover:bg-gray-300 px-3 py-1.5 text-gray-500 text-sm font-medium"
+        }
+      >
+        🛒
+      </button>
+      <button
+        type="button"
+        disabled={item.wantToBuy}
+        className="rounded bg-[#ff3860] hover:bg-[#ff2b56] px-3 py-1.5 text-white text-sm font-medium disabled:bg-gray-300 disabled:cursor-not-allowed"
+        onClick={() => onDelete(item.id)}
+      >
+        削除
+      </button>
     </article>
   );
 }

--- a/openspec/changes/phase2-shopping-list/.openspec.yaml
+++ b/openspec/changes/phase2-shopping-list/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-26

--- a/openspec/changes/phase2-shopping-list/design.md
+++ b/openspec/changes/phase2-shopping-list/design.md
@@ -1,0 +1,105 @@
+## Context
+
+Phase 1 で `wantToBuy` フィールドは `StockItem` 型と DB に存在するが、UI からトグルする手段は無い。バックエンドの `PATCH /api/stock-items/:id` は wantToBuy を含むすべてのフィールドを optional で受け取り、更新時 `updated_at = now()` を発行する。Phase 2 D (編集) で `updateStockItem(id, params)` の API クライアントが整っているため、トグルはこれを再利用するだけで実現できる。
+
+ItemCard は phase2-edit-item で `<article>` + 兄弟 `<button>` (編集 / 削除) 構造に変更済み。toggle ボタンも同じ並びに足せばクリック動線の競合 (編集モーダル誤発火) は起きない。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 商品カード上のトグルボタンで wantToBuy を切替できる
+- トグル成功時に `updated_at` が更新され、カードが一覧の先頭に並ぶ
+- wantToBuy=true / false の状態が視覚的に区別できる
+- 既存の編集・削除動線と干渉しない (誤クリックがない)
+
+**Non-Goals:**
+- wantToBuy=true のアイテムだけを表示するフィルタ UI (Phase 2 F で扱う)
+- 「買いたい」アイテムの専用ビュー / 別ページ
+- 追加・消費 (旧プロダクトの [+追加] [-消費]) のストック数操作 (本プロジェクトでは在庫数管理を簡略化)
+- toggle 操作の楽観的更新 (optimistic UI) — 当面は API 完了後に再取得する素朴な実装
+
+## Decisions
+
+### Decision 1: トグルボタンは ItemCard 内の独立した `<button>` (編集ボタンと兄弟)
+
+`<article>` 直下に編集 button、トグル button、削除 button を flex で並べる。トグルボタンが編集ボタンに含まれていると編集モーダルが誤発火するため、独立した兄弟構造にする。
+
+```tsx
+<article aria-label={item.name}>
+  <button onClick={() => onEdit(item)}>{/* category + name */}</button>
+  <button onClick={() => onToggleWantToBuy(item)} aria-label="買いたい">🛒</button>
+  <button onClick={() => onDelete(item.id)} disabled={item.wantToBuy}>削除</button>
+</article>
+```
+
+削除ボタンは常時描画し、wantToBuy=true で `disabled` にする (非表示にすると wantToBuy トグル後にボタン位置がジャンプして UX が悪い)。
+
+**Alternatives considered:**
+- 編集ボタンの中にトグルアイコンを入れ、`stopPropagation` で誤発火を防ぐ — phase2-edit-item で兄弟構造を採用した経緯と一貫性がない
+- 削除ボタンの位置に動的に表示 (wantToBuy=false で削除、true でトグル) — どちらの状態でも常時操作可能にしたいので不可
+
+**Rationale:** phase2-edit-item で確立した「カード = `<article>` + 兄弟 button 群」のパターンを踏襲。`stopPropagation` を使わずに誤発火を防げる。
+
+### Decision 2: トグルアイコンは Tailwind + 絵文字 (🛒) で実装
+
+ライブラリ追加 (Heroicons 等) は避け、UTF-8 絵文字 🛒 をボタン内に置く。状態ごとにスタイルを変える:
+
+- **wantToBuy=true** (買いたい): `bg-[#00d1b2]` の塗りつぶし、白文字。アクティブな状態を明示
+- **wantToBuy=false** (在庫あり): `bg-gray-200 text-gray-500`。控えめに表示
+
+`aria-pressed` 属性で支援技術にも状態を伝える。
+
+**Alternatives considered:**
+- Heroicons の ShoppingCart (outline / solid 切替) — 依存追加とビジュアルの一貫性管理が必要
+- カスタム SVG — 過剰
+- テキストラベル (「買いたい」「在庫あり」) — カード上では場所を取りすぎる
+
+**Rationale:** 旧プロダクトと同じ 🛒 絵文字、Tailwind の塗り変えだけで状態表現でき、依存ゼロ。後で Heroicons 等に差し替えるのも容易。
+
+### Decision 3: トグル後の更新は再取得 (refetch)
+
+`onToggleWantToBuy(item)` ハンドラは:
+1. `updateStockItem(item.id, { wantToBuy: !item.wantToBuy })` を呼ぶ
+2. 成功したら `fetchStockItems()` を再実行して一覧を更新
+
+成功時は `updated_at` が更新されるためカードは先頭に来る (バックエンド側の `ORDER BY updated_at DESC`)。
+
+**Alternatives considered:**
+- 楽観的更新 (state を即座に変更し、API 失敗時にロールバック) — UX は良いがエラーハンドリングが煩雑
+- WebSocket / Realtime push — Phase 3 以降のスコープ
+
+**Rationale:** 既存の create / delete / edit と同じ「API 完了 → re-fetch」パターン。Phase 3 のリアルタイム化で全機能を一括で楽観的更新に切替える方が筋が通る。
+
+### Decision 4: テスト戦略
+
+- **ItemCard.test.tsx** に追加:
+  - wantToBuy=false でトグル button が aria-pressed=false で表示される
+  - wantToBuy=true でトグル button が aria-pressed=true で表示される
+  - トグルボタンクリックで `onToggleWantToBuy(item)` が呼ばれ、`onEdit` は呼ばれない
+- **ItemCard.test.tsx** 既存テスト修正:
+  - 「wantToBuy=true で削除ボタンが表示されない」は維持 (トグル button は表示される)
+  - 編集発火テストの button selector を `name: /商品名/` のままにできるか要確認 (トグル button にも商品名が含まれていなければ問題なし)
+- **page.test.tsx** に 1 ケース:
+  - トグルクリック → API 呼び出し → 一覧再取得で並び順が変わる
+- **E2E**: 本 change では追加しない。Phase 2 全体が落ち着いた後に追記
+
+### Decision 5: API クライアントは既存の `updateStockItem` を流用
+
+新関数 `toggleWantToBuy(id)` は作らない。`updateStockItem(id, { wantToBuy: !current })` で十分かつ意図が明示的。
+
+**Rationale:** 抽象化は 3 箇所目で検討。今は重複が無いので素直に書く。
+
+## Risks / Trade-offs
+
+- **[トグル中の連打で API が複数飛ぶ]** → 当面は許容。バックエンドはべき等 (同じ値を何度送っても結果は同じ)。後続で disabled 中の loading 状態を入れる
+- **[wantToBuy=true のカード上で誤って削除を期待される]** → 削除ボタンは常時描画するが wantToBuy=true で `disabled` にする。表示/非表示を切替えるとボタン位置がジャンプして UX が悪いため、有効/無効の切替で対応
+- **[並び順の急変によるユーザの混乱]** → トグルで先頭に飛ぶ挙動は旧プロダクト由来の意図的仕様。視覚状態の変化と合わせて「リストに送った」感が出る
+
+## Migration Plan
+
+不要 (UI 機能追加のみ。データモデル / API 互換性の変更なし)。
+
+## Open Questions
+
+- トグル button の aria-label は「買いたい」「買いたいリストに追加」「Toggle want to buy」のいずれが最適か → 実装で確定
+- wantToBuy=true のカード全体に視覚インジケータ (左ボーダー teal、背景薄 teal 等) を入れるか → MVP では toggle button だけで状態表現し、必要なら後で追加

--- a/openspec/changes/phase2-shopping-list/proposal.md
+++ b/openspec/changes/phase2-shopping-list/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+旧プロダクトの中心的価値は「在庫が切れた / 切れそうな商品をワンタップで買い物リストに入れる」UX。Phase 1 で wantToBuy フィールドは作成可能だが、ユーザが画面上でトグルする手段が無い。Phase 2 機能 E として、商品カード上で wantToBuy をトグルする UI を追加し、旧プロダクトの「🛒 アイコンで買いたいリスト送り」体験を再現する。
+
+## What Changes
+
+- **wantToBuy トグルボタン** を商品カードに追加 (常に表示、編集ボタン・削除ボタンと兄弟)
+- **視覚状態の差別化** — wantToBuy=true のときアイコンを teal で塗り、false なら灰色アウトライン
+- **API クライアント** は既存の `updateStockItem(id, { wantToBuy })` を再利用 (新規追加なし)
+- **トグル成功で再取得** — `updated_at` が更新されるためカードが先頭に来る (バックエンド側で COALESCE + DEFAULT now() による更新が既に動作)
+- **削除ボタンの表示条件** は変更なし (wantToBuy=false の時のみ削除可)。トグルにより wantToBuy=true になると削除ボタンが消える挙動を維持
+
+データモデル変更なし、新規エンドポイント追加なし。バックエンドは既に PATCH の wantToBuy optional 対応済み。
+
+## Capabilities
+
+### New Capabilities
+(なし)
+
+### Modified Capabilities
+- `stock-items-list`: カード UI に wantToBuy トグルボタンと状態表示を追加。トグル成功時の一覧再取得・並び替えの挙動を仕様化
+
+## Impact
+
+- **影響ファイル**:
+  - `frontend/src/components/ItemCard.tsx` (トグルボタン追加)
+  - `frontend/src/components/ItemCard.test.tsx` (トグル動線のテスト追加)
+  - `frontend/src/app/stock-items/page.tsx` (`handleToggleWantToBuy` ハンドラ + ItemCard への結線)
+  - `frontend/src/app/stock-items/page.test.tsx` (トグルフローのテスト追加)
+  - `frontend/e2e/stock-items.spec.ts` (任意・後続 PR でも可)
+- **依存関係**: 追加なし (`updateStockItem` 既存)
+- **テスト**: `ItemCard` の既存テストにアサーション修正が必要 (toggle button が常時表示される)

--- a/openspec/changes/phase2-shopping-list/specs/stock-items-list/spec.md
+++ b/openspec/changes/phase2-shopping-list/specs/stock-items-list/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: 買いたいリストへのトグル
+ユーザーは商品カード上のトグルボタンで wantToBuy 状態を切り替えることができる SHALL。トグルは編集モーダルを開かない MUST。
+
+#### Scenario: トグルボタンが常に表示される
+- **WHEN** 商品カードが描画される (wantToBuy の値に関わらず)
+- **THEN** カード内にトグルボタンが表示される
+- **AND** ボタンの状態が `aria-pressed` 属性で示される (true/false)
+
+#### Scenario: wantToBuy=false のときの視覚状態
+- **WHEN** 商品の wantToBuy が false
+- **THEN** トグルボタンは控えめな (灰色等) スタイルで表示される
+- **AND** `aria-pressed="false"` が設定される
+
+#### Scenario: wantToBuy=true のときの視覚状態
+- **WHEN** 商品の wantToBuy が true
+- **THEN** トグルボタンは強調 (teal の塗り) スタイルで表示される
+- **AND** `aria-pressed="true"` が設定される
+
+#### Scenario: トグルクリックで wantToBuy が反転し一覧が更新される
+- **WHEN** ユーザーがトグルボタンをクリックする
+- **THEN** `PATCH /api/stock-items/:id` が `{ wantToBuy: !current }` で呼ばれる
+- **AND** 成功すると一覧が再取得され、対象商品は `updated_at DESC` の並びで先頭に来る
+
+#### Scenario: トグルは編集モーダルを開かない
+- **WHEN** ユーザーがトグルボタンをクリックする
+- **THEN** 編集モーダルは開かない
+
+#### Scenario: トグル成功で削除ボタンの有効/無効が切り替わる
+- **WHEN** wantToBuy が false から true に切り替わる
+- **THEN** 削除ボタンが disabled になる
+
+- **WHEN** wantToBuy が true から false に切り替わる
+- **THEN** 削除ボタンが enabled に戻る
+
+## MODIFIED Requirements
+
+### Requirement: Display stock items list
+The system SHALL display all stock items on the main page, ordered by most recently updated first.
+
+#### Scenario: No items exist
+- **WHEN** the user opens the app and no stock items exist
+- **THEN** an empty state message is displayed
+
+#### Scenario: Items exist
+- **WHEN** the user opens the app and stock items exist
+- **THEN** all items are displayed as cards with name, category, and a wantToBuy toggle button reflecting the current state
+- **AND** items are ordered by updated_at descending
+
+#### Scenario: Loading state
+- **WHEN** the app is fetching stock items from the API
+- **THEN** a loading indicator is displayed
+
+#### Scenario: API error
+- **WHEN** the API request fails
+- **THEN** an error message is displayed

--- a/openspec/changes/phase2-shopping-list/tasks.md
+++ b/openspec/changes/phase2-shopping-list/tasks.md
@@ -1,0 +1,32 @@
+## 1. ItemCard トグルボタン
+
+- [x] 1.1 `ItemCard.tsx` の props に `onToggleWantToBuy: (item: StockItem) => void` を追加
+- [x] 1.2 編集 button と削除 button の間に トグル button を追加 (`<button>` 兄弟、aria-label と aria-pressed 設定)
+- [x] 1.3 wantToBuy=true / false でスタイル切替 (teal 塗り vs 灰色)
+- [x] 1.4 `ItemCard.test.tsx` の既存テストすべてに `onToggleWantToBuy={vi.fn()}` を追加
+- [x] 1.5 `ItemCard.test.tsx` にトグル動線のテストを追加 (Claude 提案 → user 実装):
+  - wantToBuy=false で aria-pressed=false
+  - wantToBuy=true で aria-pressed=true、削除ボタンは表示されない
+  - トグルクリックで `onToggleWantToBuy(item)` が呼ばれ、`onEdit` は呼ばれない
+- [x] 1.6 既存テストが pass することを確認
+
+## 2. ページ結線
+
+- [x] 2.1 `page.tsx` に `handleToggleWantToBuy` ハンドラを追加 (`updateStockItem(id, { wantToBuy: !item.wantToBuy })` → `fetchStockItems` 再取得)
+- [x] 2.2 ItemCard に `onToggleWantToBuy={handleToggleWantToBuy}` を渡す
+- [x] 2.3 `page.test.tsx` にトグルフローのテストを追加 (1 ケース: クリック→API 呼出→一覧更新)
+- [x] 2.4 既存テストが pass することを確認
+
+## 3. 動作確認
+
+- [x] 3.1 `npm run dev` + backend 起動でブラウザ目視確認
+- [x] 3.2 wantToBuy=false の商品をトグル → teal 塗りに変化、削除ボタンが disabled、カードが先頭に
+- [x] 3.3 wantToBuy=true の商品をトグル → 灰色アウトラインに戻り、削除ボタンが enabled
+- [x] 3.4 トグルクリックで編集モーダルが開かないこと
+
+## 4. クリーンアップ・PR
+
+- [x] 4.1 `npx vitest run` で全テスト pass
+- [x] 4.2 `npx biome check` でクリーン
+- [x] 4.3 `npx tsc --noEmit` で型エラーなし
+- [ ] 4.4 ブランチを切って commit、PR を作成


### PR DESCRIPTION
## Summary
- ItemCard に wantToBuy トグルボタン (🛒) を追加 (常に表示、`aria-pressed` で状態表示)
- wantToBuy=true で削除ボタンが disabled (位置を保つため非表示にせず無効化)
- トグルクリックで `updateStockItem` → 一覧再取得、`updated_at DESC` で先頭に移動

## Test plan
- [x] ItemCard.test.tsx / page.test.tsx で全 55 件 pass
- [x] biome / tsc クリーン
- [x] 手動確認 (トグル動作・削除ボタン disabled・編集モーダル誤発火なし)