### PR TITLE
Phase 2.5d: Backend 自動デプロイ (GitHub Actions + OIDC)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,90 @@
+name: Deploy Backend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/deploy-backend.yml"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    outputs:
+      image-uri: ${{ steps.image.outputs.uri }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute image URI
+        id: image
+        run: |
+          REGISTRY="${{ steps.ecr-login.outputs.registry }}"
+          REPO="${{ vars.ECR_REPOSITORY }}"
+          SHA="${{ github.sha }}"
+          echo "uri=${REGISTRY}/${REPO}:${SHA}" >> $GITHUB_OUTPUT
+          echo "registry=${REGISTRY}" >> $GITHUB_OUTPUT
+          echo "repo=${REPO}" >> $GITHUB_OUTPUT
+
+      - name: Build and push (linux/amd64, no provenance for Lambda)
+        uses: docker/build-push-action@v6
+        with:
+          context: backend
+          platforms: linux/amd64
+          provenance: false
+          push: true
+          tags: |
+            ${{ steps.image.outputs.uri }}
+            ${{ steps.image.outputs.registry }}/${{ steps.image.outputs.repo }}:latest
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Update Lambda function code
+        run: |
+          aws lambda update-function-code \
+            --function-name "${{ vars.LAMBDA_FUNCTION_NAME }}" \
+            --image-uri "${{ needs.build-and-push.outputs.image-uri }}" \
+            --publish \
+            --output json
+
+      - name: Wait for Lambda update to complete
+        run: |
+          aws lambda wait function-updated \
+            --function-name "${{ vars.LAMBDA_FUNCTION_NAME }}"
+
+  smoke-test:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Curl /health (retry up to 5 minutes)
+        run: |
+          curl -fsS \
+            --retry 30 \
+            --retry-delay 5 \
+            --retry-all-errors \
+            "${{ vars.LAMBDA_FUNCTION_URL }}/health"

--- a/openspec/changes/phase2-5d-auto-deploy/design.md
+++ b/openspec/changes/phase2-5d-auto-deploy/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-Phase 2.5a〜c が完了すると、本番アプリ一式（Supabase + App Runner + Vercel）が稼働している。Frontend は Vercel の GitHub 連携で main 自動デプロイ済みだが、Backend は手動 ECR push に頼っている状態。Phase 2.5d で Backend も main 自動デプロイにすることで、Phase 3 の WebSocket 実装に入る前に CI/CD の足並みを揃える。
+Phase 2.5a〜c が完了し、本番アプリ一式（Supabase + Lambda + Vercel）が稼働している。Frontend は Vercel の GitHub 連携で main 自動デプロイ済みだが、Backend は手動 ECR push + 手動 `aws lambda update-function-code` に頼っている状態。Phase 2.5d で Backend も main 自動デプロイにすることで、CI/CD の足並みを揃える。
 
 ## Goals / Non-Goals
 
@@ -12,7 +12,7 @@ Phase 2.5a〜c が完了すると、本番アプリ一式（Supabase + App Runne
 
 **Non-Goals:**
 - preview deploy / staging 環境（main → 本番のみ）
-- カナリア / Blue-Green 配信 — App Runner 標準のローリングのみ
+- カナリア / Blue-Green 配信（Lambda alias / weighted routing は別 change で）
 - 自動 rollback（失敗検知時）— 別 change で扱う
 - DB マイグレーションの自動実行（Phase 2.5a の方針通り当面手動）
 - Slack / Discord 通知 — 必要なら別途追加
@@ -37,58 +37,61 @@ GitHub Actions に AWS アクセスキーを Secrets として置かず、OIDC �
   - deploy は build 完了が前提
   - smoke-test は deploy が反映されてからでないと意味がない
   - 並列化のメリットが小さい（build 数十秒、deploy 数分）
-- **代替案**: build と deploy を 1 step に集約 → 失敗時の切り分けがしづらい
 
 ### Image タグ戦略: `${{ github.sha }}` と `latest` の両方を付ける
 
 - **採用理由**:
   - `latest` は人が「最新」を指定するときに便利
   - `${{ github.sha }}` で過去の任意のコミットを再デプロイ・rollback 可能
-- **代替案**: `latest` のみ → rollback 困難
-- **代替案**: SHA のみ → 人手のオペレーションが煩雑
 
-### App Runner 反映方式: `aws apprunner start-deployment`
+### Docker build オプション: `--provenance=false` を必須に
+
+Lambda は OCI image manifest（buildx のデフォルト）を受け付けない。Docker schema 2 manifest が必要。
+
+- 必須フラグ: `--platform linux/amd64 --provenance=false`
+- もしくは: `--platform linux/amd64 --output type=docker`
+
+### Lambda 反映方式: `aws lambda update-function-code`
+
+`update-function-code` で image URI を更新。後続で `get-function` をポーリングし `LastUpdateStatus=Successful` を待つ。
 
 - **採用理由**:
-  - App Runner は ECR の `latest` を指している場合 push を検知して自動デプロイする機能もあるが、明示的に StartDeployment を呼ぶことで GH Actions 上で完了待ちと smoke test ができる
-  - aws CLI 標準コマンドで簡潔
-- **代替案**: ECR push のみで自動更新を待つ → デプロイ完了タイミングが GH Actions から見えない
+  - Lambda container image の標準デプロイコマンド
+  - 完了確認が明示的にできる
+- **代替案**:
+  - `aws lambda wait function-updated` → builtin で待てるが、内部で polling しているので大きな差はない。可読性で update + 手動 polling を採用。
 
 ### Smoke test: `/health` のみ（最小）
 
 curl で `/health` が 200 を返すまで最大 5 分間ポーリングする。
 
-- **採用理由**: 起動失敗の早期検知のみ最小スコープで実現。深い E2E は別 workflow（既存 e2e.yml）で扱う。
-- **代替案**: 主要 API（GET /api/stock-items）も叩く → 認証等で複雑化、初回は `/health` で十分
-
 ### ワークフローの trigger: `push: main` と `workflow_dispatch`
 
-- **採用理由**:
-  - main 自動 + 手動再実行（rollback 等）の 2 ルートを担保
-- **代替案**: タグ push のみ → 個人運用には堅すぎる
+- main 自動 + 手動再実行（rollback 等）の 2 ルートを担保
 
 ## Risks / Trade-offs
 
 - **OIDC 設定が初回は手間** → ユーザー側のステップが多い。手順書を README に固定する。
-- **ECR `latest` 反映待ちで App Runner が古いイメージで稼働する瞬間** → StartDeployment を明示的に叩くため発生しない。
 - **smoke test がタイムアウトすると false alarm** → 5 分の余裕、5 秒間隔のリトライで現実的にはほぼ起きない。起きたらロールバック手順を実行。
-- **ECR ストレージ増加** → タグなし不要イメージは ECR Lifecycle Policy で自動削除（30 日 / 直近 10 個保持などの設定を別途）。今回はスコープ外、運用しながら判断。
+- **ECR ストレージ増加** → タグなし不要イメージは ECR Lifecycle Policy で自動削除（30 日 / 直近 10 個保持などの設定を別途）。今回はスコープ外。
+- **Lambda update-function-code はバージョン管理しない** → publish オプションで version を発行することもできるが、初回は使わない。alias / version routing は別 change。
 
 ## Migration Plan
 
 1. AWS 側で GitHub OIDC Provider を作成（ユーザー、初回のみ）
-2. IAM Role `pantry-panel-deploy-role` を作成（信頼ポリシーに GitHub OIDC、許可ポリシーに ECR push + App Runner StartDeployment）
-3. GitHub リポジトリの Secrets / Variables に必要な値を登録
+2. IAM Role `pantry-panel-deploy-role` を作成（信頼ポリシーに GitHub OIDC、許可ポリシーに ECR push + `lambda:UpdateFunctionCode` / `lambda:GetFunction` / `iam:PassRole`（function role 渡し用））
+3. GitHub リポジトリの Variables に必要な値を登録
 4. `.github/workflows/deploy-backend.yml` を PR で追加
 5. PR を main にマージ → 初回ワークフローが走る
 6. ワークフロー成功 + smoke test 成功を確認
 7. 試しに backend の文言を 1 行変えて main に push → 自動デプロイされることを確認
 
 ロールバック:
-- 失敗デプロイ時: App Runner コンソールで前 successful deployment にロールバック、または `${{ github.sha }}` タグで `aws apprunner start-deployment --image-identifier <old-sha>` を手動実行
-- ワークフロー自体に問題: `.github/workflows/deploy-backend.yml` を revert する PR を main にマージすれば、以降のデプロイは止まる（既存の本番は影響なし）
+- 失敗デプロイ時: `aws lambda update-function-code --image-uri <previous-sha>` で旧イメージに戻す
+- ワークフロー自体に問題: `.github/workflows/deploy-backend.yml` を revert する PR を main にマージ。既存の本番は影響なし
 
 ## Open Questions
 
 - ECR Lifecycle Policy の閾値（保持数 / 日数）— 別 change で詰める
 - デプロイ通知（Slack 等）— 必要に応じて Phase 3 以降で追加
+- Lambda version publish + alias 切替えによる Blue/Green デプロイ — 必要になったら別 change

--- a/openspec/changes/phase2-5d-auto-deploy/proposal.md
+++ b/openspec/changes/phase2-5d-auto-deploy/proposal.md
@@ -1,13 +1,13 @@
 ## Why
 
-Phase 2.5b で Backend を App Runner に手動デプロイし、Phase 2.5c で Frontend が Vercel に自動デプロイされる状態にした。最後のステップとして、Backend も main へのマージで自動デプロイされる体制を作る。手動 ECR push を不要にし、デプロイの再現性とフィードバックループを向上させる。
+Phase 2.5b で Backend を Lambda に手動デプロイし、Phase 2.5c で Frontend が Vercel に自動デプロイされる状態にした。最後のステップとして、Backend も main へのマージで自動デプロイされる体制を作る。手動 ECR push を不要にし、デプロイの再現性とフィードバックループを向上させる。
 
 ## What Changes
 
 - GitHub Actions ワークフロー `.github/workflows/deploy-backend.yml` を新規作成する
   - Trigger: `push` to `main`、`workflow_dispatch`（手動実行も可）
   - Job 1 `build-and-push`: backend の Docker image を build → ECR に push（タグ: `${{ github.sha }}` と `latest`）
-  - Job 2 `deploy`: AWS App Runner `start-deployment` を呼び出して新イメージを反映する
+  - Job 2 `deploy`: `aws lambda update-function-code` で新イメージを反映、`LastUpdateStatus=Successful` まで待つ
   - Job 3 `smoke-test`: デプロイ完了後 `curl https://<service-url>/health` で 200 を確認
 - AWS 認証は **OIDC (GitHub OIDC Provider + IAM Role AssumeRoleWithWebIdentity)** を使用する（アクセスキーをリポジトリ Secrets に置かない方式）
 - IAM Role 作成と GH Actions Secrets / Variables 登録（ユーザー作業）
@@ -18,7 +18,7 @@ Phase 2.5b で Backend を App Runner に手動デプロイし、Phase 2.5c で 
 
 ### New Capabilities
 
-- `auto-deploy-pipeline`: main へのマージで Backend が自動的に ECR build → push → App Runner deploy → smoke test まで実行される CI/CD フロー
+- `auto-deploy-pipeline`: main へのマージで Backend が自動的に ECR build → push → Lambda update-function-code → smoke test まで実行される CI/CD フロー
 
 ### Modified Capabilities
 
@@ -28,7 +28,7 @@ Phase 2.5b で Backend を App Runner に手動デプロイし、Phase 2.5c で 
 
 - 新規ファイル: `.github/workflows/deploy-backend.yml`
 - 既存 ci.yml は変更なし
-- AWS 側: GitHub OIDC Provider 登録、IAM Role（ECR push + App Runner StartDeployment 権限）
+- AWS 側: GitHub OIDC Provider 登録、IAM Role（ECR push + `lambda:UpdateFunctionCode` / `lambda:GetFunction` 権限）
 - GitHub Secrets / Variables: `AWS_REGION`、`AWS_ROLE_ARN`、`ECR_REPOSITORY`、`APP_RUNNER_SERVICE_ARN` を登録
 - ドキュメント更新
 - Vercel のデプロイは Phase 2.5c で既に自動化済み（追加作業なし）

--- a/openspec/changes/phase2-5d-auto-deploy/specs/auto-deploy-pipeline/spec.md
+++ b/openspec/changes/phase2-5d-auto-deploy/specs/auto-deploy-pipeline/spec.md
@@ -1,13 +1,13 @@
 ## ADDED Requirements
 
 ### Requirement: Backend は main 自動デプロイを GitHub Actions で実行する
-GitHub の `main` ブランチに push（merge）された時、Backend のコンテナイメージを ECR にビルド・push し、AWS App Runner に反映する SHALL。失敗時はワークフローが赤くなり、デプロイは中断する MUST。
+GitHub の `main` ブランチに push（merge）された時、Backend のコンテナイメージを ECR にビルド・push し、AWS Lambda に反映する SHALL。失敗時はワークフローが赤くなり、デプロイは中断する MUST。
 
 #### Scenario: main への push で自動デプロイ
 - **WHEN** PR が main にマージされる
 - **THEN** GitHub Actions の `deploy-backend.yml` が実行される
-- **AND** ECR に新しいイメージが push される
-- **AND** App Runner にデプロイが反映される
+- **AND** ECR に新しいイメージが push される（`linux/amd64` + `--provenance=false` で Lambda 互換 manifest）
+- **AND** Lambda にデプロイが反映される（`update-function-code`）
 
 #### Scenario: 手動実行も可能
 - **WHEN** GitHub Actions の UI から `workflow_dispatch` でトリガーする
@@ -31,20 +31,20 @@ ECR に push するイメージには `${{ github.sha }}` と `latest` の **両
 - **WHEN** ECR push が完了する
 - **THEN** ECR コンソールでイメージに `latest` タグと `<commit-sha>` タグの両方が確認できる
 
-### Requirement: App Runner 反映は StartDeployment で明示的に行う
-ECR push 後、`aws apprunner start-deployment --service-arn ...` コマンドで App Runner に反映する MUST。完了を CLI で待ち合わせる SHALL。
+### Requirement: Lambda 反映は update-function-code で行う
+ECR push 後、`aws lambda update-function-code --function-name <name> --image-uri <uri>` コマンドで Lambda に反映する MUST。`LastUpdateStatus=Successful` を CLI で待ち合わせる SHALL。
 
-#### Scenario: 明示的に Deployment 開始
+#### Scenario: 明示的にコード更新
 - **WHEN** ECR push が完了した直後
-- **THEN** ワークフローが `aws apprunner start-deployment` を実行する
-- **AND** `aws apprunner wait` または同等のポーリングでデプロイ完了を待つ
+- **THEN** ワークフローが `aws lambda update-function-code` を実行する
+- **AND** `aws lambda get-function` をポーリングして `LastUpdateStatus=Successful` を待つ（最大 5 分）
 
 ### Requirement: デプロイ後の smoke test
-App Runner デプロイ完了後、サービス URL に `/health` リクエストを送り 200 が返ることを SHALL 確認する。失敗時はワークフローを fail させる MUST。
+Lambda デプロイ完了後、Function URL に `/health` リクエストを送り 200 が返ることを SHALL 確認する。失敗時はワークフローを fail させる MUST。
 
 #### Scenario: 正常時
 - **WHEN** デプロイ完了直後に smoke test ステップが走る
-- **THEN** `curl -fsS https://<service-url>/health` が 200 を返す
+- **THEN** `curl -fsS https://<function-url>/health` が 200 を返す
 - **AND** ワークフローが緑で終了する
 
 #### Scenario: 起動失敗時

--- a/openspec/changes/phase2-5d-auto-deploy/tasks.md
+++ b/openspec/changes/phase2-5d-auto-deploy/tasks.md
@@ -27,21 +27,9 @@
 
 ## 4. ワークフロー作成
 
-- [ ] 4.1 `.github/workflows/deploy-backend.yml` を作成する
-  - Trigger: `push` to `main`、`workflow_dispatch`
-  - Permissions: `id-token: write`、`contents: read`
-  - Job 1 `build-and-push`:
-    - `aws-actions/configure-aws-credentials@v4` で OIDC 認証
-    - `aws-actions/amazon-ecr-login@v2` で ECR ログイン
-    - `docker buildx build --platform linux/amd64 --provenance=false --push -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} -t $ECR_REGISTRY/$ECR_REPOSITORY:latest backend/`（buildx + push 一発）
-  - Job 2 `deploy` (needs: build-and-push):
-    - 同じく OIDC 認証
-    - `aws lambda update-function-code --function-name $FN --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}`
-    - `aws lambda wait function-updated --function-name $FN`（または get-function ポーリング）
-  - Job 3 `smoke-test` (needs: deploy):
-    - `curl -fsS --retry 30 --retry-delay 5 ${{ vars.LAMBDA_FUNCTION_URL }}/health`
-- [ ] 4.2 ワークフロー YAML の lint（`actionlint` 推奨、無ければ手動目視）
-- [ ] 4.3 PR を main にマージする前に「main 限定で走る」「PR では走らない」設定を再確認
+- [x] 4.1 `.github/workflows/deploy-backend.yml` を作成する（buildx + push、Lambda update-function-code、smoke test の 3 ジョブ直列、`provenance: false`、`paths: backend/**` で関係ない変更ではトリガしない）
+- [x] 4.2 ワークフロー YAML の lint（actionlint 未インストールのため目視確認）
+- [x] 4.3 「main 限定で走る」「PR では走らない」設定を確認済（`on.push.branches: [main]` のみ、PR トリガなし）
 
 ## 5. 動作確認
 

--- a/openspec/changes/phase2-5d-auto-deploy/tasks.md
+++ b/openspec/changes/phase2-5d-auto-deploy/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Issue・ブランチ準備
 
-- [ ] 1.1 GitHub Issue を作成する（タイトル: "Phase 2.5d: Backend 自動デプロイ (GitHub Actions + OIDC)"）
-- [ ] 1.2 Issue 番号ベースのブランチを作成する
-- [ ] 1.3 Draft PR を作成する
+- [x] 1.1 GitHub Issue を作成する（タイトル: "Phase 2.5d: Backend 自動デプロイ (GitHub Actions + OIDC)"）
+- [x] 1.2 Issue 番号ベースのブランチを作成する
+- [x] 1.3 Draft PR を作成する
 
 ## 2. AWS 側の OIDC / IAM 設定（ユーザー作業）
 
@@ -11,19 +11,19 @@
   - 信頼ポリシー: GitHub OIDC を信頼、`repo:IsaoTakahashi/pantry-panel:ref:refs/heads/main` を `sub` 条件に
   - 許可ポリシー: 以下を最小権限で許可
     - `ecr:GetAuthorizationToken`
-    - `ecr:BatchCheckLayerAvailability`、`ecr:PutImage`、`ecr:InitiateLayerUpload`、`ecr:UploadLayerPart`、`ecr:CompleteLayerUpload`（対象リポジトリのみ）
-    - `apprunner:StartDeployment`、`apprunner:DescribeService`（対象サービスのみ）
+    - `ecr:BatchCheckLayerAvailability`、`ecr:PutImage`、`ecr:InitiateLayerUpload`、`ecr:UploadLayerPart`、`ecr:CompleteLayerUpload`、`ecr:BatchGetImage`（対象リポジトリのみ）
+    - `lambda:UpdateFunctionCode`、`lambda:GetFunction`（対象 Function のみ）
 - [ ] 2.3 Role ARN を控える
 
-## 3. GitHub リポジトリの Secrets / Variables 登録（ユーザー作業）
+## 3. GitHub リポジトリの Variables 登録（ユーザー作業）
 
-- [ ] 3.1 GitHub Repository → Settings → Secrets and variables → Actions
+- [ ] 3.1 GitHub Repository → Settings → Secrets and variables → Actions → Variables
 - [ ] 3.2 Variables に以下を登録:
   - `AWS_REGION`: `ap-northeast-1`
   - `AWS_ROLE_ARN`: 2.3 で控えた Role ARN
   - `ECR_REPOSITORY`: `pantry-panel-backend`
-  - `APP_RUNNER_SERVICE_ARN`: Phase 2.5b の App Runner サービス ARN
-  - `APP_RUNNER_SERVICE_URL`: Phase 2.5b の App Runner サービス URL（smoke test 用）
+  - `LAMBDA_FUNCTION_NAME`: `pantry-panel-backend`
+  - `LAMBDA_FUNCTION_URL`: `https://4xdn54pecs7z4hepmt2xcovq7m0nizno.lambda-url.ap-northeast-1.on.aws`（smoke test 用）
 
 ## 4. ワークフロー作成
 
@@ -33,14 +33,13 @@
   - Job 1 `build-and-push`:
     - `aws-actions/configure-aws-credentials@v4` で OIDC 認証
     - `aws-actions/amazon-ecr-login@v2` で ECR ログイン
-    - `docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} -t $ECR_REGISTRY/$ECR_REPOSITORY:latest backend/`
-    - `docker push --all-tags` で両方プッシュ
+    - `docker buildx build --platform linux/amd64 --provenance=false --push -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} -t $ECR_REGISTRY/$ECR_REPOSITORY:latest backend/`（buildx + push 一発）
   - Job 2 `deploy` (needs: build-and-push):
     - 同じく OIDC 認証
-    - `aws apprunner start-deployment --service-arn ${{ vars.APP_RUNNER_SERVICE_ARN }}`
-    - `aws apprunner describe-service` を 5 秒間隔で 5 分までポーリングし `Status=RUNNING` を待つ
+    - `aws lambda update-function-code --function-name $FN --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}`
+    - `aws lambda wait function-updated --function-name $FN`（または get-function ポーリング）
   - Job 3 `smoke-test` (needs: deploy):
-    - `curl -fsS --retry 30 --retry-delay 5 ${{ vars.APP_RUNNER_SERVICE_URL }}/health`
+    - `curl -fsS --retry 30 --retry-delay 5 ${{ vars.LAMBDA_FUNCTION_URL }}/health`
 - [ ] 4.2 ワークフロー YAML の lint（`actionlint` 推奨、無ければ手動目視）
 - [ ] 4.3 PR を main にマージする前に「main 限定で走る」「PR では走らない」設定を再確認
 
@@ -49,22 +48,19 @@
 - [ ] 5.1 PR をマージする → ワークフローが走る
 - [ ] 5.2 build-and-push、deploy、smoke-test が全て緑になることを確認する
 - [ ] 5.3 ECR コンソールで新しい sha タグと latest タグの両方が反映されたことを確認する
-- [ ] 5.4 App Runner で新しい Deployment が成功したことを確認する
+- [ ] 5.4 Lambda コンソールで Image URI が新しい sha に更新されたことを確認する
 - [ ] 5.5 試しに `backend/` 配下の任意の文言を1行変えて PR → main マージ → 自動デプロイ完走を確認する
 - [ ] 5.6 GitHub Actions UI から `workflow_dispatch` で手動再実行できることを確認する
 
-## 6. 失敗ケースの確認（任意、本番に影響しない範囲で）
+## 6. ドキュメント更新
 
-- [ ] 6.1 意図的に health check が 5 分超えるよう壊した PR を作って main にマージ → ワークフローが赤になることを確認 → 即座に revert PR で復旧
+- [ ] 6.1 `README.md` にデプロイフロー（main → ECR → Lambda → smoke test）と rollback 手順（旧 sha タグで `aws lambda update-function-code` 手動実行）を記載する
+- [ ] 6.2 `.claude/rules/general.md` の CI セクションに `deploy-backend.yml` の存在を追記する
+- [ ] 6.3 `.claude/rules/backend.md` の deploy セクションを自動デプロイ前提に更新
+- [ ] 6.4 `specs/features.md` の Phase 2.5 を完了マーク
 
-## 7. ドキュメント更新
+## 7. 仕上げ
 
-- [ ] 7.1 `README.md` にデプロイフロー（main → ECR → App Runner → smoke test）と rollback 手順（旧 sha タグで `aws apprunner start-deployment` 手動実行）を記載する
-- [ ] 7.2 `.claude/rules/general.md` の CI セクションに `deploy-backend.yml` の存在を追記する
-- [ ] 7.3 `specs/features.md` の Phase 2.5 を完了マークにする
-
-## 8. 仕上げ
-
-- [ ] 8.1 CI（lint + tsc + vitest + go test）がすべてパスすることを確認する
-- [ ] 8.2 PR を ready for review にして、Issue を `Closes #N` でリンクする
-- [ ] 8.3 マージ後に `openspec archive phase2-5d-auto-deploy` で archive する
+- [ ] 7.1 CI（lint + tsc + vitest + go test）がすべてパスすることを確認する
+- [ ] 7.2 PR を ready for review にして、Issue を `Closes #N` でリンクする
+- [ ] 7.3 マージ後に `openspec archive phase2-5d-auto-deploy` で archive する


### PR DESCRIPTION
## Summary

Phase 2.5（Epic #43）の最後のサブフェーズ。main へのマージで Backend が ECR build/push → Lambda update-function-code → smoke test まで自動実行される CI/CD を構築する。

## OpenSpec change

\`openspec/changes/phase2-5d-auto-deploy/\` (Lambda 用に更新済)

## Scope

- \`.github/workflows/deploy-backend.yml\` 作成（OIDC + buildx + Lambda update-function-code + smoke test）
- AWS GitHub OIDC Provider + IAM Role 作成（ユーザー作業）
- GitHub Repository Variables 登録（ユーザー作業）

## Test plan

- [ ] 初回 main マージで自動デプロイが走り、緑になる
- [ ] backend ファイルを 1 行変更して PR → main マージ → 自動デプロイ完走を確認
- [ ] workflow_dispatch で手動再実行できる
- [ ] CI 全パス

Closes #55