### PR TITLE
Add Phase 2.5 OpenSpec proposals (a/b/c/d)

### DIFF
--- a/openspec/changes/phase2-5a-supabase-setup/.openspec.yaml
+++ b/openspec/changes/phase2-5a-supabase-setup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/phase2-5a-supabase-setup/design.md
+++ b/openspec/changes/phase2-5a-supabase-setup/design.md
@@ -1,0 +1,65 @@
+## Context
+
+現状、開発・テストともにローカルの Docker Compose で Postgres 18 を起動している。Phase 2.5 で本番デプロイを始めるにあたり、Backend と Frontend の前にまず DB を本番用に立ち上げる必要がある。Supabase Postgres は無料枠（500MB / 2 プロジェクト）で要件を満たし、後続の Phase 3.5 で同じ DB を使って Supabase Realtime に切り替えるため、最初から Supabase を採用する。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 本番 DB が Supabase 上で稼働している（プロジェクト作成 + マイグレーション適用済み）
+- Backend がローカルから Supabase に直接続できる（DATABASE_URL 切替で）
+- Direct Connection (5432) で接続できる — Phase 3 の LISTEN/NOTIFY を使うため必須
+
+**Non-Goals:**
+- Backend のホスティング（Phase 2.5b で扱う）
+- Frontend のホスティング（Phase 2.5c で扱う）
+- 自動マイグレーション機構の導入（マイグレーションが 1 本のみのため、SQL Editor 手動で十分）
+- バックアップ・復旧戦略（Supabase の標準バックアップを使用、別 change で扱う）
+
+## Decisions
+
+### マイグレーション戦略: Supabase SQL Editor で手動適用
+
+`backend/db/migrations/001_create_stock_items.sql` の中身を Supabase Dashboard の SQL Editor にコピー＆実行する。
+
+- **採用理由**: マイグレーションは現状 1 本のみで、`golang-migrate` 等の導入はオーバーエンジニアリング。Phase 4 以降でマイグレーションが増えてきた段階で再評価する。
+- **代替案**:
+  - `golang-migrate` を CI で実行 → 現時点では不要
+  - 起動時に `embed.FS` で適用 → スキーマ変更とアプリ起動が密結合になりロールバックがしづらい
+
+### 接続方法: Direct Connection (5432)
+
+Supabase の3つの接続方法のうち Direct Connection を選ぶ。
+
+- **採用理由**: Phase 3 の自前 WebSocket で LISTEN/NOTIFY を使うため、transaction pooler (6543) は使用不可。`session pooler (5432, Supavisor)` でも LISTEN/NOTIFY 可能だがシンプルさを優先して Direct を選ぶ。
+- **代替案**:
+  - Transaction pooler (6543) → 接続数制限が緩いが LISTEN/NOTIFY 不可、Phase 3 で詰む
+  - Supavisor session mode → 同等。将来コネクション数で困ったら切替えを検討
+
+### SSL: `sslmode=require` を明示
+
+- **採用理由**: Supabase は SSL 必須。`pgx` のデフォルトは `prefer` だが、本番接続文字列で `sslmode=require` を明示することで意図を明確化する。
+- **代替案**: `sslmode=verify-full` → 証明書検証が厳格になるが、初回デプロイの動作確認段階では `require` で十分。後で強化する。
+
+### 認証: パスワード認証のみ（IAM 認証なし）
+
+- **採用理由**: Supabase の標準。IAM 認証は AWS RDS 系の機能で Supabase には存在しない。
+- **代替案**: なし
+
+## Risks / Trade-offs
+
+- **接続パスワードを GitHub に push してしまうリスク** → `.env.local` でローカル開発、本番は AWS Secrets Manager / App Runner secrets で扱う（2.5b で確定）。今回はローカル動作確認のみで、コミットには含めない。
+- **無料枠 500MB の制限** → 個人運用では十分。家族 4 人で年 1 万件登録しても KB 単位なので問題なし。
+- **Direct Connection はコネクション数が少ない** → App Runner は通常 1 インスタンスで稼働するため問題化しない。スケールアウト時は Supavisor session mode に切替えを検討。
+- **マイグレーションの手動適用ミス** → コピー＆実行のため typo は実質発生しない。複数本になったら自動化する。
+
+## Migration Plan
+
+1. Supabase アカウント作成（ユーザー）
+2. 新規プロジェクトを ap-northeast-1 / Tokyo 相当のリージョンで作成（ユーザー）
+3. SQL Editor で `001_create_stock_items.sql` を実行（ユーザー）
+4. Project Settings → Database から Connection string (Direct) を取得
+5. ローカル `.env.local` に `DATABASE_URL=postgres://...` を設定
+6. Backend を `DATABASE_URL=...` で起動 → `/health` で 200、CRUD 動作確認
+7. ローカルでの確認が取れたら Phase 2.5b に進む
+
+ロールバック: ローカル接続のみのため、`.env.local` を元に戻して compose 経由の Postgres に戻すだけで完結。

--- a/openspec/changes/phase2-5a-supabase-setup/proposal.md
+++ b/openspec/changes/phase2-5a-supabase-setup/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Phase 2.5（初回デプロイ）の最初のステップとして、ローカル Postgres から Supabase（マネージド Postgres）への接続を確立する。Phase 2.5b 以降のサービス（App Runner / Vercel）が稼働するために、共有データストアが本番側に存在している必要がある。
+
+## What Changes
+
+- Supabase プロジェクトを新規作成する（ユーザー手作業）
+- 既存マイグレーション `backend/db/migrations/001_create_stock_items.sql` を Supabase の SQL Editor で適用する
+- Backend を Supabase Direct Connection (5432) または Supavisor session mode で動作させ、`DATABASE_URL` 環境変数で切り替えられることを確認する（Phase 3 で `LISTEN/NOTIFY` を使うため transaction pooler 6543 は不可）
+- Backend が SSL 必須の Supabase に対して `sslmode=require` で接続できることを確認する
+- ローカルから Supabase に接続して既存の API テスト（CRUD）が通ることを動作確認する
+- `specs/features.md` ・ `.claude/rules/backend.md` の手順を最新化する
+
+## Capabilities
+
+### New Capabilities
+
+- `production-database`: 本番 DB（Supabase Postgres）への接続要件と SSL / プーラー方針を定義する
+
+### Modified Capabilities
+
+（なし）
+
+## Impact
+
+- `backend/main.go`: 既に `DATABASE_URL` 駆動になっているが、SSL を含む接続文字列の動作を実機で検証
+- `backend/db/db.go`: 必要に応じて `sslmode=require` 対応の確認
+- 新しい依存追加なし
+- ドキュメント: 接続文字列の取得手順、Supabase プロジェクトの作成手順

--- a/openspec/changes/phase2-5a-supabase-setup/specs/production-database/spec.md
+++ b/openspec/changes/phase2-5a-supabase-setup/specs/production-database/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: 本番 DB は Supabase Postgres を使用する
+本番環境のデータストアは Supabase Postgres を SHALL とする。リージョンは Tokyo に近い場所を選択する。
+
+#### Scenario: 本番 DB の存在
+- **WHEN** Phase 2.5a が完了した時点
+- **THEN** Supabase Dashboard に Pantry Panel 用のプロジェクトが存在する
+- **AND** stock_items テーブルが作成されている
+
+### Requirement: マイグレーションは SQL Editor で手動適用する
+Phase 2.5 時点でのマイグレーションは Supabase Dashboard の SQL Editor に SQL ファイルを貼り付けて実行する SHALL。
+
+#### Scenario: 初回マイグレーション適用
+- **WHEN** Supabase プロジェクト作成直後
+- **THEN** `backend/db/migrations/001_create_stock_items.sql` の内容が SQL Editor で実行されている
+- **AND** `\d stock_items` 相当の確認で必要なカラム（id, name, category, image_url, want_to_buy, created_at, updated_at）が存在する
+
+### Requirement: Backend は DATABASE_URL 環境変数で接続先を切り替える
+Backend は接続文字列を環境変数 `DATABASE_URL` から読み取り、ローカル / Supabase を切り替えられる SHALL。`DATABASE_URL` 未設定時はローカルの compose Postgres に接続する MUST。
+
+#### Scenario: Supabase に接続
+- **WHEN** Backend を `DATABASE_URL=postgres://...supabase.co:5432/postgres?sslmode=require` で起動する
+- **THEN** Backend が Supabase に接続できる
+- **AND** `/health` が 200 を返す
+
+#### Scenario: 環境変数なしでローカル接続
+- **WHEN** Backend を `DATABASE_URL` 未設定で起動する
+- **THEN** Backend が `localhost:5432` の Postgres に接続する
+
+### Requirement: 接続は Direct Connection (5432) を使用する
+Backend は Supabase に対し Direct Connection（ポート 5432）または Supavisor session mode を MUST 使用する。Transaction pooler（6543）は LISTEN/NOTIFY 不可のため Phase 3 で支障となるので NOT 使用する。
+
+#### Scenario: ポート 5432 を使う
+- **WHEN** Supabase に接続する
+- **THEN** 接続文字列のポートが 5432 である
+
+### Requirement: SSL 接続を明示する
+Supabase への接続文字列は `sslmode=require` 以上を MUST 含む。
+
+#### Scenario: SSL 必須
+- **WHEN** Supabase 接続文字列を構成する
+- **THEN** クエリ部分に `sslmode=require` が含まれる
+
+### Requirement: 既存 API は Supabase 接続でも全て動作する
+Phase 1-2 で実装済みの Stock Items API（一覧・登録・編集・削除・wantToBuy トグル）は Supabase 接続環境でも全て SHALL 動作する。
+
+#### Scenario: CRUD の動作確認
+- **WHEN** Backend を Supabase 接続で起動し、Frontend をローカルで起動する
+- **THEN** 商品の登録・一覧表示・編集・削除・wantToBuy トグルが Phase 1-2 の挙動どおりに動く

--- a/openspec/changes/phase2-5a-supabase-setup/tasks.md
+++ b/openspec/changes/phase2-5a-supabase-setup/tasks.md
@@ -1,0 +1,43 @@
+## 1. Issue・ブランチ準備
+
+- [ ] 1.1 GitHub Issue を作成する（タイトル: "Phase 2.5a: Supabase 接続セットアップ"）
+- [ ] 1.2 Issue 番号ベースのブランチを作成する
+- [ ] 1.3 Draft PR を作成する
+
+## 2. Supabase プロジェクト作成（ユーザー作業）
+
+- [ ] 2.1 Supabase アカウントを作成する（既にあればスキップ）
+- [ ] 2.2 新規プロジェクトを Tokyo に近いリージョン（ap-northeast-1 / Northeast Asia）で作成する
+- [ ] 2.3 DB パスワードを安全に保管する（パスワードマネージャーまたは AWS Secrets Manager）
+- [ ] 2.4 Project Settings → Database から Direct Connection の接続文字列を取得する
+
+## 3. マイグレーション適用（ユーザー作業）
+
+- [ ] 3.1 `backend/db/migrations/001_create_stock_items.sql` の内容を Supabase Dashboard の SQL Editor に貼り付けて実行する
+- [ ] 3.2 SQL Editor で `SELECT * FROM stock_items;` を実行し、テーブルが空で存在することを確認する
+
+## 4. Backend を Supabase 接続で動作確認
+
+- [ ] 4.1 接続文字列に `sslmode=require` を付与する（例: `postgres://postgres:<password>@db.<ref>.supabase.co:5432/postgres?sslmode=require`）
+- [ ] 4.2 ローカル `.env.local`（または環境変数）に `DATABASE_URL` を設定する（コミットしない）
+- [ ] 4.3 Backend を `DATABASE_URL` 付きで起動し、`/health` が 200 を返すことを確認する
+- [ ] 4.4 既存の `backend/db/db.go` / `db_test.go` の挙動を確認し、SSL 接続でエラーが出ないか手動確認する
+- [ ] 4.5 ローカルの Frontend (port 3000) から Supabase 接続済み Backend (port 8080) を経由して以下が動作することを確認する:
+  - 商品の一覧表示
+  - 商品登録
+  - 商品編集
+  - 商品削除
+  - wantToBuy トグル
+- [ ] 4.6 SQL Editor で実際にデータが書き込まれたことを確認する
+
+## 5. ドキュメント更新
+
+- [ ] 5.1 `specs/features.md` の Phase 2.5 セクションを更新（Supabase 接続済みであること）
+- [ ] 5.2 README または `.claude/rules/backend.md` に Supabase 接続文字列の取得手順を追記する
+- [ ] 5.3 `.gitignore` に `.env.local` が含まれていることを確認する
+
+## 6. 仕上げ
+
+- [ ] 6.1 CI（lint + tsc + vitest + go test）がすべてパスすることを確認する
+- [ ] 6.2 PR を ready for review にして、Issue を `Closes #N` でリンクする
+- [ ] 6.3 マージ後に `openspec archive phase2-5a-supabase-setup` で archive する

--- a/openspec/changes/phase2-5b-app-runner-deploy/.openspec.yaml
+++ b/openspec/changes/phase2-5b-app-runner-deploy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/phase2-5b-app-runner-deploy/design.md
+++ b/openspec/changes/phase2-5b-app-runner-deploy/design.md
@@ -1,0 +1,105 @@
+## Context
+
+Phase 2.5a で Supabase 上に DB が立ち上がっている。Backend をローカル稼働で本番 DB に接続できる状態だが、Frontend からは到達できない（localhost のみ）。Phase 2.5b では Backend を AWS App Runner にデプロイし、`*.awsapprunner.com` の HTTPS エンドポイントとして公開する。Phase 3 で WebSocket を本番検証するため、常時稼働 + WebSocket 対応のホスティングが必要で、App Runner は両条件を満たす。
+
+## Goals / Non-Goals
+
+**Goals:**
+- Backend のコンテナイメージが ECR に存在する
+- App Runner サービスが ECR イメージから稼働している
+- 外部 HTTPS リクエストで `/health` と CRUD API が応答する
+- App Runner の環境変数で DATABASE_URL / PORT / CORS が切り替えられる
+
+**Non-Goals:**
+- 自動デプロイ（Phase 2.5d）
+- Frontend のデプロイ（Phase 2.5c）
+- カスタムドメイン（標準ドメインで開始）
+- IaC 化（Terraform / CDK）— 初回は手動、運用が安定してから検討
+- Blue/Green デプロイ・カナリアリリース — App Runner 標準のローリング更新で十分
+- 監視・アラート（CloudWatch アラーム等）— 別 change で扱う
+
+## Decisions
+
+### コンテナ配信モード: ECR + App Runner（GitHub Source 不採用）
+
+ECR に push 済みのイメージを App Runner が pull して稼働する構成。
+
+- **採用理由**:
+  - イメージタグで明示的にバージョン管理ができる
+  - GH Actions 側でビルド時間が見えて、CI とデプロイの責務が分離する
+  - rollback はタグ指定で即可能
+- **代替案**: App Runner GitHub Source モード → コードを push するだけで App Runner がビルド & デプロイ。手軽だが、ビルドの可観測性が下がり、private modules を扱うときに苦戦する
+
+### Dockerfile: multi-stage + scratch ベース or alpine
+
+Builder stage で `go build -ldflags="-s -w"` した static binary を、最終 stage の `scratch` または `alpine:3` にコピーする。
+
+- **採用理由**:
+  - イメージサイズが小さい（数十 MB 以下）→ ECR 転送・App Runner 起動が早い
+  - 攻撃面が小さい
+- **alpine vs scratch**: 初回は `alpine:3` を採用。`tzdata` や `ca-certificates`（HTTPS 通信に必要）が同梱され、デバッグも `sh` で入れる。`scratch` は将来検討。
+
+### PORT 環境変数
+
+`backend/main.go` で `PORT` を読み、未設定なら `8080` を使う。
+
+- **採用理由**: App Runner は環境変数 `PORT` を渡してくれる前提（多くの PaaS の慣習）。コード側で対応するのが標準パターン。
+- **代替案**: ハードコード 8080 のまま → App Runner 設定でポート 8080 を指定すれば動くが、PaaS 移行時の柔軟性が下がる
+
+### CORS: 環境変数駆動（カンマ区切り）
+
+`CORS_ALLOWED_ORIGINS` を読み、`,` で split して `AllowOrigins` に渡す。未設定時は localhost:3000（開発用デフォルト）。
+
+- **採用理由**:
+  - 本番フロント URL は Phase 2.5c までは確定しないので、環境変数で後付けが必要
+  - 複数 origin（preview deploy）対応がしやすい
+- **代替案**:
+  - `*` で全許可 → セキュリティ NG
+  - ハードコード → Vercel preview URL に対応できない
+
+### App Runner インスタンスサイズ: 0.25 vCPU / 0.5 GB
+
+最小構成。
+
+- **採用理由**: 個人 / 家族用途、トラフィックは1日数十リクエスト想定。最小構成で十分。コスト ~$5/月。
+- **代替案**: 0.5 vCPU / 1 GB → 不要、コスト 2 倍。
+
+### Auto-scaling: min=1, max=1（最小構成）
+
+スケールアウトを有効化しない。
+
+- **採用理由**:
+  - Phase 3 で LISTEN/NOTIFY を扱う際、複数インスタンスだと NOTIFY が来た 1 インスタンスから他のインスタンスに pub/sub する仕組みが追加で必要になる
+  - 個人運用ではスケールが必要にならない
+  - Direct Connection はコネクション数が少ないので、複数インスタンスでコネクション枯渇のリスクがある
+- **代替案**: max=2 以上 → Phase 3 で破綻する
+
+### Health check: `/health` を使用
+
+App Runner の health check path に `/health` を設定。間隔 10 秒、失敗 3 回でアンヘルシー（App Runner デフォルト）。
+
+- **採用理由**: 既存の `/health` エンドポイントが DB ping を含むため、DB 切断にも気づける。
+
+## Risks / Trade-offs
+
+- **App Runner はゼロスケールできない（min=1 必須）** → 月 ~$5 のコストが必ず発生。許容範囲内。
+- **ECR への手動 push が手間** → Phase 2.5d で GH Actions 自動化する。
+- **環境変数に DATABASE_URL を平文で持つ** → AWS Secrets Manager 連携を将来導入。初回は App Runner の secret env で代替（コンソール上で一度だけ入力、表示されない）。
+- **ap-northeast-1 でも latency 数十 ms 程度** → 個人利用では問題なし。
+- **rollback はタグ指定 → 手順書化が必須** → README に手順を残す。
+
+## Migration Plan
+
+1. ローカルで Dockerfile を書き、`docker build && docker run` で動作確認
+2. ECR リポジトリ作成（ユーザー、コンソールまたは AWS CLI）
+3. ローカルから ECR に push（手動）
+4. App Runner サービス作成（ユーザー、コンソール）
+   - Source: ECR
+   - Image: 手動 push したタグ
+   - 環境変数: DATABASE_URL（Supabase）/ PORT=8080 / CORS_ALLOWED_ORIGINS=http://localhost:3000（暫定）
+   - Health check: `/health`
+5. デプロイ完了後、サービス URL を取得
+6. ローカル Frontend で `NEXT_PUBLIC_API_URL=https://<runner-url>` に切り替えて動作確認
+7. 確認 OK なら Phase 2.5c に進む
+
+ロールバック: App Runner サービスを停止すれば課金停止。コードは branch なので merge しなければ影響なし。

--- a/openspec/changes/phase2-5b-app-runner-deploy/proposal.md
+++ b/openspec/changes/phase2-5b-app-runner-deploy/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Phase 2.5a で Supabase に DB を立ち上げた次のステップとして、Backend を AWS App Runner にデプロイし、外部から HTTPS で到達可能な API として常時稼働させる。Phase 3 で WebSocket + LISTEN/NOTIFY を本番検証する土台でもある（App Runner は WebSocket をサポート、direct connection 可）。
+
+## What Changes
+
+- Backend の **Dockerfile** を作成する（multi-stage build、Alpine ベース、static binary）
+- `backend/main.go` の HTTP リッスンポートを `PORT` 環境変数駆動にする（App Runner デフォルト 8080 互換）
+- `backend/main.go` の CORS 設定を `CORS_ALLOWED_ORIGINS` 環境変数（カンマ区切り）駆動にする
+- AWS ECR リポジトリを `ap-northeast-1` に作成する（ユーザー手作業）
+- ローカルから ECR にイメージを **手動 push** して動作確認する（自動化は Phase 2.5d）
+- AWS App Runner サービスを作成し、ECR からデプロイする（ユーザー手作業）
+  - Region: `ap-northeast-1`
+  - Instance: 0.25 vCPU / 0.5 GB
+  - 環境変数: `DATABASE_URL`、`PORT`、`CORS_ALLOWED_ORIGINS`
+  - Health check: `/health` を使用
+- App Runner のサービス URL（`*.awsapprunner.com`）から `/health` と `/api/stock-items` が応答することを確認する
+
+## Capabilities
+
+### New Capabilities
+
+- `production-backend-runtime`: Backend が AWS App Runner 上で常時稼働し HTTPS で到達可能であること、コンテナ運用に必要な設定（Dockerfile・PORT・CORS 駆動）を定義する
+
+### Modified Capabilities
+
+（なし — Phase 2.5a で導入する `production-database` の前提を引き継ぐが、要件追加は別 capability で扱う）
+
+## Impact
+
+- 新規ファイル: `backend/Dockerfile`、`.dockerignore`
+- 変更: `backend/main.go`（PORT・CORS の env 駆動化）
+- 新規 IaC リソース: ECR repository、App Runner service（IaC コード化はせず、初回はコンソール作業で記録のみ）
+- AWS コスト: ~$5/月（0.25 vCPU / 0.5 GB / 24h 稼働）
+- ドキュメント: ECR push 手順、App Runner 設定手順

--- a/openspec/changes/phase2-5b-app-runner-deploy/specs/production-backend-runtime/spec.md
+++ b/openspec/changes/phase2-5b-app-runner-deploy/specs/production-backend-runtime/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Backend は Dockerfile でビルドできる
+Backend のコードは `backend/Dockerfile` を使ってコンテナイメージにビルドできる SHALL。マルチステージビルドで static binary を最終イメージに含める MUST。
+
+#### Scenario: ローカルでビルドできる
+- **WHEN** リポジトリルートで `docker build -t pantry-panel-backend:local backend/` を実行する
+- **THEN** ビルドが成功し、イメージが生成される
+
+#### Scenario: イメージから起動できる
+- **WHEN** ビルド済みイメージを `docker run -p 8080:8080 -e DATABASE_URL=... pantry-panel-backend:local` で起動する
+- **THEN** `/health` が 200 を返す
+
+### Requirement: Backend は PORT 環境変数で待ち受けポートを切り替える
+Backend は `PORT` 環境変数を読み取り、その値で listen する SHALL。未設定時は 8080 を使用する MUST。
+
+#### Scenario: PORT 指定で起動
+- **WHEN** Backend を `PORT=9000` で起動する
+- **THEN** `:9000` で listen する
+
+#### Scenario: PORT 未設定で起動
+- **WHEN** Backend を `PORT` 環境変数なしで起動する
+- **THEN** `:8080` で listen する
+
+### Requirement: Backend は CORS_ALLOWED_ORIGINS 環境変数で CORS 許可 origin を切り替える
+Backend は `CORS_ALLOWED_ORIGINS`（カンマ区切り）を読み取り、Echo の CORS middleware の `AllowOrigins` に設定する SHALL。未設定時は `http://localhost:3000` を使用する MUST。
+
+#### Scenario: 単一 origin
+- **WHEN** Backend を `CORS_ALLOWED_ORIGINS=https://example.vercel.app` で起動する
+- **THEN** `https://example.vercel.app` からのリクエストに `Access-Control-Allow-Origin: https://example.vercel.app` を返す
+
+#### Scenario: 複数 origin
+- **WHEN** Backend を `CORS_ALLOWED_ORIGINS=https://a.vercel.app,https://b.vercel.app` で起動する
+- **THEN** どちらの origin からのリクエストにも対応する CORS ヘッダを返す
+
+#### Scenario: 未設定時はローカル用
+- **WHEN** Backend を `CORS_ALLOWED_ORIGINS` 未設定で起動する
+- **THEN** `http://localhost:3000` のみ許可する
+
+### Requirement: Backend は ECR から App Runner にデプロイできる
+Backend のコンテナイメージは AWS ECR (`ap-northeast-1`) にホストし、AWS App Runner サービスがそれを pull して稼働する SHALL。
+
+#### Scenario: ECR 上にイメージが存在する
+- **WHEN** Phase 2.5b 完了時点
+- **THEN** `ap-northeast-1` の ECR リポジトリ `pantry-panel-backend` にビルド済みイメージが少なくとも 1 つ存在する
+
+#### Scenario: App Runner が稼働中
+- **WHEN** Phase 2.5b 完了時点
+- **THEN** App Runner コンソールに `pantry-panel-backend` サービスが `Running` 状態で存在する
+- **AND** サービス URL から `/health` が 200 を返す
+
+### Requirement: App Runner は最小構成で稼働する
+App Runner のインスタンスサイズは 0.25 vCPU / 0.5 GB MUST、Auto Scaling は min=1, max=1 とする MUST。
+
+#### Scenario: スケール設定
+- **WHEN** App Runner サービスの設定を確認する
+- **THEN** インスタンスサイズが 0.25 vCPU / 0.5 GB
+- **AND** min instances = max instances = 1
+
+### Requirement: App Runner は /health をヘルスチェックに使用する
+App Runner のヘルスチェック設定は `/health` をパスとして MUST 設定する。
+
+#### Scenario: ヘルスチェック設定
+- **WHEN** App Runner サービスの設定を確認する
+- **THEN** Health check path が `/health`
+- **AND** プロトコルが HTTP（コンテナ内通信のため）
+
+### Requirement: 本番 API は HTTPS で外部から到達可能
+App Runner サービス URL（`*.awsapprunner.com`）から HTTPS で API が応答する SHALL。
+
+#### Scenario: 外部から /health に到達
+- **WHEN** ブラウザまたは curl で `https://<service-url>/health` を叩く
+- **THEN** 200 が返る
+
+#### Scenario: 外部から CRUD API に到達
+- **WHEN** ローカルの Frontend を `NEXT_PUBLIC_API_URL=https://<service-url>` で起動して操作する
+- **THEN** 商品の登録・一覧表示・編集・削除が成功する

--- a/openspec/changes/phase2-5b-app-runner-deploy/tasks.md
+++ b/openspec/changes/phase2-5b-app-runner-deploy/tasks.md
@@ -1,0 +1,57 @@
+## 1. Issue・ブランチ準備
+
+- [ ] 1.1 GitHub Issue を作成する（タイトル: "Phase 2.5b: Backend を AWS App Runner にデプロイ"）
+- [ ] 1.2 Issue 番号ベースのブランチを作成する
+- [ ] 1.3 Draft PR を作成する
+
+## 2. Backend のコード対応
+
+- [ ] 2.1 `backend/main.go` の `e.Start(":8080")` を `os.Getenv("PORT")` 駆動にする（未設定時 8080）
+- [ ] 2.2 `backend/main.go` の `AllowOrigins` を `CORS_ALLOWED_ORIGINS`（カンマ区切り、未設定時 `http://localhost:3000`）駆動にする
+- [ ] 2.3 既存の Go ユニットテストが通ることを確認する
+- [ ] 2.4 `backend/main.go` の env 解析部分に必要に応じてユニットテストを追加する（`strings.Split` の空文字ハンドリング等）
+
+## 3. Dockerfile / .dockerignore 作成
+
+- [ ] 3.1 `backend/Dockerfile`（multi-stage、builder: golang:1.26-alpine、final: alpine:3、static binary）を作成する
+- [ ] 3.2 `backend/.dockerignore` を作成する（go test artifacts、`.git`、`.serena`、テストデータ等を除外）
+- [ ] 3.3 `docker build -t pantry-panel-backend:local backend/` でビルド成功することを確認する
+- [ ] 3.4 ローカル Postgres に接続して `docker run -p 8080:8080 -e DATABASE_URL=...` で起動し `/health` が 200 を返すことを確認する
+
+## 4. AWS ECR 作成と push（ユーザー作業）
+
+- [ ] 4.1 AWS ECR で `pantry-panel-backend` リポジトリを `ap-northeast-1` に作成する
+- [ ] 4.2 ECR ログイン（`aws ecr get-login-password ... | docker login ...`）
+- [ ] 4.3 イメージにタグを付けて push する（タグ: `v0.1.0` と `latest`）
+- [ ] 4.4 ECR コンソールで push されたイメージを確認する
+
+## 5. AWS App Runner サービス作成（ユーザー作業）
+
+- [ ] 5.1 App Runner で新規サービスを作成する（Source: ECR、Image: `pantry-panel-backend:latest`、Region: `ap-northeast-1`）
+- [ ] 5.2 インスタンス: 0.25 vCPU / 0.5 GB、Auto scaling: min=1 max=1 を設定する
+- [ ] 5.3 環境変数を設定する:
+  - `DATABASE_URL`（Phase 2.5a の Supabase Direct Connection 文字列、`sslmode=require` 込み、**Secret として登録**）
+  - `PORT`: `8080`
+  - `CORS_ALLOWED_ORIGINS`: `http://localhost:3000`（Vercel デプロイ後 2.5c で更新）
+- [ ] 5.4 Health check: HTTP `/health`、Interval 10s、Timeout 5s
+- [ ] 5.5 サービス作成 → 稼働開始まで待つ（数分）
+- [ ] 5.6 サービス URL（`*.awsapprunner.com`）を控える
+
+## 6. 動作確認
+
+- [ ] 6.1 `curl https://<service-url>/health` が 200 を返すことを確認する
+- [ ] 6.2 ローカル Frontend を `NEXT_PUBLIC_API_URL=https://<service-url>` で起動し、商品 CRUD と wantToBuy トグルが動作することを確認する
+- [ ] 6.3 Supabase SQL Editor で実データが書き込まれていることを確認する
+- [ ] 6.4 App Runner ログで リクエストが処理されていることを確認する
+
+## 7. ドキュメント更新
+
+- [ ] 7.1 `README.md` または `.claude/rules/backend.md` に ECR push 手順と App Runner 設定手順をまとめる
+- [ ] 7.2 ロールバック手順（ECR の旧タグへ App Runner Image URI を変更）を記載する
+- [ ] 7.3 `specs/features.md` の Phase 2.5 セクションを更新する
+
+## 8. 仕上げ
+
+- [ ] 8.1 CI（lint + tsc + vitest + go test）がすべてパスすることを確認する
+- [ ] 8.2 PR を ready for review にして、Issue を `Closes #N` でリンクする
+- [ ] 8.3 マージ後に `openspec archive phase2-5b-app-runner-deploy` で archive する

--- a/openspec/changes/phase2-5c-vercel-frontend-deploy/.openspec.yaml
+++ b/openspec/changes/phase2-5c-vercel-frontend-deploy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/phase2-5c-vercel-frontend-deploy/design.md
+++ b/openspec/changes/phase2-5c-vercel-frontend-deploy/design.md
@@ -1,0 +1,76 @@
+## Context
+
+Phase 2.5b で Backend が App Runner で本番稼働中。Frontend は現状ローカル `npm run dev` のみで起動可能で、API URL が `localhost:8080` 前提のコードになっている可能性がある。Phase 2.5c では Frontend を Vercel にデプロイし、本番 Backend に接続できる構成にする。Vercel は Next.js 公式の推奨ホスティングで、GitHub 連携で自動デプロイが標準（Phase 2.5d で別途自動化する Backend と異なり、Vercel は最初から自動）。
+
+## Goals / Non-Goals
+
+**Goals:**
+- Frontend が Vercel 上で公開されている（`*.vercel.app` で到達可能）
+- 環境変数 `NEXT_PUBLIC_API_URL` で API ベース URL を切り替え可能
+- 本番 URL から Backend を経由した CRUD が全て動作する
+- main へのマージで自動デプロイが走る（Vercel デフォルト）
+
+**Non-Goals:**
+- カスタムドメイン（標準 `*.vercel.app` で開始）
+- preview deploy（PR ごとの URL）の活用 — Vercel デフォルトで作られるが、CORS の対応は最低限とする
+- Edge Functions / ISR の活用 — Phase 4 以降で必要に応じて
+- 監視・パフォーマンス計測（Vercel Analytics）— 別 change
+
+## Decisions
+
+### API URL: `NEXT_PUBLIC_API_URL` 環境変数駆動
+
+Frontend の fetch 先 base URL を環境変数で外出しする。
+
+- **採用理由**:
+  - ローカル開発（localhost）/ Vercel 本番（App Runner URL）/ preview を切り替え可能
+  - Next.js 公式の env var パターンに沿う
+  - `NEXT_PUBLIC_` プレフィクスでクライアント側でも読める
+- **代替案**:
+  - `process.env.NODE_ENV` で分岐 → 環境追加時に肥大化、preview に対応できない
+  - リバースプロキシで同一 origin 化 → CORS 不要になるが Vercel の rewrite 設定が必要、構成が複雑
+
+### 環境変数の置き方
+
+- 開発: `frontend/.env.local`（コミットしない）に `NEXT_PUBLIC_API_URL=http://localhost:8080`
+- 本番: Vercel ダッシュボード → Project Settings → Environment Variables に Production / Preview / Development 用にそれぞれ設定
+
+### preview deploy への CORS 対応: 暫定で本番 URL のみ許可
+
+Vercel preview deploy は PR ごとに URL が変わる（`*-pr-N.vercel.app` 等）。CORS で全部許可すると wildcard が必要になる。
+
+- **採用方針**: Phase 2.5c では本番 URL（`pantry-panel-<account>.vercel.app` 相当）のみ App Runner CORS に追加する。preview deploy は `npm run dev` のローカル相当として割り切る（必要時に App Runner CORS に追記）。
+- **代替案**:
+  - regex で `*.vercel.app` 全許可 → CORS の wildcard サポート的に複雑、またセキュリティ的に乱用される
+  - Vercel preview にも対応する自動 CORS 更新 → Phase 2.5d 以降で検討
+
+### Backend CORS の更新タイミング
+
+Vercel デプロイ完了後、本番 URL を確認してから App Runner の `CORS_ALLOWED_ORIGINS` を更新する。順序を間違えると本番から API が叩けない（CORS エラー）状態が一時的に発生するため。
+
+### Root Directory: `frontend/`
+
+monorepo 構成のため Vercel 側で Root Directory を指定する。
+
+- **採用理由**: backend と frontend が同居しているため、Vercel が backend のファイルを検査しないように Root を絞る。
+
+## Risks / Trade-offs
+
+- **環境変数の漏洩** → `NEXT_PUBLIC_*` はブラウザに露出する。API URL は秘匿情報ではないので問題なし。Backend の DATABASE_URL 等は Frontend には絶対渡さない。
+- **本番 URL を Vercel 任せの自動命名にすると、変わるとリンク切れ** → 命名は `pantry-panel-<vercel-account>.vercel.app` 等で固定される想定。Production deployment は alias 固定なので心配薄。
+- **CORS の更新忘れで一時的にアプリが動かない** → デプロイ手順書に「Vercel デプロイ完了 → URL 確認 → App Runner 環境変数追記 → App Runner 再デプロイ → 動作確認」を明記する。
+- **preview deploy の CORS 不対応** → 開発体験は下がるが、Phase 2.5 のスコープを抑えるため割り切る。
+
+## Migration Plan
+
+1. Frontend のコードを `NEXT_PUBLIC_API_URL` 駆動に変更（PR で）
+2. `frontend/.env.local.example` を追加し `.env.local` の存在を周知
+3. Vercel アカウント作成（ユーザー）
+4. Vercel プロジェクトを GitHub から import、Root Directory を `frontend/` に設定（ユーザー）
+5. Vercel 環境変数 `NEXT_PUBLIC_API_URL` に App Runner URL を設定
+6. main にマージ → Vercel が自動デプロイ → 本番 URL を確認
+7. App Runner コンソールで `CORS_ALLOWED_ORIGINS` に Vercel 本番 URL を追記、再デプロイ
+8. 本番 URL でアプリを開き、CRUD・wantToBuy・フィルタ・シンプルビューが全て動くことを確認
+9. 確認 OK なら Phase 2.5d に進む
+
+ロールバック: Vercel の Deployment 画面から旧 deploy に "Promote to Production" で即時切替え可能。

--- a/openspec/changes/phase2-5c-vercel-frontend-deploy/proposal.md
+++ b/openspec/changes/phase2-5c-vercel-frontend-deploy/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Phase 2.5b で本番 Backend が App Runner で稼働している。次のステップとして Frontend を Vercel にデプロイし、本番 URL から本番 Backend にアクセスできる状態にする。エンドユーザー（家族）が PWA としてブックマークから利用可能になる。
+
+## What Changes
+
+- Frontend の API ベース URL を `NEXT_PUBLIC_API_URL` 環境変数駆動にする
+- 既存の `frontend/src/lib/api.ts` で API URL の組み立て箇所を環境変数経由に置き換える
+- Vercel アカウント作成（ユーザー作業）
+- Vercel プロジェクトを GitHub リポジトリから import（ユーザー作業）
+  - Root Directory: `frontend/`
+  - Build / Output / Install: Vercel デフォルト（Next.js プリセット）
+- Vercel 環境変数: `NEXT_PUBLIC_API_URL` に Phase 2.5b の App Runner サービス URL を設定
+- App Runner の `CORS_ALLOWED_ORIGINS` に Vercel 本番 URL を追記する（コンソール環境変数更新 → 自動再デプロイ）
+- 本番 URL（`*.vercel.app`）からアプリを開いて、Phase 1-2 の機能が全て動作することを確認する
+
+## Capabilities
+
+### New Capabilities
+
+- `production-frontend-runtime`: Frontend が Vercel 上で公開され、`NEXT_PUBLIC_API_URL` で本番 Backend と通信できる要件
+
+### Modified Capabilities
+
+- `production-backend-runtime`: CORS 許可 origin に Vercel 本番 URL を追加する設定変更
+
+## Impact
+
+- 変更: `frontend/src/lib/api.ts`（または fetch 呼び出しの集約箇所）— 環境変数化
+- 新規: Vercel プロジェクト（GitHub 連携、main 自動デプロイが有効化される）
+- 設定変更: App Runner 環境変数 `CORS_ALLOWED_ORIGINS` に Vercel ドメイン追加
+- ドキュメント: Vercel プロジェクト設定手順、env vars の管理ルール
+- バックエンド 2.5b の自動デプロイは Vercel と異なり Phase 2.5d で対応する

--- a/openspec/changes/phase2-5c-vercel-frontend-deploy/specs/production-frontend-runtime/spec.md
+++ b/openspec/changes/phase2-5c-vercel-frontend-deploy/specs/production-frontend-runtime/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Frontend は NEXT_PUBLIC_API_URL で API ベース URL を切り替える
+Frontend は `NEXT_PUBLIC_API_URL` 環境変数を読み取り、すべての API 呼び出しのベース URL に使用する SHALL。未設定時は `http://localhost:8080` を使用する MUST。
+
+#### Scenario: 環境変数指定で動作
+- **WHEN** Frontend を `NEXT_PUBLIC_API_URL=https://example.awsapprunner.com` でビルド・起動する
+- **THEN** すべての fetch リクエストの URL が `https://example.awsapprunner.com/...` で始まる
+
+#### Scenario: 未設定時はローカル
+- **WHEN** Frontend を `NEXT_PUBLIC_API_URL` 未設定で起動する
+- **THEN** すべての fetch リクエストの URL が `http://localhost:8080/...` で始まる
+
+### Requirement: Frontend は Vercel 上で公開される
+Frontend は Vercel にホストされ、`*.vercel.app` の HTTPS URL で外部から到達可能 SHALL。
+
+#### Scenario: 本番 URL に到達できる
+- **WHEN** ブラウザで `https://<vercel-url>/stock-items` を開く
+- **THEN** 商品一覧ページが表示される
+
+#### Scenario: main へのマージで自動デプロイ
+- **WHEN** GitHub の main ブランチに変更が push される
+- **THEN** Vercel が自動でビルド・デプロイし、本番 URL が更新される
+
+### Requirement: 本番 URL から Phase 1-2 の全機能が動作する
+本番の Frontend (Vercel) と本番の Backend (App Runner) と本番の DB (Supabase) が連携して、Phase 1-2 の機能が全て SHALL 動作する。
+
+#### Scenario: 商品 CRUD
+- **WHEN** 本番 URL から商品を登録・編集・削除する
+- **THEN** 操作が成功し、Supabase 側にも反映される
+
+#### Scenario: wantToBuy トグル
+- **WHEN** 本番 URL でカートアイコンをクリックする
+- **THEN** トグルが切り替わり、Supabase に保存される
+
+#### Scenario: フィルタ・シンプルビュー
+- **WHEN** 本番 URL でフィルタ操作・表示モード切替を行う
+- **THEN** Phase 2 / Phase 4 の挙動どおりに動作する
+
+### Requirement: Vercel プロジェクトの Root Directory は `frontend/` に設定する
+monorepo 構成のため、Vercel プロジェクト設定で Root Directory を `frontend/` に MUST 指定する。
+
+#### Scenario: ビルドが frontend のみ対象
+- **WHEN** Vercel のビルドログを確認する
+- **THEN** `frontend/` 配下のみがビルド対象になっている（backend ファイルは無視）
+
+## MODIFIED Requirements
+
+### Requirement: Backend は CORS_ALLOWED_ORIGINS 環境変数で CORS 許可 origin を切り替える
+Backend は `CORS_ALLOWED_ORIGINS`（カンマ区切り）を読み取り、Echo の CORS middleware の `AllowOrigins` に設定する SHALL。未設定時は `http://localhost:3000` を使用する MUST。本番環境では Vercel の本番 URL を MUST 含める。
+
+#### Scenario: 単一 origin
+- **WHEN** Backend を `CORS_ALLOWED_ORIGINS=https://example.vercel.app` で起動する
+- **THEN** `https://example.vercel.app` からのリクエストに `Access-Control-Allow-Origin: https://example.vercel.app` を返す
+
+#### Scenario: 複数 origin
+- **WHEN** Backend を `CORS_ALLOWED_ORIGINS=https://a.vercel.app,https://b.vercel.app` で起動する
+- **THEN** どちらの origin からのリクエストにも対応する CORS ヘッダを返す
+
+#### Scenario: 未設定時はローカル用
+- **WHEN** Backend を `CORS_ALLOWED_ORIGINS` 未設定で起動する
+- **THEN** `http://localhost:3000` のみ許可する
+
+#### Scenario: 本番では Vercel URL を含む
+- **WHEN** App Runner の `CORS_ALLOWED_ORIGINS` 環境変数を確認する
+- **THEN** Vercel 本番 URL（例: `https://pantry-panel-xxxxx.vercel.app`）が含まれる

--- a/openspec/changes/phase2-5c-vercel-frontend-deploy/tasks.md
+++ b/openspec/changes/phase2-5c-vercel-frontend-deploy/tasks.md
@@ -1,0 +1,53 @@
+## 1. Issue・ブランチ準備
+
+- [ ] 1.1 GitHub Issue を作成する（タイトル: "Phase 2.5c: Frontend を Vercel にデプロイ"）
+- [ ] 1.2 Issue 番号ベースのブランチを作成する
+- [ ] 1.3 Draft PR を作成する
+
+## 2. Frontend のコード対応
+
+- [ ] 2.1 `frontend/src/lib/api.ts` を読み、API URL のベース部分を `process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080"` に切り替える
+- [ ] 2.2 `frontend/.env.local.example` を作成（`NEXT_PUBLIC_API_URL=http://localhost:8080` の例）
+- [ ] 2.3 `frontend/.gitignore` に `.env*.local` が含まれていることを確認する
+- [ ] 2.4 既存テストが通ることを確認する（`vi.mock("@/lib/api")` 経由なので影響なしのはず）
+- [ ] 2.5 ローカル `npm run dev` で動作確認（`.env.local` に `NEXT_PUBLIC_API_URL=http://localhost:8080` を設定）
+
+## 3. Vercel プロジェクト作成（ユーザー作業）
+
+- [ ] 3.1 Vercel アカウントを作成する（GitHub OAuth 推奨）
+- [ ] 3.2 GitHub リポジトリ `pantry-panel` を Vercel に import する
+- [ ] 3.3 プロジェクト設定で Root Directory を `frontend/` に指定する
+- [ ] 3.4 Framework Preset が Next.js として認識されていることを確認する
+- [ ] 3.5 環境変数 `NEXT_PUBLIC_API_URL` に Phase 2.5b の App Runner URL（例: `https://xxxxx.ap-northeast-1.awsapprunner.com`）を Production / Preview / Development の全環境に設定する
+- [ ] 3.6 main ブランチを Production Branch として確認する
+- [ ] 3.7 初回デプロイを実行 → 完了を確認
+- [ ] 3.8 デプロイ完了後の本番 URL（`*.vercel.app`）を控える
+
+## 4. Backend CORS の更新（App Runner 環境変数更新）
+
+- [ ] 4.1 App Runner コンソールで `pantry-panel-backend` サービスを開く
+- [ ] 4.2 環境変数 `CORS_ALLOWED_ORIGINS` を `http://localhost:3000,https://<vercel-url>` に更新する
+- [ ] 4.3 設定保存 → App Runner が自動再デプロイされる（数分待つ）
+- [ ] 4.4 再デプロイ完了を確認
+
+## 5. 本番動作確認
+
+- [ ] 5.1 ブラウザで `https://<vercel-url>/stock-items` を開く
+- [ ] 5.2 Network タブで API リクエストが App Runner URL に向かっていることを確認する
+- [ ] 5.3 商品の登録・一覧表示・編集・削除・wantToBuy トグルが動作することを確認する
+- [ ] 5.4 フィルタ（検索・カテゴリ・買いたいものだけ）が動作することを確認する
+- [ ] 5.5 表示モード切替（通常 ⇔ シンプル）が動作することを確認する
+- [ ] 5.6 Supabase SQL Editor で本番データが書き込まれていることを確認する
+
+## 6. ドキュメント更新
+
+- [ ] 6.1 `README.md` に本番 URL（Frontend / Backend）を記載する
+- [ ] 6.2 `frontend/.env.local.example` の内容を確認する
+- [ ] 6.3 `specs/features.md` の Phase 2.5 セクションを更新する
+- [ ] 6.4 `.claude/rules/frontend.md` に Vercel 設定の参照を追記する
+
+## 7. 仕上げ
+
+- [ ] 7.1 CI（lint + tsc + vitest + go test）がすべてパスすることを確認する
+- [ ] 7.2 PR を ready for review にして、Issue を `Closes #N` でリンクする
+- [ ] 7.3 マージ後に `openspec archive phase2-5c-vercel-frontend-deploy` で archive する

--- a/openspec/changes/phase2-5d-auto-deploy/.openspec.yaml
+++ b/openspec/changes/phase2-5d-auto-deploy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/phase2-5d-auto-deploy/design.md
+++ b/openspec/changes/phase2-5d-auto-deploy/design.md
@@ -1,0 +1,94 @@
+## Context
+
+Phase 2.5a〜c が完了すると、本番アプリ一式（Supabase + App Runner + Vercel）が稼働している。Frontend は Vercel の GitHub 連携で main 自動デプロイ済みだが、Backend は手動 ECR push に頼っている状態。Phase 2.5d で Backend も main 自動デプロイにすることで、Phase 3 の WebSocket 実装に入る前に CI/CD の足並みを揃える。
+
+## Goals / Non-Goals
+
+**Goals:**
+- main への push（merge）で Backend が自動デプロイされる
+- AWS への認証は OIDC（短命トークン）を使用する
+- デプロイ完了後の smoke test で `/health` 200 を必須にする
+- 失敗時は GitHub Actions が赤くなり、人間が気づける
+
+**Non-Goals:**
+- preview deploy / staging 環境（main → 本番のみ）
+- カナリア / Blue-Green 配信 — App Runner 標準のローリングのみ
+- 自動 rollback（失敗検知時）— 別 change で扱う
+- DB マイグレーションの自動実行（Phase 2.5a の方針通り当面手動）
+- Slack / Discord 通知 — 必要なら別途追加
+
+## Decisions
+
+### AWS 認証: OIDC (GitHub OIDC Provider) を採用
+
+GitHub Actions に AWS アクセスキーを Secrets として置かず、OIDC で短命トークンを取得して IAM Role を AssumeRole する。
+
+- **採用理由**:
+  - アクセスキー漏洩リスクなし
+  - GitHub 公式推奨 (`aws-actions/configure-aws-credentials@v4`)
+  - 監査がしやすい（CloudTrail に Web Identity が残る）
+- **代替案**: アクセスキー + Secrets に保存 → 漏洩リスクあり、ローテーション手間あり
+
+### Job 構成: build-and-push → deploy → smoke-test の 3 段直列
+
+並列化せず直列にする。
+
+- **採用理由**:
+  - deploy は build 完了が前提
+  - smoke-test は deploy が反映されてからでないと意味がない
+  - 並列化のメリットが小さい（build 数十秒、deploy 数分）
+- **代替案**: build と deploy を 1 step に集約 → 失敗時の切り分けがしづらい
+
+### Image タグ戦略: `${{ github.sha }}` と `latest` の両方を付ける
+
+- **採用理由**:
+  - `latest` は人が「最新」を指定するときに便利
+  - `${{ github.sha }}` で過去の任意のコミットを再デプロイ・rollback 可能
+- **代替案**: `latest` のみ → rollback 困難
+- **代替案**: SHA のみ → 人手のオペレーションが煩雑
+
+### App Runner 反映方式: `aws apprunner start-deployment`
+
+- **採用理由**:
+  - App Runner は ECR の `latest` を指している場合 push を検知して自動デプロイする機能もあるが、明示的に StartDeployment を呼ぶことで GH Actions 上で完了待ちと smoke test ができる
+  - aws CLI 標準コマンドで簡潔
+- **代替案**: ECR push のみで自動更新を待つ → デプロイ完了タイミングが GH Actions から見えない
+
+### Smoke test: `/health` のみ（最小）
+
+curl で `/health` が 200 を返すまで最大 5 分間ポーリングする。
+
+- **採用理由**: 起動失敗の早期検知のみ最小スコープで実現。深い E2E は別 workflow（既存 e2e.yml）で扱う。
+- **代替案**: 主要 API（GET /api/stock-items）も叩く → 認証等で複雑化、初回は `/health` で十分
+
+### ワークフローの trigger: `push: main` と `workflow_dispatch`
+
+- **採用理由**:
+  - main 自動 + 手動再実行（rollback 等）の 2 ルートを担保
+- **代替案**: タグ push のみ → 個人運用には堅すぎる
+
+## Risks / Trade-offs
+
+- **OIDC 設定が初回は手間** → ユーザー側のステップが多い。手順書を README に固定する。
+- **ECR `latest` 反映待ちで App Runner が古いイメージで稼働する瞬間** → StartDeployment を明示的に叩くため発生しない。
+- **smoke test がタイムアウトすると false alarm** → 5 分の余裕、5 秒間隔のリトライで現実的にはほぼ起きない。起きたらロールバック手順を実行。
+- **ECR ストレージ増加** → タグなし不要イメージは ECR Lifecycle Policy で自動削除（30 日 / 直近 10 個保持などの設定を別途）。今回はスコープ外、運用しながら判断。
+
+## Migration Plan
+
+1. AWS 側で GitHub OIDC Provider を作成（ユーザー、初回のみ）
+2. IAM Role `pantry-panel-deploy-role` を作成（信頼ポリシーに GitHub OIDC、許可ポリシーに ECR push + App Runner StartDeployment）
+3. GitHub リポジトリの Secrets / Variables に必要な値を登録
+4. `.github/workflows/deploy-backend.yml` を PR で追加
+5. PR を main にマージ → 初回ワークフローが走る
+6. ワークフロー成功 + smoke test 成功を確認
+7. 試しに backend の文言を 1 行変えて main に push → 自動デプロイされることを確認
+
+ロールバック:
+- 失敗デプロイ時: App Runner コンソールで前 successful deployment にロールバック、または `${{ github.sha }}` タグで `aws apprunner start-deployment --image-identifier <old-sha>` を手動実行
+- ワークフロー自体に問題: `.github/workflows/deploy-backend.yml` を revert する PR を main にマージすれば、以降のデプロイは止まる（既存の本番は影響なし）
+
+## Open Questions
+
+- ECR Lifecycle Policy の閾値（保持数 / 日数）— 別 change で詰める
+- デプロイ通知（Slack 等）— 必要に応じて Phase 3 以降で追加

--- a/openspec/changes/phase2-5d-auto-deploy/proposal.md
+++ b/openspec/changes/phase2-5d-auto-deploy/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Phase 2.5b で Backend を App Runner に手動デプロイし、Phase 2.5c で Frontend が Vercel に自動デプロイされる状態にした。最後のステップとして、Backend も main へのマージで自動デプロイされる体制を作る。手動 ECR push を不要にし、デプロイの再現性とフィードバックループを向上させる。
+
+## What Changes
+
+- GitHub Actions ワークフロー `.github/workflows/deploy-backend.yml` を新規作成する
+  - Trigger: `push` to `main`、`workflow_dispatch`（手動実行も可）
+  - Job 1 `build-and-push`: backend の Docker image を build → ECR に push（タグ: `${{ github.sha }}` と `latest`）
+  - Job 2 `deploy`: AWS App Runner `start-deployment` を呼び出して新イメージを反映する
+  - Job 3 `smoke-test`: デプロイ完了後 `curl https://<service-url>/health` で 200 を確認
+- AWS 認証は **OIDC (GitHub OIDC Provider + IAM Role AssumeRoleWithWebIdentity)** を使用する（アクセスキーをリポジトリ Secrets に置かない方式）
+- IAM Role 作成と GH Actions Secrets / Variables 登録（ユーザー作業）
+- 既存 `ci.yml` の backend ジョブとは独立に動作する（PR では実行しない、main push のみ）
+- README にデプロイフローと rollback 手順を記載する
+
+## Capabilities
+
+### New Capabilities
+
+- `auto-deploy-pipeline`: main へのマージで Backend が自動的に ECR build → push → App Runner deploy → smoke test まで実行される CI/CD フロー
+
+### Modified Capabilities
+
+（なし）
+
+## Impact
+
+- 新規ファイル: `.github/workflows/deploy-backend.yml`
+- 既存 ci.yml は変更なし
+- AWS 側: GitHub OIDC Provider 登録、IAM Role（ECR push + App Runner StartDeployment 権限）
+- GitHub Secrets / Variables: `AWS_REGION`、`AWS_ROLE_ARN`、`ECR_REPOSITORY`、`APP_RUNNER_SERVICE_ARN` を登録
+- ドキュメント更新
+- Vercel のデプロイは Phase 2.5c で既に自動化済み（追加作業なし）

--- a/openspec/changes/phase2-5d-auto-deploy/specs/auto-deploy-pipeline/spec.md
+++ b/openspec/changes/phase2-5d-auto-deploy/specs/auto-deploy-pipeline/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Backend は main 自動デプロイを GitHub Actions で実行する
+GitHub の `main` ブランチに push（merge）された時、Backend のコンテナイメージを ECR にビルド・push し、AWS App Runner に反映する SHALL。失敗時はワークフローが赤くなり、デプロイは中断する MUST。
+
+#### Scenario: main への push で自動デプロイ
+- **WHEN** PR が main にマージされる
+- **THEN** GitHub Actions の `deploy-backend.yml` が実行される
+- **AND** ECR に新しいイメージが push される
+- **AND** App Runner にデプロイが反映される
+
+#### Scenario: 手動実行も可能
+- **WHEN** GitHub Actions の UI から `workflow_dispatch` でトリガーする
+- **THEN** 同じデプロイフローが実行される
+
+### Requirement: AWS 認証は OIDC を使用する
+GitHub Actions が AWS にアクセスする際は **GitHub OIDC + IAM Role AssumeRoleWithWebIdentity** を MUST 使用する。長期有効なアクセスキーを GitHub Secrets に保存しない MUST。
+
+#### Scenario: OIDC で認証
+- **WHEN** ワークフローが AWS API を呼ぶ
+- **THEN** `aws-actions/configure-aws-credentials@v4` で OIDC トークンから一時クレデンシャルを取得している
+
+#### Scenario: アクセスキーが secrets に存在しない
+- **WHEN** リポジトリの Secrets を確認する
+- **THEN** `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` 等の長期クレデンシャルが存在しない
+
+### Requirement: イメージタグは sha と latest の両方を付与する
+ECR に push するイメージには `${{ github.sha }}` と `latest` の **両方** のタグを MUST 付与する。
+
+#### Scenario: タグ付与
+- **WHEN** ECR push が完了する
+- **THEN** ECR コンソールでイメージに `latest` タグと `<commit-sha>` タグの両方が確認できる
+
+### Requirement: App Runner 反映は StartDeployment で明示的に行う
+ECR push 後、`aws apprunner start-deployment --service-arn ...` コマンドで App Runner に反映する MUST。完了を CLI で待ち合わせる SHALL。
+
+#### Scenario: 明示的に Deployment 開始
+- **WHEN** ECR push が完了した直後
+- **THEN** ワークフローが `aws apprunner start-deployment` を実行する
+- **AND** `aws apprunner wait` または同等のポーリングでデプロイ完了を待つ
+
+### Requirement: デプロイ後の smoke test
+App Runner デプロイ完了後、サービス URL に `/health` リクエストを送り 200 が返ることを SHALL 確認する。失敗時はワークフローを fail させる MUST。
+
+#### Scenario: 正常時
+- **WHEN** デプロイ完了直後に smoke test ステップが走る
+- **THEN** `curl -fsS https://<service-url>/health` が 200 を返す
+- **AND** ワークフローが緑で終了する
+
+#### Scenario: 起動失敗時
+- **WHEN** Backend が起動失敗で `/health` が 5 分以内に 200 を返さない
+- **THEN** smoke test ステップが fail し、ワークフロー全体が赤になる
+
+### Requirement: ワークフロー定義は `.github/workflows/deploy-backend.yml`
+ファイルパスは `.github/workflows/deploy-backend.yml` MUST。
+
+#### Scenario: ファイル存在
+- **WHEN** リポジトリを確認する
+- **THEN** `.github/workflows/deploy-backend.yml` が存在し、次の trigger を持つ:
+  - `push.branches: [main]`
+  - `workflow_dispatch:`
+
+### Requirement: PR では本ワークフローは走らない
+本ワークフローは PR では走らず main の push のみで走る MUST。PR の検証は既存 `ci.yml` / `e2e.yml` が担当する。
+
+#### Scenario: PR では実行されない
+- **WHEN** PR が作成・更新される
+- **THEN** `deploy-backend.yml` は実行されない
+- **AND** `ci.yml` と `e2e.yml` のみ走る

--- a/openspec/changes/phase2-5d-auto-deploy/tasks.md
+++ b/openspec/changes/phase2-5d-auto-deploy/tasks.md
@@ -1,0 +1,70 @@
+## 1. Issue・ブランチ準備
+
+- [ ] 1.1 GitHub Issue を作成する（タイトル: "Phase 2.5d: Backend 自動デプロイ (GitHub Actions + OIDC)"）
+- [ ] 1.2 Issue 番号ベースのブランチを作成する
+- [ ] 1.3 Draft PR を作成する
+
+## 2. AWS 側の OIDC / IAM 設定（ユーザー作業）
+
+- [ ] 2.1 AWS IAM で GitHub OIDC Provider を作成する（URL: `https://token.actions.githubusercontent.com`、Audience: `sts.amazonaws.com`）
+- [ ] 2.2 IAM Role `pantry-panel-deploy-role` を作成する
+  - 信頼ポリシー: GitHub OIDC を信頼、`repo:IsaoTakahashi/pantry-panel:ref:refs/heads/main` を `sub` 条件に
+  - 許可ポリシー: 以下を最小権限で許可
+    - `ecr:GetAuthorizationToken`
+    - `ecr:BatchCheckLayerAvailability`、`ecr:PutImage`、`ecr:InitiateLayerUpload`、`ecr:UploadLayerPart`、`ecr:CompleteLayerUpload`（対象リポジトリのみ）
+    - `apprunner:StartDeployment`、`apprunner:DescribeService`（対象サービスのみ）
+- [ ] 2.3 Role ARN を控える
+
+## 3. GitHub リポジトリの Secrets / Variables 登録（ユーザー作業）
+
+- [ ] 3.1 GitHub Repository → Settings → Secrets and variables → Actions
+- [ ] 3.2 Variables に以下を登録:
+  - `AWS_REGION`: `ap-northeast-1`
+  - `AWS_ROLE_ARN`: 2.3 で控えた Role ARN
+  - `ECR_REPOSITORY`: `pantry-panel-backend`
+  - `APP_RUNNER_SERVICE_ARN`: Phase 2.5b の App Runner サービス ARN
+  - `APP_RUNNER_SERVICE_URL`: Phase 2.5b の App Runner サービス URL（smoke test 用）
+
+## 4. ワークフロー作成
+
+- [ ] 4.1 `.github/workflows/deploy-backend.yml` を作成する
+  - Trigger: `push` to `main`、`workflow_dispatch`
+  - Permissions: `id-token: write`、`contents: read`
+  - Job 1 `build-and-push`:
+    - `aws-actions/configure-aws-credentials@v4` で OIDC 認証
+    - `aws-actions/amazon-ecr-login@v2` で ECR ログイン
+    - `docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} -t $ECR_REGISTRY/$ECR_REPOSITORY:latest backend/`
+    - `docker push --all-tags` で両方プッシュ
+  - Job 2 `deploy` (needs: build-and-push):
+    - 同じく OIDC 認証
+    - `aws apprunner start-deployment --service-arn ${{ vars.APP_RUNNER_SERVICE_ARN }}`
+    - `aws apprunner describe-service` を 5 秒間隔で 5 分までポーリングし `Status=RUNNING` を待つ
+  - Job 3 `smoke-test` (needs: deploy):
+    - `curl -fsS --retry 30 --retry-delay 5 ${{ vars.APP_RUNNER_SERVICE_URL }}/health`
+- [ ] 4.2 ワークフロー YAML の lint（`actionlint` 推奨、無ければ手動目視）
+- [ ] 4.3 PR を main にマージする前に「main 限定で走る」「PR では走らない」設定を再確認
+
+## 5. 動作確認
+
+- [ ] 5.1 PR をマージする → ワークフローが走る
+- [ ] 5.2 build-and-push、deploy、smoke-test が全て緑になることを確認する
+- [ ] 5.3 ECR コンソールで新しい sha タグと latest タグの両方が反映されたことを確認する
+- [ ] 5.4 App Runner で新しい Deployment が成功したことを確認する
+- [ ] 5.5 試しに `backend/` 配下の任意の文言を1行変えて PR → main マージ → 自動デプロイ完走を確認する
+- [ ] 5.6 GitHub Actions UI から `workflow_dispatch` で手動再実行できることを確認する
+
+## 6. 失敗ケースの確認（任意、本番に影響しない範囲で）
+
+- [ ] 6.1 意図的に health check が 5 分超えるよう壊した PR を作って main にマージ → ワークフローが赤になることを確認 → 即座に revert PR で復旧
+
+## 7. ドキュメント更新
+
+- [ ] 7.1 `README.md` にデプロイフロー（main → ECR → App Runner → smoke test）と rollback 手順（旧 sha タグで `aws apprunner start-deployment` 手動実行）を記載する
+- [ ] 7.2 `.claude/rules/general.md` の CI セクションに `deploy-backend.yml` の存在を追記する
+- [ ] 7.3 `specs/features.md` の Phase 2.5 を完了マークにする
+
+## 8. 仕上げ
+
+- [ ] 8.1 CI（lint + tsc + vitest + go test）がすべてパスすることを確認する
+- [ ] 8.2 PR を ready for review にして、Issue を `Closes #N` でリンクする
+- [ ] 8.3 マージ後に `openspec archive phase2-5d-auto-deploy` で archive する


### PR DESCRIPTION
## Summary

Phase 2.5（初回デプロイ）の OpenSpec change proposals を 4 つまとめて追加。実装着手前にレビューしやすいよう、コードを触らずドキュメントのみで先行マージする。

## 含まれる Change

| Change | Capability | タスク数 |
|--------|------------|----------|
| `phase2-5a-supabase-setup` | `production-database` (新) | 21 |
| `phase2-5b-app-runner-deploy` | `production-backend-runtime` (新) | 31 |
| `phase2-5c-vercel-frontend-deploy` | `production-frontend-runtime` (新) + backend CORS modified | 33 |
| `phase2-5d-auto-deploy` | `auto-deploy-pipeline` (新) | 24 |

各 change に `proposal.md` / `design.md` / `specs/<capability>/spec.md` / `tasks.md` が揃っており、`openspec validate <name> --strict` で全て valid。

## 設計判断（合意済み）

- D1 配信モード: ECR + App Runner（GitHub Source 不採用）
- D2 マイグレーション: Supabase SQL Editor で手動
- D3 リージョン: ap-northeast-1
- D4 Backend ホスティング: AWS App Runner (~\$5/月)
- D5 自動化: main push で自動デプロイ
- D6 ドメイン: サービス標準
- D7 スコープ: 4 サブフェーズ分割

## 適用順序

\`\`\`
2.5a (Supabase) → 2.5b (App Runner) → 2.5c (Vercel + Backend CORS) → 2.5d (auto-deploy)
\`\`\`

2.5c は \`production-backend-runtime\` を MODIFIED するため、2.5b を archive してから 2.5c の archive を行う必要がある。

## Test plan

- [x] \`openspec validate <name> --strict\` を 4 件すべて pass
- [x] コード変更なし（CI: lint / tsc / vitest / go test に影響しないことを確認）

## Refs

- Epic: #43