### PR TITLE
Add lefthook and Claude Code lint hooks

### DIFF
--- a/.claude/hooks/lint-on-edit.sh
+++ b/.claude/hooks/lint-on-edit.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# PostToolUse hook: edit/write した file path に応じて linter を実行する。
+# - frontend/ 配下: biome check
+# - backend/  配下: golangci-lint
+# 該当しないファイル (ドキュメント等) は何もしない。
+
+set -euo pipefail
+
+repo_root="$(git -C "$CLAUDE_PROJECT_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$CLAUDE_PROJECT_DIR")"
+
+input="$(cat)"
+file_path="$(echo "$input" | jq -r '.tool_input.file_path // empty')"
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+case "$file_path" in
+  "$repo_root"/frontend/*.ts | "$repo_root"/frontend/*.tsx | \
+  "$repo_root"/frontend/*.js | "$repo_root"/frontend/*.jsx | \
+  "$repo_root"/frontend/*.json | "$repo_root"/frontend/*.css)
+    cd "$repo_root/frontend"
+    npx --no-install biome check "$file_path" 1>&2 || exit 2
+    ;;
+  "$repo_root"/backend/*.go)
+    cd "$repo_root/backend"
+    pkg_dir="$(dirname "$file_path")"
+    golangci-lint run "$pkg_dir" 1>&2 || exit 2
+    ;;
+  *)
+    exit 0
+    ;;
+esac

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/lint-on-edit.sh",
+            "timeout": 60,
+            "statusMessage": "Linting changed file..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Claude Code
 .claude/settings.local.json
 
+# Serena MCP (local state)
+.serena/
+
 # Next.js
 .next/
 out/

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,3 +2,4 @@
 node = "24"
 go = "1.26"
 golangci-lint = "2"
+lefthook = "latest"

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,9 +3,11 @@ module github.com/IsaoTakahashi/pantry-panel/backend
 go 1.26.2
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/labstack/echo/v5 v5.1.0
 	github.com/stretchr/testify v1.11.1
+	github.com/testcontainers/testcontainers-go v0.42.0
 )
 
 require (
@@ -27,7 +29,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
@@ -45,7 +46,6 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
-	github.com/testcontainers/testcontainers-go v0.42.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+pre-commit:
+  parallel: true
+  commands:
+    frontend-lint:
+      root: "frontend/"
+      glob: "*.{ts,tsx,js,jsx,json,css}"
+      run: npx biome check {staged_files}
+    backend-lint:
+      root: "backend/"
+      glob: "*.go"
+      run: golangci-lint run ./...


### PR DESCRIPTION
## 概要

frontend / backend それぞれの linter を **pre-commit** と **Claude Code の編集後** で自動実行するためのフック整備。

## 主な変更

### Pre-commit hook (lefthook)

- `.mise.toml` に lefthook を追加
- `lefthook.yml` を新規作成し並列実行を構成
  - `frontend/` 配下が staged → `npx biome check {staged_files}`
  - `backend/` 配下が staged → `golangci-lint run ./...`

### Claude Code hook (PostToolUse)

- `.claude/settings.json` を新規作成し `Edit|Write|MultiEdit` の PostToolUse に hook を登録
- `.claude/hooks/lint-on-edit.sh` を新規作成し編集ファイルパスに応じて linter を起動
  - frontend (`.ts/.tsx/.js/.jsx/.json/.css`) → biome check
  - backend (`.go`) → golangci-lint run（パッケージ単位）
  - 該当しないファイルは何もしない
  - lint 失敗時は exit 2 で Claude にエラー文を返す

### その他

- `backend/go.mod` を `go mod tidy` で整理（uuid と testcontainers を direct deps に昇格）
- `.serena/`（Serena MCP のローカル状態）を `.gitignore` に追加

## 動作確認

- pipe-test 3パターン（frontend / backend / 対象外）で hook script の正常動作を確認
- sentinel test で Claude Code hook の発火を確認
- 実際にこの PR の作業中、pre-commit hook が Biome のフォーマット違反を1件キャッチして自動 fix → re-commit に成功

## 経緯

元々は Issue #39（Phase 2 機能F: フィルタリング）の作業中に副次的に追加したフックでしたが、Filter 機能自体は #37 で先行マージされたため、本 PR はフック関連の変更だけを残す形に整理。