### PR TITLE
Add stock-items filter bar (search/wantToBuy/category)

### DIFF
--- a/frontend/e2e/stock-items.spec.ts
+++ b/frontend/e2e/stock-items.spec.ts
@@ -8,7 +8,7 @@ test("商品を登録して削除できる", async ({ page }) => {
   // 商品登録
   await page.getByRole("button", { name: "商品を追加" }).click();
   await page.getByLabel("名前").fill(itemName);
-  await page.getByLabel("カテゴリ").selectOption("調味料");
+  await page.getByLabel("カテゴリ", { exact: true }).selectOption("調味料");
   await page.getByRole("button", { name: "追加", exact: true }).click();
 
   // 登録した商品が表示されていることを確認

--- a/frontend/src/app/stock-items/page.test.tsx
+++ b/frontend/src/app/stock-items/page.test.tsx
@@ -184,4 +184,66 @@ describe("StockItemsPage", () => {
       ).toBeDisabled();
     });
   });
+
+  it("検索入力で絞り込まれ、クリアで戻る", async () => {
+    const { fetchStockItems } = await import("@/lib/api");
+    vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
+
+    const user = userEvent.setup();
+    render(<StockItemsPage />);
+
+    // 初期: 両方表示
+    await waitFor(() => {
+      expect(screen.getByText("醤油")).toBeInTheDocument();
+      expect(screen.getByText("味噌")).toBeInTheDocument();
+    });
+
+    // "醤" を入力 → 醤油のみ
+    await user.type(screen.getByRole("searchbox"), "醤");
+    expect(screen.getByText("醤油")).toBeInTheDocument();
+    expect(screen.queryByText("味噌")).not.toBeInTheDocument();
+
+    // クリアで両方戻る
+    await user.click(screen.getByRole("button", { name: "クリア" }));
+    expect(screen.getByText("醤油")).toBeInTheDocument();
+    expect(screen.getByText("味噌")).toBeInTheDocument();
+  });
+
+  it("「買いたいものだけ」ON で wantToBuy=false が消える", async () => {
+    const { fetchStockItems } = await import("@/lib/api");
+    vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
+
+    const user = userEvent.setup();
+    render(<StockItemsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("醤油")).toBeInTheDocument();
+      expect(screen.getByText("味噌")).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("checkbox", { name: "買いたいものだけ" }),
+    );
+
+    expect(screen.queryByText("醤油")).not.toBeInTheDocument(); // wantToBuy: false → 消える
+    expect(screen.getByText("味噌")).toBeInTheDocument(); // wantToBuy: true → 残る
+  });
+
+  it("フィルタで 0 件のとき「該当する商品がありません」が表示される", async () => {
+    const { fetchStockItems } = await import("@/lib/api");
+    vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
+
+    const user = userEvent.setup();
+    render(<StockItemsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("醤油")).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByRole("searchbox"), "なすび");
+
+    expect(screen.getByText("該当する商品がありません")).toBeInTheDocument();
+    // raw 0 件メッセージは出ないことも確認 (Decision 6 の区別)
+    expect(screen.queryByText("商品がありません")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/stock-items/page.tsx
+++ b/frontend/src/app/stock-items/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import CreateItemModal from "@/components/CreateItemModal";
 import EditItemModal from "@/components/EditItemModal";
+import FilterBar from "@/components/FilterBar";
 import ItemCard from "@/components/ItemCard";
 import {
   createStockItem,
@@ -10,6 +11,7 @@ import {
   fetchStockItems,
   updateStockItem,
 } from "@/lib/api";
+import { type FilterCondition, filterStockItems } from "@/lib/filterStockItems";
 import type { StockItem } from "@/types/stockItem";
 
 export default function StockItemsPage() {
@@ -18,6 +20,16 @@ export default function StockItemsPage() {
   const [editingItem, setEditingItem] = useState<StockItem | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<FilterCondition>({
+    searchText: "",
+    wantToBuyOnly: false,
+    category: null,
+  });
+
+  const filteredItems = useMemo(
+    () => filterStockItems(items, filter),
+    [items, filter],
+  );
 
   const handleCreate = async (name: string, category: string) => {
     await createStockItem({ name, category });
@@ -76,11 +88,12 @@ export default function StockItemsPage() {
           </p>
         ) : (
           <>
-            <div className="mb-6 flex justify-end">
+            <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <FilterBar value={filter} onChange={setFilter} />
               <button
                 type="button"
                 onClick={() => setIsModalOpen(true)}
-                className="bg-[#00d1b2] hover:bg-[#00c4a7] text-white px-4 py-2 rounded font-medium"
+                className="bg-[#00d1b2] hover:bg-[#00c4a7] text-white px-4 py-2 rounded font-medium md:self-start"
               >
                 商品を追加
               </button>
@@ -100,9 +113,13 @@ export default function StockItemsPage() {
               <p className="text-center py-12 text-gray-600">
                 商品がありません
               </p>
+            ) : filteredItems.length === 0 ? (
+              <p className="text-center py-12 text-gray-600">
+                該当する商品がありません
+              </p>
             ) : (
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-                {items.map((item) => (
+                {filteredItems.map((item) => (
                   <ItemCard
                     key={item.id}
                     item={item}

--- a/frontend/src/components/FilterBar.test.tsx
+++ b/frontend/src/components/FilterBar.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { FilterCondition } from "@/lib/filterStockItems";
+import FilterBar from "./FilterBar";
+
+const baseValue: FilterCondition = {
+  searchText: "",
+  wantToBuyOnly: false,
+  category: null,
+};
+
+describe("FilterBar", () => {
+  it("検索テキストを入力すると onChange が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<FilterBar value={baseValue} onChange={onChange} />);
+
+    await user.type(screen.getByRole("searchbox"), "醤");
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...baseValue,
+      searchText: "醤",
+    });
+  });
+
+  it("クリアボタンをクリックすると検索テキストが空になり onChange が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <FilterBar
+        value={{ ...baseValue, searchText: "醤油" }}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "クリア" }));
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...baseValue,
+      searchText: "",
+    });
+  });
+
+  it("検索テキストが空のときクリアボタンは表示されない", () => {
+    render(<FilterBar value={baseValue} onChange={vi.fn()} />);
+    expect(
+      screen.queryByRole("button", { name: "クリア" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("「買いたいものだけ」チェックボックスをクリックすると onChange が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<FilterBar value={baseValue} onChange={onChange} />);
+
+    await user.click(
+      screen.getByRole("checkbox", { name: "買いたいものだけ" }),
+    );
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...baseValue,
+      wantToBuyOnly: true,
+    });
+  });
+
+  it("カテゴリを選択すると onChange が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<FilterBar value={baseValue} onChange={onChange} />);
+
+    await user.selectOptions(screen.getByLabelText("カテゴリ"), "調味料");
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...baseValue,
+      category: "調味料",
+    });
+  });
+
+  it("全部を選択すると、カテゴリが null になり onChange が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <FilterBar
+        value={{ ...baseValue, category: "調味料" }}
+        onChange={onChange}
+      />,
+    );
+
+    await user.selectOptions(screen.getByLabelText("カテゴリ"), "全部");
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...baseValue,
+      category: null,
+    });
+  });
+});

--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { CATEGORIES } from "@/constants/categories";
+import type { FilterCondition } from "@/lib/filterStockItems";
+
+type FilterBarProps = {
+  value: FilterCondition;
+  onChange: (next: FilterCondition) => void;
+};
+
+export default function FilterBar({ value, onChange }: FilterBarProps) {
+  const handleSearchTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange({ ...value, searchText: e.target.value });
+  };
+
+  const handleClearSearchText = () => {
+    onChange({ ...value, searchText: "" });
+  };
+
+  const handleWantToBuyOnlyChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    onChange({ ...value, wantToBuyOnly: e.target.checked });
+  };
+
+  const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    onChange({
+      ...value,
+      category: e.target.value === "" ? null : e.target.value,
+    });
+  };
+
+  return (
+    <div className="flex flex-col md:flex-row items-start md:items-center gap-2">
+      <div className="relative w-full md:w-auto">
+        <input
+          type="search"
+          aria-label="検索"
+          placeholder="検索"
+          value={value.searchText}
+          onChange={handleSearchTextChange}
+          className="w-full md:w-auto border border-gray-300 rounded px-3 py-2 pr-10 focus:outline-none focus:ring-2 focus:ring-blue-500
+  [&::-webkit-search-cancel-button]:appearance-none"
+        />
+        {value.searchText && (
+          <button
+            type="button"
+            aria-label="クリア"
+            onClick={handleClearSearchText}
+            className="absolute right-2 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700 focus:outline-none"
+          >
+            ×
+          </button>
+        )}
+      </div>
+      <label className="flex items-center gap-1">
+        <input
+          type="checkbox"
+          checked={value.wantToBuyOnly}
+          onChange={handleWantToBuyOnlyChange}
+        />
+        買いたいものだけ
+      </label>
+      <label className="flex items-center gap-1">
+        カテゴリ
+        <select
+          value={value.category ?? ""}
+          onChange={handleCategoryChange}
+          className="border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="">全部</option>
+          {CATEGORIES.map((cat) => (
+            <option key={cat} value={cat}>
+              {cat}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/frontend/src/lib/filterStockItems.test.ts
+++ b/frontend/src/lib/filterStockItems.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { StockItem } from "@/types/stockItem";
+import { filterStockItems } from "./filterStockItems";
+
+const baseItem = (overrides: Partial<StockItem> = {}): StockItem => ({
+  id: "1",
+  name: "醤油",
+  category: "調味料",
+  imageUrl: null,
+  wantToBuy: false,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  ...overrides,
+});
+
+describe("filterStockItems", () => {
+  const items: StockItem[] = [
+    baseItem({ id: "1", name: "醤油", category: "調味料", wantToBuy: false }),
+    baseItem({ id: "2", name: "味噌", category: "調味料", wantToBuy: true }),
+    baseItem({
+      id: "3",
+      name: "コーヒー",
+      category: "飲み物",
+      wantToBuy: true,
+    }),
+  ];
+
+  it("空conditionで全件返す", () => {
+    const result = filterStockItems(items, {
+      searchText: "",
+      wantToBuyOnly: false,
+      category: null,
+    });
+    expect(result).toEqual(items);
+  });
+
+  it("searchTextの部分一致で絞り込む", () => {
+    const result = filterStockItems(items, {
+      searchText: "醤",
+      wantToBuyOnly: false,
+      category: null,
+    });
+    expect(result).toEqual([items[0]]);
+  });
+
+  it("wantToBuy=trueのとき、買いたいものだけ返す", () => {
+    const result = filterStockItems(items, {
+      searchText: "",
+      wantToBuyOnly: true,
+      category: null,
+    });
+    expect(result).toEqual([items[1], items[2]]);
+  });
+
+  it("category指定で該当カテゴリのみ返す", () => {
+    const result = filterStockItems(items, {
+      searchText: "",
+      wantToBuyOnly: false,
+      category: "調味料",
+    });
+    expect(result).toEqual([items[0], items[1]]);
+  });
+
+  it("category=nullで全カテゴリを返す", () => {
+    const result = filterStockItems(items, {
+      searchText: "",
+      wantToBuyOnly: false,
+      category: null,
+    });
+    expect(result).toEqual(items);
+  });
+
+  it("複数条件の組み合わせ", () => {
+    const result = filterStockItems(items, {
+      searchText: "コー",
+      wantToBuyOnly: true,
+      category: "飲み物",
+    });
+    expect(result).toEqual([items[2]]);
+  });
+});

--- a/frontend/src/lib/filterStockItems.ts
+++ b/frontend/src/lib/filterStockItems.ts
@@ -1,0 +1,19 @@
+import type { StockItem } from "@/types/stockItem";
+
+export type FilterCondition = {
+  searchText: string;
+  wantToBuyOnly: boolean;
+  category: string | null;
+};
+
+export function filterStockItems(
+  items: StockItem[],
+  condition: FilterCondition,
+): StockItem[] {
+  return items
+    .filter((item) => !condition.wantToBuyOnly || item.wantToBuy)
+    .filter(
+      (item) => !condition.category || item.category === condition.category,
+    )
+    .filter((item) => item.name.includes(condition.searchText));
+}

--- a/openspec/changes/phase2-filter/.openspec.yaml
+++ b/openspec/changes/phase2-filter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/phase2-filter/design.md
+++ b/openspec/changes/phase2-filter/design.md
@@ -1,0 +1,150 @@
+## Context
+
+Phase 2 で CRUD と wantToBuy トグルが揃った。商品件数が増えると、特定カテゴリや「買いたいだけ」を見たい場面が頻出する。旧プロダクトでは Vuex の `filter` ストアに `searchText` と `filterCondition: { toBuy, outOfStock, category }` を持ち、`computed` で `filteredItems` を派生させていた。本 change では React の同等構造で再現する (`outOfStock` は本プロダクトでは在庫数を持たないため対象外)。
+
+カテゴリ定数は現在 `frontend/src/components/CreateItemModal.tsx` 内に直書きされており、FilterBar 側でも同じものが必要になるため共通化する。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 商品名検索 (部分一致) で一覧を絞り込める
+- 「買いたいだけ」トグルで wantToBuy=true のみ表示できる
+- カテゴリ select で特定カテゴリのみ表示できる (「全部」で全カテゴリ)
+- 全フィルタは AND 結合
+- フィルタ適用後 0 件のとき「該当する商品がありません」を表示
+- フィルタロジックは純関数として切り出し、ユニットテストで網羅
+
+**Non-Goals:**
+- スマート初期値 (フィルタ中の検索テキスト・カテゴリを CreateItemModal に引き継ぐ) — 旧プロダクトの機能だが別 change で扱う
+- URL クエリへのフィルタ状態反映・ブラウザ履歴連携
+- サーバーサイドフィルタ (現状 `GET /api/stock-items` は全件返す前提。家庭規模のデータでは十分)
+- フィルタ条件のローカルストレージ永続化
+- フィルタ条件の組み合わせを「OR」で結合するモード
+
+## Decisions
+
+### Decision 1: フィルタは純関数 `filterStockItems` に分離する
+
+```ts
+// frontend/src/lib/filterStockItems.ts
+export type FilterCondition = {
+  searchText: string;
+  wantToBuyOnly: boolean;
+  category: string | null; // null = 全部
+};
+
+export function filterStockItems(
+  items: StockItem[],
+  condition: FilterCondition,
+): StockItem[] {
+  return items
+    .filter((item) => !condition.wantToBuyOnly || item.wantToBuy)
+    .filter((item) => !condition.category || item.category === condition.category)
+    .filter((item) => item.name.includes(condition.searchText));
+}
+```
+
+**Alternatives considered:**
+- ページコンポーネント内で `useMemo` 直書き — テストするとレンダリングを通す必要があり読みにくい
+- カスタム hook `useFilteredItems(items, condition)` — 過剰。純関数で十分
+
+**Rationale:** ロジックが React と独立するためテストが軽い (DOM 不要)。旧プロダクトの `filter.js` も純関数で、移植しやすい。
+
+### Decision 2: フィルタ状態は `page.tsx` の `useState` 1 箇所に集約
+
+```tsx
+const [filter, setFilter] = useState<FilterCondition>({
+  searchText: "",
+  wantToBuyOnly: false,
+  category: null,
+});
+
+const filteredItems = useMemo(
+  () => filterStockItems(items, filter),
+  [items, filter],
+);
+```
+
+`FilterBar` は `value: FilterCondition` と `onChange: (next: FilterCondition) => void` を受ける制御コンポーネント。
+
+**Alternatives considered:**
+- 各フィールドを個別 state (`searchText`, `wantToBuyOnly`, `category`) — props が増える。1 オブジェクトで運ぶ方がシンプル
+- Context / Zustand 等の状態ライブラリ — 過剰。1 ページ内の状態
+
+**Rationale:** 単一の真実源。`filteredItems` は `useMemo` で派生。
+
+### Decision 3: カテゴリ定数は `frontend/src/constants/categories.ts` に共通化
+
+```ts
+export const CATEGORIES = [
+  "★", "洗面", "100均", "KALDI", "調味料", "飲み物",
+  "缶詰", "おかず", "おかずの素", "おやつ", "その他",
+] as const;
+
+export type Category = (typeof CATEGORIES)[number];
+```
+
+`CreateItemModal` の直書き定数を import に置換。FilterBar の select も同じ定数 + 「全部」option を表示。
+
+**Alternatives considered:**
+- 定数を `FilterBar` 内に複製 — 同期漏れリスク
+- DB から取得 — 旧仕様で固定リスト確定。サーバー往復不要
+
+**Rationale:** Single source of truth。後でカテゴリ追加するときに 1 箇所変更で済む。
+
+### Decision 4: 「全部」option の値は空文字 `""` で表現、内部状態では `null`
+
+select の `<option value="">全部</option>` を選んだら state は `category: null`。`<option value="調味料">調味料</option>` なら `category: "調味料"`。
+
+**Alternatives considered:**
+- 「全部」も文字列 `"all"` で表現 — 「all」がカテゴリ名と衝突する将来リスク
+- `category: undefined` — オブジェクト spread 時に扱いづらい
+
+**Rationale:** TypeScript 的に `string | null` が読みやすい。フィルタ関数の判定 `!condition.category` で空文字も null も同じ扱い。
+
+### Decision 5: 検索のクリアボタンは入力欄に文字があるときだけ表示
+
+`searchText` が非空のときに「×」ボタンを右側に表示し、クリックで `searchText: ""` に。
+
+**Alternatives considered:**
+- 常時表示 — 空のときに無意味
+- HTML5 `<input type="search">` のネイティブ `×` を使う — ブラウザによって表示が異なる
+
+**Rationale:** UX 上の小さな配慮。コードコストも小さい。
+
+### Decision 6: 空結果は「商品がない (raw 0 件)」と「該当なし (フィルタで 0 件)」を区別する
+
+- `items.length === 0` → 「商品がありません」(既存)
+- `items.length > 0 && filteredItems.length === 0` → 「該当する商品がありません」(新規)
+
+**Rationale:** ユーザーの取るべき行動が違う (前者は商品追加、後者はフィルタ解除)。
+
+### Decision 7: テスト戦略
+
+- **`filterStockItems.test.ts`** — 純関数の網羅:
+  - 空 condition で全件返す
+  - searchText の部分一致 (大文字小文字は `includes` 既定通り = 区別する)
+  - wantToBuyOnly=true で wantToBuy=true のみ
+  - category 指定で該当カテゴリのみ
+  - 3 軸 AND の組合せ 1-2 ケース
+- **`FilterBar.test.tsx`** — 入力で `onChange` が正しい `FilterCondition` で呼ばれる (検索入力・トグル・select 変更・クリアボタン)
+- **`page.test.tsx`** — 統合 1-2 ケース:
+  - 検索入力 → 表示が絞られる、クリアで戻る
+  - 「買いたいだけ」ON で wantToBuy=false が消える
+  - フィルタで 0 件のとき「該当する商品がありません」が表示される
+
+## Risks / Trade-offs
+
+- **[件数が増えると毎入力で全件再フィルタする]** → 数千件レベルまでは問題なし (in-memory で millisec)。Phase 4 以降で API 側に検索パラメータを足す選択肢も残せる
+- **[`includes` は大文字小文字を区別する]** → 旧プロダクトの挙動を踏襲。日本語商品名では実害なし。英語混在で困ったら `toLowerCase` 比較に変更
+- **[フィルタ条件の組合せでユーザーが混乱]** → 「該当する商品がありません」表示と、検索クリアボタン / wantToBuy トグル / 「全部」の存在で逃げ道を確保
+
+## Migration Plan
+
+不要 (UI 機能追加のみ。データモデル / API 互換性の変更なし)。`CreateItemModal` のカテゴリ定数 import 切替は同 PR 内で完結。
+
+## Open Questions
+
+- フィルタ UI の見た目 (横並び 1 行 vs ラップ) — レスポンシブで調整。MVP では横並び、狭い画面で wrap
+- カテゴリ select の「全部」option 表記は「全部」「すべて」「— 全カテゴリ —」のいずれか → 旧プロダクトの「全部」を踏襲
+- 検索入力で `<input type="search">` を使うか `<input type="text">` か → `type="search"` (アクセシブルだがネイティブ × ボタンは抑制)。実装で確定

--- a/openspec/changes/phase2-filter/proposal.md
+++ b/openspec/changes/phase2-filter/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+旧プロダクトでは「商品名検索」「買いたいリストだけ表示」「カテゴリ絞り込み」の 3 軸 AND フィルタが日常利用の中心だった (例: 醤油類だけ見る、買いたいものだけ見る、買い物前に "🛒+カテゴリ" で絞る)。Phase 2 で CRUD と wantToBuy トグルが揃った今、件数が増えても探しやすくするためにフィルタリングを揃える。
+
+## What Changes
+
+- **テキスト検索**: 商品名の部分一致フィルタ。クリアボタン付き
+- **wantToBuy フィルタ**: チェックボックス的なトグル (全部 / 買いたいだけ の 2 状態)
+- **カテゴリフィルタ**: 単一選択 `<select>`、「全部」option を含む
+- **AND 結合**: 旧 `filter.js` と同じく全条件を AND で適用
+- **空結果表示**: フィルタ後 0 件のとき「該当する商品がありません」を表示
+- **新規コンポーネント `FilterBar`**: 検索 / トグル / select の合成
+- **純関数 `filterStockItems`**: `frontend/src/lib/filterStockItems.ts` に分離 (テスト容易)
+- **カテゴリ定数の共通化**: `frontend/src/constants/categories.ts` に切り出し、CreateItemModal と FilterBar が共有
+- **クライアントサイドフィルタ**: 現状の `GET /api/stock-items` (全件) を前提に in-memory で絞り込む
+
+## Capabilities
+
+### New Capabilities
+(なし)
+
+### Modified Capabilities
+- `stock-items-list`: フィルタ UI (検索・wantToBuy・カテゴリ) と AND 適用、空結果表示の挙動を仕様化
+
+## Impact
+
+- **影響ファイル**:
+  - `frontend/src/app/stock-items/page.tsx` (filter state + 派生 `filteredItems`、FilterBar 結線)
+  - `frontend/src/app/stock-items/page.test.tsx` (フィルタ結合テスト追加)
+  - `frontend/src/components/FilterBar.tsx` (新規)
+  - `frontend/src/components/FilterBar.test.tsx` (新規)
+  - `frontend/src/lib/filterStockItems.ts` (新規・純関数)
+  - `frontend/src/lib/filterStockItems.test.ts` (新規)
+  - `frontend/src/constants/categories.ts` (新規・共通化)
+  - `frontend/src/components/CreateItemModal.tsx` (カテゴリ定数を import に置換)
+- **依存関係**: 追加なし
+- **データモデル / API**: 変更なし

--- a/openspec/changes/phase2-filter/specs/stock-items-list/spec.md
+++ b/openspec/changes/phase2-filter/specs/stock-items-list/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: 一覧をフィルタリングできる
+ユーザーは商品名検索・買いたいリストトグル・カテゴリ選択の 3 軸で一覧をフィルタリングできる SHALL。すべてのフィルタは AND で結合される MUST。
+
+#### Scenario: 初期状態では全商品が表示される
+- **WHEN** ユーザーがページを開く
+- **THEN** フィルタは未指定 (検索テキスト空・買いたいだけ OFF・カテゴリ「全部」)
+- **AND** 全商品が表示される
+
+#### Scenario: 商品名で部分一致検索する
+- **WHEN** ユーザーが検索ボックスに文字列を入力する
+- **THEN** 商品名にその文字列を含む商品のみが表示される
+- **AND** 入力するたびにリアルタイムで絞り込みが反映される
+
+#### Scenario: 検索クリアボタンで検索を解除する
+- **WHEN** 検索ボックスに文字が入っている状態でクリアボタンをクリックする
+- **THEN** 検索ボックスが空になり、検索条件が解除される
+
+#### Scenario: 検索ボックスが空のときクリアボタンは表示されない
+- **WHEN** 検索ボックスが空である
+- **THEN** クリアボタンは表示されない
+
+#### Scenario: 「買いたいだけ」トグルで wantToBuy=true のみ表示する
+- **WHEN** ユーザーが「買いたいだけ」トグルを ON にする
+- **THEN** wantToBuy=true の商品のみが表示される
+
+#### Scenario: 「買いたいだけ」トグル OFF で全件対象に戻る
+- **WHEN** ユーザーが「買いたいだけ」トグルを OFF にする
+- **THEN** wantToBuy の値による絞り込みが解除される
+
+#### Scenario: カテゴリ select で特定カテゴリのみ表示する
+- **WHEN** ユーザーがカテゴリ select で「調味料」を選ぶ
+- **THEN** category が「調味料」の商品のみが表示される
+
+#### Scenario: カテゴリ「全部」で全カテゴリ対象に戻る
+- **WHEN** ユーザーがカテゴリ select で「全部」を選ぶ
+- **THEN** カテゴリによる絞り込みが解除される
+
+#### Scenario: 複数フィルタの AND 結合
+- **WHEN** 検索テキスト「醤」、買いたいだけ ON、カテゴリ「調味料」を同時に指定する
+- **THEN** 商品名に「醤」を含み、wantToBuy=true で、category=「調味料」の商品のみが表示される
+
+#### Scenario: フィルタ適用後 0 件のとき該当なしメッセージを表示する
+- **WHEN** フィルタ適用後の商品が 0 件である
+- **AND** 元の商品データは 1 件以上ある
+- **THEN** 「該当する商品がありません」メッセージが表示される
+
+## MODIFIED Requirements
+
+### Requirement: Display stock items list
+The system SHALL display all stock items on the main page, ordered by most recently updated first. Items MAY be filtered by user-controlled criteria (search text, wantToBuy, category).
+
+#### Scenario: No items exist
+- **WHEN** the user opens the app and no stock items exist
+- **THEN** an empty state message "商品がありません" is displayed
+
+#### Scenario: Items exist
+- **WHEN** the user opens the app and stock items exist
+- **THEN** all items matching the current filter are displayed as cards with name, category, and a wantToBuy toggle button reflecting the current state
+- **AND** items are ordered by updated_at descending
+
+#### Scenario: Loading state
+- **WHEN** the app is fetching stock items from the API
+- **THEN** a loading indicator is displayed
+
+#### Scenario: API error
+- **WHEN** the API request fails
+- **THEN** an error message is displayed

--- a/openspec/changes/phase2-filter/tasks.md
+++ b/openspec/changes/phase2-filter/tasks.md
@@ -1,0 +1,57 @@
+## 1. カテゴリ定数の共通化
+
+- [x] 1.1 `frontend/src/constants/categories.ts` を新規作成し `CATEGORIES`/`Category` を export
+- [x] 1.2 `CreateItemModal.tsx` の直書きカテゴリ配列を `CATEGORIES` import に置換
+- [x] 1.3 `CreateItemModal.test.tsx` が pass することを確認
+
+## 2. フィルタ純関数
+
+- [x] 2.1 `frontend/src/lib/filterStockItems.ts` を新規作成 (`FilterCondition` 型 + `filterStockItems` 関数)
+- [x] 2.2 `frontend/src/lib/filterStockItems.test.ts` を新規作成 (Claude 提案 → user 実装):
+  - 空 condition で全件返る
+  - searchText 部分一致 (1 件マッチ / 0 件マッチ)
+  - wantToBuyOnly=true で wantToBuy=true のみ
+  - category 指定で該当カテゴリのみ
+  - category=null で全カテゴリ
+  - 3 軸 AND 結合 1 ケース
+
+## 3. FilterBar コンポーネント
+
+- [x] 3.1 `frontend/src/components/FilterBar.tsx` を新規作成 (props: `value: FilterCondition`, `onChange: (next) => void`)
+- [x] 3.2 検索 input (`type="search"`) + クリアボタン (searchText 非空時のみ表示) を実装
+- [x] 3.3 「買いたいだけ」トグル (チェックボックス) を実装
+- [x] 3.4 カテゴリ select (「全部」option + `CATEGORIES`) を実装
+- [x] 3.5 `frontend/src/components/FilterBar.test.tsx` を新規作成 (Claude 提案 → user 実装):
+  - 検索入力で `onChange` が `searchText` 更新で呼ばれる
+  - クリアボタンクリックで `searchText: ""` 更新で呼ばれる
+  - 検索が空のときクリアボタンが表示されない
+  - 「買いたいだけ」トグル変更で `wantToBuyOnly` 更新で呼ばれる
+  - カテゴリ select 変更で `category` 更新で呼ばれる
+  - カテゴリ「全部」選択で `category: null` 更新で呼ばれる
+
+## 4. ページ結線
+
+- [x] 4.1 `page.tsx` に `filter` state + `useMemo` で `filteredItems` を派生
+- [x] 4.2 `FilterBar` を一覧の上に配置し `value={filter}` `onChange={setFilter}` を渡す
+- [x] 4.3 `items.map` を `filteredItems.map` に変更
+- [x] 4.4 `items.length > 0 && filteredItems.length === 0` のとき「該当する商品がありません」を表示
+- [x] 4.5 `page.test.tsx` にフィルタ統合テストを追加 (Claude 提案 → user 実装):
+  - 検索入力で表示が絞られ、クリアで戻る
+  - 「買いたいだけ」ON で wantToBuy=false が消える
+  - フィルタで 0 件のとき「該当する商品がありません」が表示される
+
+## 5. 動作確認
+
+- [x] 5.1 `npm run dev` + backend 起動でブラウザ目視確認
+- [x] 5.2 検索: 商品名一部入力で絞り込まれる、クリアで戻る
+- [x] 5.3 「買いたいだけ」: トグル ON で wantToBuy=true のみ、OFF で全件
+- [x] 5.4 カテゴリ: 特定カテゴリ選択で絞り込まれる、「全部」で戻る
+- [x] 5.5 AND 結合: 3 軸全部適用しても期待通り絞れる
+- [x] 5.6 該当なし: 全件除外される条件で「該当する商品がありません」が表示される
+
+## 6. クリーンアップ・PR
+
+- [x] 6.1 `npx vitest run` で全テスト pass
+- [x] 6.2 `npx biome check` でクリーン
+- [x] 6.3 `npx tsc --noEmit` で型エラーなし
+- [ ] 6.4 ブランチを切って commit、PR を作成


### PR DESCRIPTION
## Summary
- 純関数 `filterStockItems` (`frontend/src/lib/filterStockItems.ts`) を追加し、searchText 部分一致 / wantToBuyOnly / category の 3 軸 AND フィルタをロジックとして分離
- `FilterBar` コンポーネントを追加 (検索 input + クリアボタン、買いたいものだけトグル、カテゴリ select、design Decision 4 通り「全部」option は空文字 value)
- `stock-items` ページに filter state + `useMemo` で `filteredItems` を派生させ、フィルタで 0 件のとき「該当する商品がありません」を表示 (Decision 6 の raw 0 件との区別)

## Test plan
- [x] `npx vitest run` — 70 tests pass (9 files)
- [x] `npx biome check` — clean
- [x] `npx tsc --noEmit` — no type errors
- [x] 手動: 検索・クリア / 買いたいものだけトグル / カテゴリ select / 「全部」 / 3 軸 AND / 該当なし表示
- [x] 手動: WebKit ネイティブ × ボタンが `[&::-webkit-search-cancel-button]:appearance-none` で抑制されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)