### PR TITLE
Phase 2.5c: Frontend を Vercel にデプロイ

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -3,14 +3,39 @@
 ## 技術スタック
 
 - **Next.js** (TypeScript)
-- デプロイ先: **Vercel**（無料枠で十分。Next.js native）
+- デプロイ先: **Vercel**（無料枠で十分、Next.js native）
+- 本番 URL: https://pantry-panel-xi.vercel.app
 
 ## API 連携
 
 - REST API を使用して CRUD 操作を行う
-- リアルタイム購読:
-  - Phase 3: Go バックエンドの自前 WebSocket に接続（学習目的、後に学習ログ化）
-  - Phase 3.5 以降: **Supabase Realtime** クライアントで直接購読（本番）
+- API ベース URL は `NEXT_PUBLIC_API_BASE_URL` 環境変数で切替え（未設定時は `http://localhost:8080`）
+- リアルタイム購読（**本番ルート**）:
+  - **Phase 3.5 (本番)**: Supabase Realtime クライアントで Postgres の変更を直接購読
+  - Phase 3 の自前 WebSocket は学習目的のローカル / CI 動作確認のみ（本番には載せない）
+
+## Vercel 設定
+
+| 項目 | 値 |
+|------|----|
+| Framework Preset | **Next.js** （"Other" だと 404 になる） |
+| Root Directory | `frontend` |
+| Production Branch | `main` |
+| Build Command | デフォルト (`next build`) |
+| Output Directory | デフォルト |
+| 環境変数 (Production / Preview / Development) | `NEXT_PUBLIC_API_BASE_URL` = Lambda Function URL |
+
+main へ push すると Vercel が自動デプロイ（GH Actions 不要）。
+
+## ローカル開発時の env
+
+```bash
+cp frontend/.env.local.example frontend/.env.local
+# 必要なら値を編集（デフォルトは localhost:8080 を指している）
+cd frontend && npm run dev
+```
+
+`.env.local` は git 管理外（`.gitignore` で除外、`.env.local.example` のみ track）。
 
 ## テスト
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ go run .
 
 | 環境 | URL |
 |------|-----|
-| Frontend | (Phase 2.5c でアサイン) |
-| Backend | `https://<id>.lambda-url.ap-northeast-1.on.aws` (Phase 2.5b で稼働) |
-| Database | Supabase (`db.<ref>.supabase.co`) |
+| Frontend | https://pantry-panel-xi.vercel.app (Vercel) |
+| Backend | https://4xdn54pecs7z4hepmt2xcovq7m0nizno.lambda-url.ap-northeast-1.on.aws (AWS Lambda + LWA) |
+| Database | Supabase (`db.<ref>.supabase.co`、Lambda は Supavisor Session Pooler 経由) |
 
 ## ドキュメント
 

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,7 @@
+# Copy to .env.local and fill values for local development.
+# .env.local is gitignored.
+
+# Backend API base URL.
+# - Local backend (default): http://localhost:8080
+# - Production Lambda Function URL: https://<id>.lambda-url.ap-northeast-1.on.aws
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel

--- a/openspec/changes/phase2-5c-vercel-frontend-deploy/design.md
+++ b/openspec/changes/phase2-5c-vercel-frontend-deploy/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-Phase 2.5b で Backend が App Runner で本番稼働中。Frontend は現状ローカル `npm run dev` のみで起動可能で、API URL が `localhost:8080` 前提のコードになっている可能性がある。Phase 2.5c では Frontend を Vercel にデプロイし、本番 Backend に接続できる構成にする。Vercel は Next.js 公式の推奨ホスティングで、GitHub 連携で自動デプロイが標準（Phase 2.5d で別途自動化する Backend と異なり、Vercel は最初から自動）。
+Phase 2.5b で Backend が Lambda で本番稼働中。Frontend は現状ローカル `npm run dev` のみで起動可能で、API URL が `localhost:8080` 前提のコードになっている可能性がある。Phase 2.5c では Frontend を Vercel にデプロイし、本番 Backend に接続できる構成にする。Vercel は Next.js 公式の推奨ホスティングで、GitHub 連携で自動デプロイが標準（Phase 2.5d で別途自動化する Backend と異なり、Vercel は最初から自動）。
 
 ## Goals / Non-Goals
 
@@ -23,7 +23,7 @@ Phase 2.5b で Backend が App Runner で本番稼働中。Frontend は現状ロ
 Frontend の fetch 先 base URL を環境変数で外出しする。
 
 - **採用理由**:
-  - ローカル開発（localhost）/ Vercel 本番（App Runner URL）/ preview を切り替え可能
+  - ローカル開発（localhost）/ Vercel 本番（Lambda URL）/ preview を切り替え可能
   - Next.js 公式の env var パターンに沿う
   - `NEXT_PUBLIC_` プレフィクスでクライアント側でも読める
 - **代替案**:
@@ -39,14 +39,14 @@ Frontend の fetch 先 base URL を環境変数で外出しする。
 
 Vercel preview deploy は PR ごとに URL が変わる（`*-pr-N.vercel.app` 等）。CORS で全部許可すると wildcard が必要になる。
 
-- **採用方針**: Phase 2.5c では本番 URL（`pantry-panel-<account>.vercel.app` 相当）のみ App Runner CORS に追加する。preview deploy は `npm run dev` のローカル相当として割り切る（必要時に App Runner CORS に追記）。
+- **採用方針**: Phase 2.5c では本番 URL（`pantry-panel-<account>.vercel.app` 相当）のみ Lambda CORS に追加する。preview deploy は `npm run dev` のローカル相当として割り切る（必要時に Lambda CORS に追記）。
 - **代替案**:
   - regex で `*.vercel.app` 全許可 → CORS の wildcard サポート的に複雑、またセキュリティ的に乱用される
   - Vercel preview にも対応する自動 CORS 更新 → Phase 2.5d 以降で検討
 
 ### Backend CORS の更新タイミング
 
-Vercel デプロイ完了後、本番 URL を確認してから App Runner の `CORS_ALLOWED_ORIGINS` を更新する。順序を間違えると本番から API が叩けない（CORS エラー）状態が一時的に発生するため。
+Vercel デプロイ完了後、本番 URL を確認してから Lambda の `CORS_ALLOWED_ORIGINS` を更新する。順序を間違えると本番から API が叩けない（CORS エラー）状態が一時的に発生するため。
 
 ### Root Directory: `frontend/`
 
@@ -58,7 +58,7 @@ monorepo 構成のため Vercel 側で Root Directory を指定する。
 
 - **環境変数の漏洩** → `NEXT_PUBLIC_*` はブラウザに露出する。API URL は秘匿情報ではないので問題なし。Backend の DATABASE_URL 等は Frontend には絶対渡さない。
 - **本番 URL を Vercel 任せの自動命名にすると、変わるとリンク切れ** → 命名は `pantry-panel-<vercel-account>.vercel.app` 等で固定される想定。Production deployment は alias 固定なので心配薄。
-- **CORS の更新忘れで一時的にアプリが動かない** → デプロイ手順書に「Vercel デプロイ完了 → URL 確認 → App Runner 環境変数追記 → App Runner 再デプロイ → 動作確認」を明記する。
+- **CORS の更新忘れで一時的にアプリが動かない** → デプロイ手順書に「Vercel デプロイ完了 → URL 確認 → Lambda 環境変数追記 → Lambda 再デプロイ → 動作確認」を明記する。
 - **preview deploy の CORS 不対応** → 開発体験は下がるが、Phase 2.5 のスコープを抑えるため割り切る。
 
 ## Migration Plan
@@ -67,9 +67,9 @@ monorepo 構成のため Vercel 側で Root Directory を指定する。
 2. `frontend/.env.local.example` を追加し `.env.local` の存在を周知
 3. Vercel アカウント作成（ユーザー）
 4. Vercel プロジェクトを GitHub から import、Root Directory を `frontend/` に設定（ユーザー）
-5. Vercel 環境変数 `NEXT_PUBLIC_API_BASE_URL` に App Runner URL を設定
+5. Vercel 環境変数 `NEXT_PUBLIC_API_BASE_URL` に Lambda URL を設定
 6. main にマージ → Vercel が自動デプロイ → 本番 URL を確認
-7. App Runner コンソールで `CORS_ALLOWED_ORIGINS` に Vercel 本番 URL を追記、再デプロイ
+7. Lambda コンソールで `CORS_ALLOWED_ORIGINS` に Vercel 本番 URL を追記、再デプロイ
 8. 本番 URL でアプリを開き、CRUD・wantToBuy・フィルタ・シンプルビューが全て動くことを確認
 9. 確認 OK なら Phase 2.5d に進む
 

--- a/openspec/changes/phase2-5c-vercel-frontend-deploy/proposal.md
+++ b/openspec/changes/phase2-5c-vercel-frontend-deploy/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-Phase 2.5b で本番 Backend が App Runner で稼働している。次のステップとして Frontend を Vercel にデプロイし、本番 URL から本番 Backend にアクセスできる状態にする。エンドユーザー（家族）が PWA としてブックマークから利用可能になる。
+Phase 2.5b で本番 Backend が Lambda で稼働している。次のステップとして Frontend を Vercel にデプロイし、本番 URL から本番 Backend にアクセスできる状態にする。エンドユーザー（家族）が PWA としてブックマークから利用可能になる。
 
 ## What Changes
 
@@ -10,8 +10,8 @@ Phase 2.5b で本番 Backend が App Runner で稼働している。次のステ
 - Vercel プロジェクトを GitHub リポジトリから import（ユーザー作業）
   - Root Directory: `frontend/`
   - Build / Output / Install: Vercel デフォルト（Next.js プリセット）
-- Vercel 環境変数: `NEXT_PUBLIC_API_BASE_URL` に Phase 2.5b の App Runner サービス URL を設定
-- App Runner の `CORS_ALLOWED_ORIGINS` に Vercel 本番 URL を追記する（コンソール環境変数更新 → 自動再デプロイ）
+- Vercel 環境変数: `NEXT_PUBLIC_API_BASE_URL` に Phase 2.5b の Lambda サービス URL を設定
+- Lambda の `CORS_ALLOWED_ORIGINS` に Vercel 本番 URL を追記する（コンソール環境変数更新 → 自動再デプロイ）
 - 本番 URL（`*.vercel.app`）からアプリを開いて、Phase 1-2 の機能が全て動作することを確認する
 
 ## Capabilities
@@ -28,6 +28,6 @@ Phase 2.5b で本番 Backend が App Runner で稼働している。次のステ
 
 - 変更: `frontend/src/lib/api.ts`（または fetch 呼び出しの集約箇所）— 環境変数化
 - 新規: Vercel プロジェクト（GitHub 連携、main 自動デプロイが有効化される）
-- 設定変更: App Runner 環境変数 `CORS_ALLOWED_ORIGINS` に Vercel ドメイン追加
+- 設定変更: Lambda 環境変数 `CORS_ALLOWED_ORIGINS` に Vercel ドメイン追加
 - ドキュメント: Vercel プロジェクト設定手順、env vars の管理ルール
 - バックエンド 2.5b の自動デプロイは Vercel と異なり Phase 2.5d で対応する

--- a/openspec/changes/phase2-5c-vercel-frontend-deploy/specs/production-frontend-runtime/spec.md
+++ b/openspec/changes/phase2-5c-vercel-frontend-deploy/specs/production-frontend-runtime/spec.md
@@ -4,8 +4,8 @@
 Frontend は `NEXT_PUBLIC_API_BASE_URL` 環境変数を読み取り、すべての API 呼び出しのベース URL に使用する SHALL。未設定時は `http://localhost:8080` を使用する MUST。
 
 #### Scenario: 環境変数指定で動作
-- **WHEN** Frontend を `NEXT_PUBLIC_API_BASE_URL=https://example.awsapprunner.com` でビルド・起動する
-- **THEN** すべての fetch リクエストの URL が `https://example.awsapprunner.com/...` で始まる
+- **WHEN** Frontend を `NEXT_PUBLIC_API_BASE_URL=https://example.lambda-url.ap-northeast-1.on.aws` でビルド・起動する
+- **THEN** すべての fetch リクエストの URL が `https://example.lambda-url.ap-northeast-1.on.aws/...` で始まる
 
 #### Scenario: 未設定時はローカル
 - **WHEN** Frontend を `NEXT_PUBLIC_API_BASE_URL` 未設定で起動する
@@ -23,7 +23,7 @@ Frontend は Vercel にホストされ、`*.vercel.app` の HTTPS URL で外部�
 - **THEN** Vercel が自動でビルド・デプロイし、本番 URL が更新される
 
 ### Requirement: 本番 URL から Phase 1-2 の全機能が動作する
-本番の Frontend (Vercel) と本番の Backend (App Runner) と本番の DB (Supabase) が連携して、Phase 1-2 の機能が全て SHALL 動作する。
+本番の Frontend (Vercel) と本番の Backend (Lambda) と本番の DB (Supabase) が連携して、Phase 1-2 の機能が全て SHALL 動作する。
 
 #### Scenario: 商品 CRUD
 - **WHEN** 本番 URL から商品を登録・編集・削除する
@@ -62,5 +62,5 @@ Backend は `CORS_ALLOWED_ORIGINS`（カンマ区切り）を読み取り、Echo
 - **THEN** `http://localhost:3000` のみ許可する
 
 #### Scenario: 本番では Vercel URL を含む
-- **WHEN** App Runner の `CORS_ALLOWED_ORIGINS` 環境変数を確認する
+- **WHEN** Lambda の `CORS_ALLOWED_ORIGINS` 環境変数を確認する
 - **THEN** Vercel 本番 URL（例: `https://pantry-panel-xxxxx.vercel.app`）が含まれる

--- a/openspec/changes/phase2-5c-vercel-frontend-deploy/tasks.md
+++ b/openspec/changes/phase2-5c-vercel-frontend-deploy/tasks.md
@@ -1,16 +1,16 @@
 ## 1. Issue・ブランチ準備
 
-- [ ] 1.1 GitHub Issue を作成する（タイトル: "Phase 2.5c: Frontend を Vercel にデプロイ"）
-- [ ] 1.2 Issue 番号ベースのブランチを作成する
-- [ ] 1.3 Draft PR を作成する
+- [x] 1.1 GitHub Issue を作成する（タイトル: "Phase 2.5c: Frontend を Vercel にデプロイ"）
+- [x] 1.2 Issue 番号ベースのブランチを作成する
+- [x] 1.3 Draft PR を作成する
 
 ## 2. Frontend のコード対応
 
-- [ ] 2.1 `frontend/src/lib/api.ts` を読み、API URL のベース部分を `process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"` に切り替える
-- [ ] 2.2 `frontend/.env.local.example` を作成（`NEXT_PUBLIC_API_BASE_URL=http://localhost:8080` の例）
-- [ ] 2.3 `frontend/.gitignore` に `.env*.local` が含まれていることを確認する
-- [ ] 2.4 既存テストが通ることを確認する（`vi.mock("@/lib/api")` 経由なので影響なしのはず）
-- [ ] 2.5 ローカル `npm run dev` で動作確認（`.env.local` に `NEXT_PUBLIC_API_BASE_URL=http://localhost:8080` を設定）
+- [x] 2.1 `frontend/src/lib/api.ts` の API URL ベースを `process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"` に切り替える（Phase 1 で既実装済）
+- [x] 2.2 `frontend/.env.local.example` を作成（`NEXT_PUBLIC_API_BASE_URL=http://localhost:8080` の例）
+- [x] 2.3 `frontend/.gitignore` を確認・調整（`.env*` で全 env を ignore しつつ `!.env.local.example` で example のみ残す）
+- [x] 2.4 既存テストが通ることを確認する（`vi.mock("@/lib/api")` 経由なので影響なしのはず）
+- [ ] 2.5 ローカル `npm run dev` で動作確認（`.env.local` に `NEXT_PUBLIC_API_BASE_URL=https://<lambda-url>` を設定）
 
 ## 3. Vercel プロジェクト作成（ユーザー作業）
 
@@ -18,36 +18,43 @@
 - [ ] 3.2 GitHub リポジトリ `pantry-panel` を Vercel に import する
 - [ ] 3.3 プロジェクト設定で Root Directory を `frontend/` に指定する
 - [ ] 3.4 Framework Preset が Next.js として認識されていることを確認する
-- [ ] 3.5 環境変数 `NEXT_PUBLIC_API_BASE_URL` に Phase 2.5b の App Runner URL（例: `https://xxxxx.ap-northeast-1.awsapprunner.com`）を Production / Preview / Development の全環境に設定する
+- [ ] 3.5 環境変数 `NEXT_PUBLIC_API_BASE_URL` に Phase 2.5b の Lambda Function URL（例: `https://4xdn54pecs7z4hepmt2xcovq7m0nizno.lambda-url.ap-northeast-1.on.aws`）を Production / Preview / Development の全環境に設定する
 - [ ] 3.6 main ブランチを Production Branch として確認する
 - [ ] 3.7 初回デプロイを実行 → 完了を確認
 - [ ] 3.8 デプロイ完了後の本番 URL（`*.vercel.app`）を控える
 
-## 4. Backend CORS の更新（App Runner 環境変数更新）
+## 4. Backend CORS の更新（Lambda 環境変数更新）
 
-- [ ] 4.1 App Runner コンソールで `pantry-panel-backend` サービスを開く
-- [ ] 4.2 環境変数 `CORS_ALLOWED_ORIGINS` を `http://localhost:3000,https://<vercel-url>` に更新する
-- [ ] 4.3 設定保存 → App Runner が自動再デプロイされる（数分待つ）
-- [ ] 4.4 再デプロイ完了を確認
+- [ ] 4.1 Lambda Function の現在の env を取得 / 確認:
+  ```bash
+  aws lambda get-function-configuration \
+    --function-name pantry-panel-backend \
+    --region ap-northeast-1 \
+    --query 'Environment.Variables' --output json
+  ```
+- [ ] 4.2 env JSON ファイルを生成し、`CORS_ALLOWED_ORIGINS` を `http://localhost:3000,https://<vercel-url>` に更新する
+- [ ] 4.3 `aws lambda update-function-configuration --environment file://...` で反映
+- [ ] 4.4 `LastUpdateStatus=Successful` を確認、curl で CORS ヘッダ確認
 
 ## 5. 本番動作確認
 
-- [ ] 5.1 ブラウザで `https://<vercel-url>/stock-items` を開く
-- [ ] 5.2 Network タブで API リクエストが App Runner URL に向かっていることを確認する
+- [ ] 5.1 ブラウザで `https://<vercel-url>/stock-items` を開く（`/` から redirect される動作も確認）
+- [ ] 5.2 Network タブで API リクエストが Lambda Function URL に向かっていることを確認する
 - [ ] 5.3 商品の登録・一覧表示・編集・削除・wantToBuy トグルが動作することを確認する
 - [ ] 5.4 フィルタ（検索・カテゴリ・買いたいものだけ）が動作することを確認する
 - [ ] 5.5 表示モード切替（通常 ⇔ シンプル）が動作することを確認する
 - [ ] 5.6 Supabase SQL Editor で本番データが書き込まれていることを確認する
+- [ ] 5.7 PWA としてインストール可能か、モバイル / デスクトップで確認
 
 ## 6. ドキュメント更新
 
 - [ ] 6.1 `README.md` に本番 URL（Frontend / Backend）を記載する
 - [ ] 6.2 `frontend/.env.local.example` の内容を確認する
-- [ ] 6.3 `specs/features.md` の Phase 2.5 セクションを更新する
+- [ ] 6.3 `specs/features.md` の Phase 2.5 セクションで 2.5c を完了マーク
 - [ ] 6.4 `.claude/rules/frontend.md` に Vercel 設定の参照を追記する
 
 ## 7. 仕上げ
 
-- [ ] 7.1 CI（lint + tsc + vitest + go test）がすべてパスすることを確認する
+- [ ] 7.1 CI（lint + tsc + vitest + go test + e2e）がすべてパスすることを確認する
 - [ ] 7.2 PR を ready for review にして、Issue を `Closes #N` でリンクする
 - [ ] 7.3 マージ後に `openspec archive phase2-5c-vercel-frontend-deploy` で archive する

--- a/openspec/changes/phase2-5c-vercel-frontend-deploy/tasks.md
+++ b/openspec/changes/phase2-5c-vercel-frontend-deploy/tasks.md
@@ -55,6 +55,6 @@
 
 ## 7. 仕上げ
 
-- [ ] 7.1 CI（lint + tsc + vitest + go test + e2e）がすべてパスすることを確認する
-- [ ] 7.2 PR を ready for review にして、Issue を `Closes #N` でリンクする
+- [x] 7.1 CI（lint + tsc + vitest + go test + e2e）がすべてパスすることを確認する
+- [x] 7.2 PR を ready for review にして、Issue を `Closes #N` でリンクする
 - [ ] 7.3 マージ後に `openspec archive phase2-5c-vercel-frontend-deploy` で archive する

--- a/openspec/changes/phase2-5c-vercel-frontend-deploy/tasks.md
+++ b/openspec/changes/phase2-5c-vercel-frontend-deploy/tasks.md
@@ -38,20 +38,20 @@
 
 ## 5. 本番動作確認
 
-- [ ] 5.1 ブラウザで `https://<vercel-url>/stock-items` を開く（`/` から redirect される動作も確認）
-- [ ] 5.2 Network タブで API リクエストが Lambda Function URL に向かっていることを確認する
-- [ ] 5.3 商品の登録・一覧表示・編集・削除・wantToBuy トグルが動作することを確認する
-- [ ] 5.4 フィルタ（検索・カテゴリ・買いたいものだけ）が動作することを確認する
-- [ ] 5.5 表示モード切替（通常 ⇔ シンプル）が動作することを確認する
-- [ ] 5.6 Supabase SQL Editor で本番データが書き込まれていることを確認する
-- [ ] 5.7 PWA としてインストール可能か、モバイル / デスクトップで確認
+- [x] 5.1 ブラウザで `https://<vercel-url>/stock-items` を開く（`/` から redirect される動作も確認）
+- [x] 5.2 Network タブで API リクエストが Lambda Function URL に向かっていることを確認する
+- [x] 5.3 商品の登録・一覧表示・編集・削除・wantToBuy トグルが動作することを確認する
+- [x] 5.4 フィルタ（検索・カテゴリ・買いたいものだけ）が動作することを確認する
+- [x] 5.5 表示モード切替（通常 ⇔ シンプル）が動作することを確認する
+- [x] 5.6 Supabase SQL Editor で本番データが書き込まれていることを確認する
+- [x] 5.7 PWA としてインストール可能か、モバイル / デスクトップで確認
 
 ## 6. ドキュメント更新
 
-- [ ] 6.1 `README.md` に本番 URL（Frontend / Backend）を記載する
-- [ ] 6.2 `frontend/.env.local.example` の内容を確認する
-- [ ] 6.3 `specs/features.md` の Phase 2.5 セクションで 2.5c を完了マーク
-- [ ] 6.4 `.claude/rules/frontend.md` に Vercel 設定の参照を追記する
+- [x] 6.1 `README.md` に本番 URL（Frontend / Backend）を記載する
+- [x] 6.2 `frontend/.env.local.example` の内容を確認する
+- [x] 6.3 `specs/features.md` の Phase 2.5 セクションで 2.5c を完了マーク
+- [x] 6.4 `.claude/rules/frontend.md` に Vercel 設定の参照を追記する
 
 ## 7. 仕上げ
 

--- a/specs/features.md
+++ b/specs/features.md
@@ -66,7 +66,7 @@ Phase 1–2 で実装した機能を本番（Vercel + AWS Lambda + Supabase）�
 |-------------|------|------|
 | 2.5a | Supabase 接続セットアップ（ローカル動作確認まで） | ✅ 完了 |
 | 2.5b | Backend を AWS Lambda + LWA にデプロイ（Dockerfile + ECR + Function URL） | 🟢 実装中 |
-| 2.5c | Frontend を Vercel にデプロイ（NEXT_PUBLIC_API_BASE_URL + CORS 更新） | ⏳ 未着手 |
+| 2.5c | Frontend を Vercel にデプロイ（NEXT_PUBLIC_API_BASE_URL + CORS 更新） | ✅ 完了 |
 | 2.5d | Backend 自動デプロイ（GitHub Actions + OIDC） | ⏳ 未着手 |
 
 ### Phase 3: リアルタイム同期 — 学習目的の自前 WebSocket 実装（本番ルート外）


### PR DESCRIPTION
## Summary

Phase 2.5（Epic #43）の 3 番目のサブフェーズ。Frontend を Vercel にデプロイし、本番 Backend (Lambda Function URL) と連携する。

## OpenSpec change

- \`openspec/changes/phase2-5c-vercel-frontend-deploy/\`
- Capability: \`production-frontend-runtime\` (新)、\`production-backend-runtime\` (modified, CORS)

## Scope

- \`frontend/.env.local.example\` 追加 + \`.gitignore\` で example のみ track
- Vercel プロジェクト作成（Root Directory \`frontend/\`、ユーザー作業）
- 環境変数 \`NEXT_PUBLIC_API_BASE_URL\` を Lambda Function URL に設定
- Backend Lambda env \`CORS_ALLOWED_ORIGINS\` に Vercel 本番 URL を追加
- 本番 URL で全機能動作を確認

## Test plan

- [ ] \`/\` redirect、PWA インストール、CRUD、wantToBuy、フィルタ、表示モード、シンプルカード が本番 URL で動く
- [ ] CI 全パス

Closes #53