### PR TITLE
Phase 2.5a: Supabase 接続セットアップ

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -17,6 +17,28 @@
   - LISTEN/NOTIFY を行うため、transaction pooler (6543) は **不可**
 - LISTEN/NOTIFY は Phase 3 の自前 WebSocket 実装で使用。Phase 3.5 以降は Supabase Realtime に移行
 
+### ローカルから Supabase に接続する手順
+
+1. Supabase Dashboard → Project Settings → Database → **Connection string (Direct)** をコピー
+   - 形式: `postgresql://postgres:[YOUR-PASSWORD]@db.<project-ref>.supabase.co:5432/postgres`
+2. 末尾に `?sslmode=require` を付与する（Supabase は SSL 必須）
+3. `DATABASE_URL` 環境変数として渡して backend を起動
+
+```bash
+cd backend
+export DATABASE_URL='postgresql://postgres:<PASSWORD>@db.<ref>.supabase.co:5432/postgres?sslmode=require'
+go run .
+```
+
+- パスワードに `#` `?` `&` 等の特殊文字が含まれる場合は URL エンコードする
+- パスワードは `.env.local` 等の git 管理外ファイルか、パスワードマネージャ（1Password / Bitwarden / macOS Keychain）で保管する。リポジトリにはコミットしない
+- マイグレーションは Supabase Dashboard の **SQL Editor** で `backend/db/migrations/*.sql` を順に実行する（Phase 2.5 時点では手動運用、件数が増えたら自動化を検討）
+
+### マイグレーション戦略
+
+- 現状: SQL ファイルを手動で SQL Editor に貼り付けて実行
+- 将来検討: `golang-migrate` を CI ジョブで実行 / 起動時に embed.FS で自動適用
+
 ## テスト
 
 | レイヤー | ツール | 対象 |

--- a/openspec/changes/phase2-5a-supabase-setup/tasks.md
+++ b/openspec/changes/phase2-5a-supabase-setup/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Issue・ブランチ準備
 
-- [ ] 1.1 GitHub Issue を作成する（タイトル: "Phase 2.5a: Supabase 接続セットアップ"）
-- [ ] 1.2 Issue 番号ベースのブランチを作成する
-- [ ] 1.3 Draft PR を作成する
+- [x] 1.1 GitHub Issue を作成する（タイトル: "Phase 2.5a: Supabase 接続セットアップ"）
+- [x] 1.2 Issue 番号ベースのブランチを作成する
+- [x] 1.3 Draft PR を作成する
 
 ## 2. Supabase プロジェクト作成（ユーザー作業）
 
@@ -34,7 +34,7 @@
 
 - [ ] 5.1 `specs/features.md` の Phase 2.5 セクションを更新（Supabase 接続済みであること）
 - [ ] 5.2 README または `.claude/rules/backend.md` に Supabase 接続文字列の取得手順を追記する
-- [ ] 5.3 `.gitignore` に `.env.local` が含まれていることを確認する
+- [x] 5.3 `.gitignore` に `.env.local` が含まれていることを確認する
 
 ## 6. 仕上げ
 

--- a/openspec/changes/phase2-5a-supabase-setup/tasks.md
+++ b/openspec/changes/phase2-5a-supabase-setup/tasks.md
@@ -38,6 +38,6 @@
 
 ## 6. 仕上げ
 
-- [ ] 6.1 CI（lint + tsc + vitest + go test）がすべてパスすることを確認する
-- [ ] 6.2 PR を ready for review にして、Issue を `Closes #N` でリンクする
+- [x] 6.1 CI（lint + tsc + vitest + go test）がすべてパスすることを確認する
+- [x] 6.2 PR を ready for review にして、Issue を `Closes #N` でリンクする
 - [ ] 6.3 マージ後に `openspec archive phase2-5a-supabase-setup` で archive する

--- a/openspec/changes/phase2-5a-supabase-setup/tasks.md
+++ b/openspec/changes/phase2-5a-supabase-setup/tasks.md
@@ -18,22 +18,22 @@
 
 ## 4. Backend を Supabase 接続で動作確認
 
-- [ ] 4.1 接続文字列に `sslmode=require` を付与する（例: `postgres://postgres:<password>@db.<ref>.supabase.co:5432/postgres?sslmode=require`）
-- [ ] 4.2 ローカル `.env.local`（または環境変数）に `DATABASE_URL` を設定する（コミットしない）
-- [ ] 4.3 Backend を `DATABASE_URL` 付きで起動し、`/health` が 200 を返すことを確認する
-- [ ] 4.4 既存の `backend/db/db.go` / `db_test.go` の挙動を確認し、SSL 接続でエラーが出ないか手動確認する
-- [ ] 4.5 ローカルの Frontend (port 3000) から Supabase 接続済み Backend (port 8080) を経由して以下が動作することを確認する:
+- [x] 4.1 接続文字列に `sslmode=require` を付与する（例: `postgres://postgres:<password>@db.<ref>.supabase.co:5432/postgres?sslmode=require`）
+- [x] 4.2 ローカル `.env.local`（または環境変数）に `DATABASE_URL` を設定する（コミットしない）
+- [x] 4.3 Backend を `DATABASE_URL` 付きで起動し、`/health` が 200 を返すことを確認する
+- [x] 4.4 既存の `backend/db/db.go` / `db_test.go` の挙動を確認し、SSL 接続でエラーが出ないか手動確認する
+- [x] 4.5 ローカルの Frontend (port 3000) から Supabase 接続済み Backend (port 8080) を経由して以下が動作することを確認する:
   - 商品の一覧表示
   - 商品登録
   - 商品編集
   - 商品削除
   - wantToBuy トグル
-- [ ] 4.6 SQL Editor で実際にデータが書き込まれたことを確認する
+- [x] 4.6 SQL Editor で実際にデータが書き込まれたことを確認する
 
 ## 5. ドキュメント更新
 
-- [ ] 5.1 `specs/features.md` の Phase 2.5 セクションを更新（Supabase 接続済みであること）
-- [ ] 5.2 README または `.claude/rules/backend.md` に Supabase 接続文字列の取得手順を追記する
+- [x] 5.1 `specs/features.md` の Phase 2.5 セクションを更新（Supabase 接続済みであること）
+- [x] 5.2 README または `.claude/rules/backend.md` に Supabase 接続文字列の取得手順を追記する
 - [x] 5.3 `.gitignore` に `.env.local` が含まれていることを確認する
 
 ## 6. 仕上げ

--- a/specs/features.md
+++ b/specs/features.md
@@ -58,6 +58,15 @@ Phase 3 で WebSocket を本番で検証するために、その手前で常時�
 
 この時点では Phase 1–2 の機能が本番で動くことを目標とする。認証は wishlist 扱いで導入しない (旧仕様の「認証なし・家族共用」を維持)。
 
+#### サブフェーズ進行状況
+
+| サブフェーズ | 内容 | 状態 |
+|-------------|------|------|
+| 2.5a | Supabase 接続セットアップ（Direct Connection + sslmode=require） | ✅ 完了 |
+| 2.5b | Backend を AWS App Runner にデプロイ（Dockerfile + ECR） | ⏳ 未着手 |
+| 2.5c | Frontend を Vercel にデプロイ（NEXT_PUBLIC_API_URL + CORS 更新） | ⏳ 未着手 |
+| 2.5d | Backend 自動デプロイ（GitHub Actions + OIDC） | ⏳ 未着手 |
+
 ### Phase 3: リアルタイム
 
 | 順 | 機能 | 理由 |


### PR DESCRIPTION
## Summary

Phase 2.5（Epic #43）の最初のサブフェーズ。本番 DB として Supabase Postgres を立ち上げ、Backend がローカル接続で動作する状態にする。

## OpenSpec change

- \`openspec/changes/phase2-5a-supabase-setup/\`
- Capability: \`production-database\` (新)

## Scope

- Supabase プロジェクト作成（ユーザー手作業）
- マイグレーション \`001_create_stock_items.sql\` を SQL Editor で適用（ユーザー手作業）
- Backend を Supabase Direct Connection (5432) + sslmode=require で接続
- ローカル Frontend → ローカル Backend → Supabase で CRUD 動作確認

## Test plan

- [ ] \`/health\` が 200 を返す
- [ ] Frontend からの商品 CRUD 全てが動作
- [ ] wantToBuy トグル後に Supabase SQL Editor でデータが書き込まれていることを確認
- [ ] CI（lint + tsc + vitest + go test）パス

Closes #45