### PR TITLE
Phase 3: 学習目的の WebSocket + LISTEN/NOTIFY 実装

### DIFF
--- a/.claude/hooks/lint-on-edit.sh
+++ b/.claude/hooks/lint-on-edit.sh
@@ -25,7 +25,15 @@ case "$file_path" in
   "$repo_root"/backend/*.go)
     cd "$repo_root/backend"
     pkg_dir="$(dirname "$file_path")"
-    golangci-lint run "$pkg_dir" 1>&2 || exit 2
+    case "$file_path" in
+      "$repo_root"/backend/learning/*)
+        # learning code requires the `learning` build tag
+        golangci-lint run --build-tags=learning "$pkg_dir" 1>&2 || exit 2
+        ;;
+      *)
+        golangci-lint run "$pkg_dir" 1>&2 || exit 2
+        ;;
+    esac
     ;;
   *)
     exit 0

--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -93,7 +93,7 @@ aws lambda wait function-updated --function-name pantry-panel-backend
 |---------|--------|------|
 | Unit | **標準 testing パッケージ** | ビジネスロジック、ハンドラー |
 | Integration | **testcontainers-go** + PostgreSQL | DB 操作、LISTEN/NOTIFY、API 結合 |
-| Learning archive | `-tags=learning` で別 job 実行 | Phase 3.5 で隔離した自前 WebSocket 実装の retention |
+| Learning archive | `-tags=learning` で別 job 実行 | Phase 3 で隔離した自前 WebSocket 実装の retention |
 
 ## Lint
 
@@ -118,6 +118,24 @@ aws lambda wait function-updated --function-name pantry-panel-backend
 2. DB 更新時に PostgreSQL NOTIFY を発行（トリガー）
 3. Go サーバーが LISTEN で変更通知を受信
 4. WebSocket 接続中のクライアントに変更内容を push
+
+#### Phase 3 学習実装の起動方法（ローカル動作確認用）
+
+```bash
+# 1. compose Postgres を起動
+docker compose up -d
+
+# 2. learning migration を適用（trigger + function）
+docker exec -i pantry-panel-db psql -U pantry -d pantry_panel \
+  < backend/db/migrations/learning_001_stock_items_notify.sql
+
+# 3. learning サーバーを起動
+cd backend
+go run -tags=learning ./learning/cmd/server
+# → ws://localhost:8080/ws で接続待機
+```
+
+INSERT/UPDATE/DELETE で `stock_items.created/updated/deleted` イベントが配信される。WebSocket クライアントは `websocat ws://127.0.0.1:8080/ws` 等で接続できる。
 
 ### Phase 3.5 以降（本番）
 

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -42,7 +42,22 @@ cd frontend && npm run dev
 | レイヤー | ツール | 対象 |
 |---------|--------|------|
 | Unit | **Vitest** + **React Testing Library** | ロジック、hooks、コンポーネント描画 |
+| Learning | **Vitest** (別 config) | `*.learning.test.{ts,tsx}` のみ。通常 vitest からは除外 |
 | E2E | **Playwright** | ユーザー操作フロー、リアルタイム同期（複数 BrowserContext） |
+
+## 学習用 WebSocket クライアント（Phase 3）
+
+`frontend/src/learning/websocket-client/` に隔離。本番ビルドには影響しない。
+
+| 項目 | 内容 |
+|------|------|
+| フック | `useStockItemsWebSocket(url): { lastEvent, readyState }` |
+| 再接続 | exponential backoff（500ms → 1s → 2s → 5s → 10s 上限）。`computeBackoff` で計算 |
+| メッセージ形式 | `{ type: "stock_items.created" \| "updated" \| "deleted", payload }` |
+| テスト | `*.learning.test.{ts,tsx}` を `vitest.learning.config.ts` で実行（`npx vitest run --config vitest.learning.config.ts`） |
+| playground | `frontend/src/app/learning/websocket-playground/page.tsx`（`.gitignore` 済、各自で書く） |
+
+ローカル動作確認は backend の learning サーバー (`go run -tags=learning ./learning/cmd/server`) と組み合わせる。詳細は `.claude/rules/backend.md` の「Phase 3 学習実装の起動方法」を参照。
 
 ## Lint / Format
 

--- a/.github/workflows/learning.yml
+++ b/.github/workflows/learning.yml
@@ -1,0 +1,55 @@
+name: Learning (Phase 3 isolated)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  backend-learning:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache: true
+          cache-dependency-path: backend/go.sum
+
+      - name: Build (no learning tag, ensures learning code is excluded)
+        run: go build ./...
+
+      - name: Build (with learning tag)
+        run: go build -tags=learning ./learning/...
+
+      - name: Test (learning, integration via testcontainers)
+        run: go test -tags=learning -race -timeout=5m ./learning/...
+
+  frontend-learning:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+
+      - name: Verify learning tests are excluded from default vitest run
+        run: |
+          # default config が learning tests を除外していることを軽くチェック
+          # (実テストではない)
+          test -f vitest.learning.config.ts
+
+      - name: Run learning vitest config
+        run: npx vitest run --config vitest.learning.config.ts

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,7 @@
+# go build output
+/backend
+/server
+/main
+
+# misc
+.DS_Store

--- a/backend/db/migrations/learning_001_stock_items_notify.sql
+++ b/backend/db/migrations/learning_001_stock_items_notify.sql
@@ -1,0 +1,35 @@
+-- LEARNING-ONLY MIGRATION
+-- Do NOT apply this to Supabase production.
+-- Apply only to the local compose Postgres for Phase 3 learning purposes.
+--
+-- This trigger sends a JSON payload via pg_notify('stock_items_changed', ...)
+-- on every INSERT/UPDATE/DELETE of stock_items rows.
+
+CREATE OR REPLACE FUNCTION notify_stock_items_change() RETURNS trigger AS $$
+DECLARE
+  payload jsonb;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    payload := jsonb_build_object(
+      'type', 'stock_items.deleted',
+      'payload', jsonb_build_object('id', OLD.id)
+    );
+  ELSIF TG_OP = 'INSERT' THEN
+    payload := jsonb_build_object(
+      'type', 'stock_items.created',
+      'payload', to_jsonb(NEW)
+    );
+  ELSE
+    payload := jsonb_build_object(
+      'type', 'stock_items.updated',
+      'payload', to_jsonb(NEW)
+    );
+  END IF;
+  PERFORM pg_notify('stock_items_changed', payload::text);
+  RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER stock_items_notify
+  AFTER INSERT OR UPDATE OR DELETE ON stock_items
+  FOR EACH ROW EXECUTE FUNCTION notify_stock_items_change();

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -60,6 +60,7 @@ require (
 )
 
 require (
+	github.com/coder/websocket v1.8.14
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -10,6 +10,8 @@ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK3
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=

--- a/backend/learning/cmd/server/main.go
+++ b/backend/learning/cmd/server/main.go
@@ -9,14 +9,45 @@
 // migration applied. PORT defaults to 8080.
 package main
 
-// TODO: implement main()
-//   1) ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM); defer cancel()
-//   2) read DATABASE_URL (default to local compose)
-//   3) hub := websocket.NewHub()
-//   4) listener := websocket.NewPgListener(dsn, "stock_items_changed", func(p string) { hub.Broadcast([]byte(p)) })
-//      go listener.Run(ctx)
-//   5) e := echo.New(); e.GET("/ws", websocket.Handler(hub))
-//   6) e.Start(":" + os.Getenv("PORT"))  // PORT default "8080"
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/IsaoTakahashi/pantry-panel/backend/learning/websocket"
+	"github.com/labstack/echo/v5"
+)
 
 func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		dsn = "postgres://pantry:pantry@localhost:5432/pantry_panel?sslmode=disable"
+	}
+
+	hub := websocket.NewHub()
+	listener := websocket.NewPgListener(dsn, "stock_items_changed", func(p string) { hub.Broadcast([]byte(p)) })
+
+	go listener.Run(ctx)
+
+	e := echo.New()
+	e.GET("/ws", websocket.Handler(hub))
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	sc := echo.StartConfig{
+		Address: ":" + port,
+	}
+
+	if err := sc.Start(ctx, e); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatal(err)
+	}
 }

--- a/backend/learning/cmd/server/main.go
+++ b/backend/learning/cmd/server/main.go
@@ -1,0 +1,22 @@
+//go:build learning
+
+// Command server is the learning entrypoint that wires up the Hub, PgListener,
+// and Echo /ws handler. Run with:
+//
+//	go run -tags=learning ./learning/cmd/server
+//
+// It expects DATABASE_URL to point at a local Postgres with the learning
+// migration applied. PORT defaults to 8080.
+package main
+
+// TODO: implement main()
+//   1) ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM); defer cancel()
+//   2) read DATABASE_URL (default to local compose)
+//   3) hub := websocket.NewHub()
+//   4) listener := websocket.NewPgListener(dsn, "stock_items_changed", func(p string) { hub.Broadcast([]byte(p)) })
+//      go listener.Run(ctx)
+//   5) e := echo.New(); e.GET("/ws", websocket.Handler(hub))
+//   6) e.Start(":" + os.Getenv("PORT"))  // PORT default "8080"
+
+func main() {
+}

--- a/backend/learning/websocket/README.md
+++ b/backend/learning/websocket/README.md
@@ -1,0 +1,61 @@
+# Learning: WebSocket + PostgreSQL LISTEN/NOTIFY
+
+## 目的
+
+WebSocket protocol、PostgreSQL LISTEN/NOTIFY、broadcast の挙動を学習するためのコード。
+
+## 本番には載せない
+
+- 全 .go ファイルに `//go:build learning` を MUST 付与
+- 通常の `go build .` / `go test ./...` / Lambda の docker build からは **完全に除外**される
+- Lambda の本番 binary には 1 バイトも含まれない
+
+## 変更ルール
+
+- **機能追加は禁止**。Phase 3.5（Supabase Realtime）を本番として採用したため、本実装は学習ログ
+- **依存追従のみ許容**:
+  - 脆弱性対応で `coder/websocket` をアップデートする
+  - Go バージョンアップで build が壊れた場合の追随
+  - testcontainers / pgx の API 破壊への追随
+- 上記以外の変更は別 capability の change として扱う
+
+## 動作確認
+
+### ローカル
+
+```bash
+# Postgres を起動
+docker compose up -d
+
+# 学習用 migration を適用 (初回のみ)
+psql 'postgres://pantry:pantry@localhost:5432/pantry_panel?sslmode=disable' \
+  -f backend/db/migrations/learning_001_stock_items_notify.sql
+
+# 学習サーバを起動
+cd backend
+go run -tags=learning ./learning/cmd/server
+
+# 別端末で WebSocket 接続
+wscat -c ws://localhost:8080/ws
+```
+
+### CI
+
+`.github/workflows/learning.yml` で `go test -tags=learning ./backend/learning/...` が走る。testcontainers で Postgres を起動して integration テストを実行。
+
+## ファイル構成
+
+```
+backend/learning/
+├── websocket/
+│   ├── README.md            (このファイル)
+│   ├── hub.go               (broadcaster: subscribe/unsubscribe/broadcast)
+│   ├── hub_test.go
+│   ├── pg_listener.go       (PostgreSQL LISTEN + auto-reconnect)
+│   ├── pg_listener_test.go
+│   ├── handler.go           (Echo /ws handler)
+│   ├── handler_test.go
+│   └── integration_test.go  (testcontainers + Postgres + WS の end-to-end)
+└── cmd/server/
+    └── main.go              (起動 entrypoint、Echo + Hub + PgListener を組み立てる)
+```

--- a/backend/learning/websocket/handler.go
+++ b/backend/learning/websocket/handler.go
@@ -19,7 +19,9 @@ import (
 func Handler(hub *Hub) func(c *echo.Context) error {
 
 	return func(c *echo.Context) error {
-		conn, err := cws.Accept(c.Response(), c.Request(), nil)
+		conn, err := cws.Accept(c.Response(), c.Request(), &cws.AcceptOptions{
+			OriginPatterns: []string{"localhost:3000"},
+		})
 		if err != nil {
 			return err
 		}

--- a/backend/learning/websocket/handler.go
+++ b/backend/learning/websocket/handler.go
@@ -1,0 +1,23 @@
+//go:build learning
+
+package websocket
+
+import (
+	"github.com/labstack/echo/v5"
+)
+
+// Handler returns an Echo handler that upgrades HTTP to WebSocket, registers
+// the new connection with hub, and pumps messages from c.Send to the wire.
+//
+// Implementation hint:
+//   1) accept the connection via coder/websocket Accept (use c.Response() and c.Request())
+//   2) make a Client with a buffered Send channel
+//   3) hub.Register(c); defer hub.Unregister(c) and conn.Close
+//   4) goroutine: for msg := range c.Send { conn.Write(...) }
+//   5) read loop: read & ignore (or implement ping/pong) until connection closes
+func Handler(hub *Hub) func(c *echo.Context) error {
+	// TODO: implement
+	return func(c *echo.Context) error {
+		return nil
+	}
+}

--- a/backend/learning/websocket/handler.go
+++ b/backend/learning/websocket/handler.go
@@ -3,6 +3,7 @@
 package websocket
 
 import (
+	cws "github.com/coder/websocket"
 	"github.com/labstack/echo/v5"
 )
 
@@ -10,14 +11,41 @@ import (
 // the new connection with hub, and pumps messages from c.Send to the wire.
 //
 // Implementation hint:
-//   1) accept the connection via coder/websocket Accept (use c.Response() and c.Request())
-//   2) make a Client with a buffered Send channel
-//   3) hub.Register(c); defer hub.Unregister(c) and conn.Close
-//   4) goroutine: for msg := range c.Send { conn.Write(...) }
-//   5) read loop: read & ignore (or implement ping/pong) until connection closes
+//  1. accept the connection via coder/websocket Accept (use c.Response() and c.Request())
+//  2. make a Client with a buffered Send channel
+//  3. hub.Register(c); defer hub.Unregister(c) and conn.Close
+//  4. goroutine: for msg := range c.Send { conn.Write(...) }
+//  5. read loop: read & ignore (or implement ping/pong) until connection closes
 func Handler(hub *Hub) func(c *echo.Context) error {
-	// TODO: implement
+
 	return func(c *echo.Context) error {
+		conn, err := cws.Accept(c.Response(), c.Request(), nil)
+		if err != nil {
+			return err
+		}
+		defer conn.Close(cws.StatusNormalClosure, "")
+
+		client := &Client{Send: make(chan []byte, 10)}
+		hub.Register(client)
+		defer hub.Unregister(client)
+
+		go func() {
+			for msg := range client.Send {
+				err := conn.Write(c.Request().Context(), cws.MessageText, msg)
+				if err != nil {
+					return
+				}
+			}
+		}()
+
+		for {
+			_, _, err := conn.Read(c.Request().Context())
+			if err != nil {
+				break
+			}
+		}
+		close(client.Send)
+
 		return nil
 	}
 }

--- a/backend/learning/websocket/handler_test.go
+++ b/backend/learning/websocket/handler_test.go
@@ -1,0 +1,26 @@
+//go:build learning
+
+package websocket
+
+import "testing"
+
+func TestHandler_RegistersOnConnect(t *testing.T) {
+	// TODO:
+	//   hub := NewHub()
+	//   e := echo.New(); e.GET("/ws", Handler(hub))
+	//   srv := httptest.NewServer(e)
+	//   defer srv.Close()
+	//   wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+	//   conn, _, err := wsClient.Dial(ctx, wsURL, nil)
+	//   require.NoError; defer conn.Close
+	//   eventually assert hub.Len() == 1
+}
+
+func TestHandler_UnregistersOnDisconnect(t *testing.T) {
+	// TODO: connect, then conn.Close; eventually assert hub.Len() == 0
+}
+
+func TestHandler_BroadcastReachesClient(t *testing.T) {
+	// TODO: connect; hub.Broadcast([]byte(`{"type":"x"}`));
+	//       conn.Read returns that message
+}

--- a/backend/learning/websocket/handler_test.go
+++ b/backend/learning/websocket/handler_test.go
@@ -2,25 +2,74 @@
 
 package websocket
 
-import "testing"
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	cws "github.com/coder/websocket"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestHandler_RegistersOnConnect(t *testing.T) {
-	// TODO:
-	//   hub := NewHub()
-	//   e := echo.New(); e.GET("/ws", Handler(hub))
-	//   srv := httptest.NewServer(e)
-	//   defer srv.Close()
-	//   wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
-	//   conn, _, err := wsClient.Dial(ctx, wsURL, nil)
-	//   require.NoError; defer conn.Close
-	//   eventually assert hub.Len() == 1
+	hub := NewHub()
+	e := echo.New()
+	e.GET("/ws", Handler(hub))
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+
+	ctx := context.Background()
+	conn, _, err := cws.Dial(ctx, wsURL, nil)
+	require.NoError(t, err)
+	defer conn.Close(cws.StatusNormalClosure, "")
+
+	assert.Eventually(t, func() bool {
+		return hub.Len() == 1
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestHandler_UnregistersOnDisconnect(t *testing.T) {
-	// TODO: connect, then conn.Close; eventually assert hub.Len() == 0
+	hub := NewHub()
+	e := echo.New()
+	e.GET("/ws", Handler(hub))
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+
+	ctx := context.Background()
+	conn, _, err := cws.Dial(ctx, wsURL, nil)
+	require.NoError(t, err)
+	conn.Close(cws.StatusNormalClosure, "")
+
+	assert.Eventually(t, func() bool {
+		return hub.Len() == 0
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestHandler_BroadcastReachesClient(t *testing.T) {
-	// TODO: connect; hub.Broadcast([]byte(`{"type":"x"}`));
-	//       conn.Read returns that message
+	hub := NewHub()
+	e := echo.New()
+	e.GET("/ws", Handler(hub))
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+
+	ctx := context.Background()
+	conn, _, err := cws.Dial(ctx, wsURL, nil)
+	require.NoError(t, err)
+	defer conn.Close(cws.StatusNormalClosure, "")
+
+	assert.Eventually(t, func() bool {
+		return hub.Len() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	hub.Broadcast([]byte(`{"type":"x"}`))
+	_, msg, err := conn.Read(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, `{"type":"x"}`, string(msg))
 }

--- a/backend/learning/websocket/hub.go
+++ b/backend/learning/websocket/hub.go
@@ -24,32 +24,50 @@ type Hub struct {
 
 // NewHub creates an empty Hub.
 func NewHub() *Hub {
-	// TODO: implement
-	return nil
+	return &Hub{
+		clients: make(map[*Client]struct{}),
+	}
 }
 
 // Register adds a client to the hub. Safe for concurrent use.
 func (h *Hub) Register(c *Client) {
-	// TODO: implement (lock + add to map)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.clients[c] = struct{}{}
 }
 
 // Unregister removes a client. If the client is not registered, this is a no-op.
 // Safe for concurrent use.
 func (h *Hub) Unregister(c *Client) {
-	// TODO: implement (lock + delete from map; do NOT close c.Send here, the
-	//       handler goroutine that owns the connection should close it)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.clients, c)
 }
 
 // Broadcast sends msg to every registered client without blocking.
 // If a client's Send channel is full, the client is unregistered (slow client policy).
 func (h *Hub) Broadcast(msg []byte) {
-	// TODO: implement
-	//   1) snapshot clients under RLock
-	//   2) for each client: select { case c.Send <- msg: default: drop & unregister }
+	h.mu.RLock()
+	clients := make([]*Client, 0, len(h.clients))
+	for c := range h.clients {
+		clients = append(clients, c)
+	}
+	h.mu.RUnlock()
+
+	for _, c := range clients {
+		select {
+		case c.Send <- msg:
+			// sent successfully
+		default:
+			// channel is full, drop client
+			h.Unregister(c)
+		}
+	}
 }
 
 // Len returns the current number of registered clients. Used by tests.
 func (h *Hub) Len() int {
-	// TODO: implement
-	return 0
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.clients)
 }

--- a/backend/learning/websocket/hub.go
+++ b/backend/learning/websocket/hub.go
@@ -1,0 +1,55 @@
+//go:build learning
+
+// Package websocket provides a learning-only Hub + WebSocket handler that
+// broadcasts PostgreSQL LISTEN/NOTIFY messages to all connected clients.
+//
+// This package is excluded from the production build by the `learning` build tag.
+package websocket
+
+import "sync"
+
+// Client represents a single WebSocket connection's outbound channel.
+// The handler goroutine owns the connection and reads from Send.
+type Client struct {
+	// Send is the buffered outbound channel. The Hub MUST do a non-blocking
+	// send; if the channel is full the client is treated as slow and dropped.
+	Send chan []byte
+}
+
+// Hub keeps track of registered clients and broadcasts messages to all of them.
+type Hub struct {
+	mu      sync.RWMutex
+	clients map[*Client]struct{}
+}
+
+// NewHub creates an empty Hub.
+func NewHub() *Hub {
+	// TODO: implement
+	return nil
+}
+
+// Register adds a client to the hub. Safe for concurrent use.
+func (h *Hub) Register(c *Client) {
+	// TODO: implement (lock + add to map)
+}
+
+// Unregister removes a client. If the client is not registered, this is a no-op.
+// Safe for concurrent use.
+func (h *Hub) Unregister(c *Client) {
+	// TODO: implement (lock + delete from map; do NOT close c.Send here, the
+	//       handler goroutine that owns the connection should close it)
+}
+
+// Broadcast sends msg to every registered client without blocking.
+// If a client's Send channel is full, the client is unregistered (slow client policy).
+func (h *Hub) Broadcast(msg []byte) {
+	// TODO: implement
+	//   1) snapshot clients under RLock
+	//   2) for each client: select { case c.Send <- msg: default: drop & unregister }
+}
+
+// Len returns the current number of registered clients. Used by tests.
+func (h *Hub) Len() int {
+	// TODO: implement
+	return 0
+}

--- a/backend/learning/websocket/hub_test.go
+++ b/backend/learning/websocket/hub_test.go
@@ -2,44 +2,103 @@
 
 package websocket
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func TestHub_NewHub_Empty(t *testing.T) {
-	// TODO: assert NewHub().Len() == 0
+	if got := NewHub().Len(); got != 0 {
+		t.Errorf("NewHub().Len() = %d, want 0", got)
+	}
 }
 
 func TestHub_Register_AddsClient(t *testing.T) {
-	// TODO:
-	//   hub := NewHub()
-	//   c := &Client{Send: make(chan []byte, 1)}
-	//   hub.Register(c)
-	//   assert hub.Len() == 1
+	hub := NewHub()
+	c := &Client{Send: make(chan []byte, 1)}
+	hub.Register(c)
+	if got := hub.Len(); got != 1 {
+		t.Errorf("After Register, hub.Len() = %d, want 1", got)
+	}
 }
 
 func TestHub_Unregister_RemovesClient(t *testing.T) {
-	// TODO:
-	//   register c then unregister c, assert Len() == 0
+	hub := NewHub()
+	c := &Client{Send: make(chan []byte, 1)}
+	hub.Register(c)
+	hub.Unregister(c)
+	if got := hub.Len(); got != 0 {
+		t.Errorf("After Unregister, hub.Len() = %d, want 0", got)
+	}
 }
 
 func TestHub_Broadcast_SingleClient(t *testing.T) {
-	// TODO:
-	//   register one client with buffered Send
-	//   hub.Broadcast([]byte("hello"))
-	//   read from c.Send and assert == "hello"
+	hub := NewHub()
+	c := &Client{Send: make(chan []byte, 1)}
+	hub.Register(c)
+	hub.Broadcast([]byte("hello"))
+	select {
+	case msg := <-c.Send:
+		if string(msg) != "hello" {
+			t.Errorf("Received message = %q, want %q", msg, "hello")
+		}
+	default:
+		t.Error("Expected to receive a message, but channel was empty")
+	}
 }
 
 func TestHub_Broadcast_MultipleClients(t *testing.T) {
-	// TODO: register 2 clients, broadcast once, both receive
+	hub := NewHub()
+	c1 := &Client{Send: make(chan []byte, 1)}
+	c2 := &Client{Send: make(chan []byte, 1)}
+	hub.Register(c1)
+	hub.Register(c2)
+
+	hub.Broadcast([]byte("hello"))
+
+	for i, c := range []*Client{c1, c2} {
+		select {
+		case msg := <-c.Send:
+			if string(msg) != "hello" {
+				t.Errorf("Client %d: Received message = %q, want %q", i+1, msg, "hello")
+			}
+		default:
+			t.Errorf("Client %d: Expected to receive a message, but channel was empty", i+1)
+		}
+	}
 }
 
 func TestHub_Broadcast_FullChannel_DropsClient(t *testing.T) {
-	// TODO:
-	//   register a client with Send buffer 0 (or full buffer)
-	//   broadcast a message
-	//   assert hub.Len() == 0  (slow client got dropped)
+	hub := NewHub()
+	c := &Client{Send: make(chan []byte, 0)} // buffer size 0
+	hub.Register(c)
+	hub.Broadcast([]byte("hello"))
+	if got := hub.Len(); got != 0 {
+		t.Errorf("After broadcast to full channel, hub.Len() = %d, want 0", got)
+	}
 }
 
 func TestHub_ConcurrentRegisterUnregister(t *testing.T) {
-	// TODO: launch many goroutines doing Register / Unregister / Broadcast.
-	//       Run with `go test -race -tags=learning ./...` to detect races.
+	hub := NewHub()
+	c := &Client{Send: make(chan []byte, 1)}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			hub.Register(c)
+			hub.Unregister(c)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			hub.Broadcast([]byte("hello"))
+		}
+	}()
+
+	wg.Wait()
 }

--- a/backend/learning/websocket/hub_test.go
+++ b/backend/learning/websocket/hub_test.go
@@ -1,0 +1,45 @@
+//go:build learning
+
+package websocket
+
+import "testing"
+
+func TestHub_NewHub_Empty(t *testing.T) {
+	// TODO: assert NewHub().Len() == 0
+}
+
+func TestHub_Register_AddsClient(t *testing.T) {
+	// TODO:
+	//   hub := NewHub()
+	//   c := &Client{Send: make(chan []byte, 1)}
+	//   hub.Register(c)
+	//   assert hub.Len() == 1
+}
+
+func TestHub_Unregister_RemovesClient(t *testing.T) {
+	// TODO:
+	//   register c then unregister c, assert Len() == 0
+}
+
+func TestHub_Broadcast_SingleClient(t *testing.T) {
+	// TODO:
+	//   register one client with buffered Send
+	//   hub.Broadcast([]byte("hello"))
+	//   read from c.Send and assert == "hello"
+}
+
+func TestHub_Broadcast_MultipleClients(t *testing.T) {
+	// TODO: register 2 clients, broadcast once, both receive
+}
+
+func TestHub_Broadcast_FullChannel_DropsClient(t *testing.T) {
+	// TODO:
+	//   register a client with Send buffer 0 (or full buffer)
+	//   broadcast a message
+	//   assert hub.Len() == 0  (slow client got dropped)
+}
+
+func TestHub_ConcurrentRegisterUnregister(t *testing.T) {
+	// TODO: launch many goroutines doing Register / Unregister / Broadcast.
+	//       Run with `go test -race -tags=learning ./...` to detect races.
+}

--- a/backend/learning/websocket/integration_test.go
+++ b/backend/learning/websocket/integration_test.go
@@ -1,20 +1,127 @@
 //go:build learning
 
-package websocket_test
+package websocket
 
-// Integration test: real Postgres (testcontainers) + Hub + PgListener + handler + WS client.
-//
-// Steps:
-//   1) start postgres testcontainer (see backend/repository/repository_integration_test.go for an example)
-//   2) apply base migration (001_create_stock_items.sql) and learning migration (learning_001_stock_items_notify.sql)
-//   3) ctx, cancel := context.WithCancel(context.Background()); defer cancel()
-//   4) hub := websocket.NewHub()
-//   5) listener := websocket.NewPgListener(dsn, "stock_items_changed", func(p string) { hub.Broadcast([]byte(p)) })
-//      go listener.Run(ctx)
-//   6) e := echo.New(); e.GET("/ws", websocket.Handler(hub))
-//      srv := httptest.NewServer(e); defer srv.Close()
-//   7) connect ws client
-//   8) execute INSERT INTO stock_items (...)
-//   9) read from ws within 5s timeout, parse JSON, assert type/payload
-//
-// TODO: implement the test function `TestIntegration_NotifyToBroadcast(t *testing.T)`.
+import (
+	"context"
+	"log"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	cws "github.com/coder/websocket"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+var testPool *pgxpool.Pool
+var connStr string
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:18",
+		postgres.WithDatabase("pantry_panel_test"),
+		postgres.WithUsername("test"),
+		postgres.WithPassword("test"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2),
+		),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	connStr, err = pgContainer.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	testPool, err = pgxpool.New(context.Background(), connStr)
+	if err != nil {
+		log.Fatalf("failed to connect to test database: %v", err)
+	}
+
+	sqlBytes1, err := os.ReadFile("../../db/migrations/001_create_stock_items.sql")
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err = testPool.Exec(context.Background(), string(sqlBytes1))
+	if err != nil {
+		log.Fatalf("failed to apply migration: %v", err)
+	}
+
+	sqlBytes2, err := os.ReadFile("../../db/migrations/learning_001_stock_items_notify.sql")
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err = testPool.Exec(context.Background(), string(sqlBytes2))
+	if err != nil {
+		log.Fatalf("failed to apply migration: %v", err)
+	}
+
+	_, err = testPool.Exec(ctx, "TRUNCATE stock_items")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	code := m.Run()
+
+	testPool.Close()
+	if err := pgContainer.Terminate(ctx); err != nil {
+		log.Printf("failed to terminate test container: %v", err)
+	}
+
+	os.Exit(code)
+}
+
+func TestIntegration_NotifyToBroadcast(t *testing.T) {
+
+	// 2. Hub + PgListener 起動
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hub := NewHub()
+	listener := NewPgListener(connStr, "stock_items_changed", func(p string) {
+		hub.Broadcast([]byte(p))
+	})
+	go listener.Run(ctx)
+	time.Sleep(300 * time.Millisecond)
+
+	// 3. Echo サーバー起動
+	e := echo.New()
+	e.GET("/ws", Handler(hub))
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	// 4. WS クライアント接続
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+	conn, _, err := cws.Dial(ctx, wsURL, nil)
+	require.NoError(t, err)
+	defer conn.Close(cws.StatusNormalClosure, "")
+
+	assert.Eventually(t, func() bool {
+		return hub.Len() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	// 5. INSERT
+	_, err = testPool.Exec(ctx, `INSERT INTO stock_items (name, category) VALUES ('醤油', '調味料')`)
+	require.NoError(t, err)
+
+	// 6. WS で受信 → アサート
+	readCtx, readCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer readCancel()
+
+	_, msg, err := conn.Read(readCtx)
+	require.NoError(t, err)
+	assert.Contains(t, string(msg), "stock_items.created")
+}

--- a/backend/learning/websocket/integration_test.go
+++ b/backend/learning/websocket/integration_test.go
@@ -1,0 +1,20 @@
+//go:build learning
+
+package websocket_test
+
+// Integration test: real Postgres (testcontainers) + Hub + PgListener + handler + WS client.
+//
+// Steps:
+//   1) start postgres testcontainer (see backend/repository/repository_integration_test.go for an example)
+//   2) apply base migration (001_create_stock_items.sql) and learning migration (learning_001_stock_items_notify.sql)
+//   3) ctx, cancel := context.WithCancel(context.Background()); defer cancel()
+//   4) hub := websocket.NewHub()
+//   5) listener := websocket.NewPgListener(dsn, "stock_items_changed", func(p string) { hub.Broadcast([]byte(p)) })
+//      go listener.Run(ctx)
+//   6) e := echo.New(); e.GET("/ws", websocket.Handler(hub))
+//      srv := httptest.NewServer(e); defer srv.Close()
+//   7) connect ws client
+//   8) execute INSERT INTO stock_items (...)
+//   9) read from ws within 5s timeout, parse JSON, assert type/payload
+//
+// TODO: implement the test function `TestIntegration_NotifyToBroadcast(t *testing.T)`.

--- a/backend/learning/websocket/pg_listener.go
+++ b/backend/learning/websocket/pg_listener.go
@@ -5,6 +5,8 @@ package websocket
 import (
 	"context"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 )
 
 // PgListener subscribes to a PostgreSQL channel via LISTEN/NOTIFY and invokes
@@ -18,8 +20,11 @@ type PgListener struct {
 
 // NewPgListener creates a listener. onMessage MUST NOT be nil.
 func NewPgListener(dsn, channel string, onMessage func(string)) *PgListener {
-	// TODO: implement
-	return nil
+	return &PgListener{
+		dsn:       dsn,
+		channel:   channel,
+		onMessage: onMessage,
+	}
 }
 
 // Run blocks until ctx is done. It connects, LISTENs on the channel, reads
@@ -28,8 +33,44 @@ func NewPgListener(dsn, channel string, onMessage func(string)) *PgListener {
 //
 // Use go listener.Run(ctx) and cancel ctx to stop.
 func (l *PgListener) Run(ctx context.Context) {
-	// TODO: implement
-	//   for { check ctx; connect (pgx.Connect); LISTEN; for { wait notification or ctx done; onMessage(payload) }; on error: sleep computeBackoff; }
+	for attempt := 0; ; attempt++ {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		conn, err := pgx.Connect(ctx, l.dsn)
+		if err != nil {
+			time.Sleep(computeBackoff(attempt))
+			continue
+		}
+
+		_, err = conn.Exec(ctx, "LISTEN "+l.channel)
+		if err != nil {
+			conn.Close(ctx)
+			time.Sleep(computeBackoff(attempt))
+			continue
+		}
+
+		attempt = 0
+		for {
+			select {
+			case <-ctx.Done():
+				conn.Close(ctx)
+				return
+			default:
+			}
+
+			notification, err := conn.WaitForNotification(ctx)
+			if err != nil {
+				conn.Close(ctx)
+				time.Sleep(computeBackoff(attempt))
+				break
+			}
+			l.onMessage(notification.Payload)
+		}
+	}
 }
 
 // computeBackoff returns the wait duration for the given attempt index.
@@ -37,6 +78,16 @@ func (l *PgListener) Run(ctx context.Context) {
 //
 // Exposed for unit testing.
 func computeBackoff(attempt int) time.Duration {
-	// TODO: implement
-	return 0
+	switch {
+	case attempt <= 0:
+		return 500 * time.Millisecond
+	case attempt == 1:
+		return 1 * time.Second
+	case attempt == 2:
+		return 2 * time.Second
+	case attempt == 3:
+		return 5 * time.Second
+	default:
+		return 10 * time.Second
+	}
 }

--- a/backend/learning/websocket/pg_listener.go
+++ b/backend/learning/websocket/pg_listener.go
@@ -1,0 +1,42 @@
+//go:build learning
+
+package websocket
+
+import (
+	"context"
+	"time"
+)
+
+// PgListener subscribes to a PostgreSQL channel via LISTEN/NOTIFY and invokes
+// onMessage for each notification payload. It auto-reconnects with exponential
+// backoff on connection failures.
+type PgListener struct {
+	dsn       string
+	channel   string
+	onMessage func(payload string)
+}
+
+// NewPgListener creates a listener. onMessage MUST NOT be nil.
+func NewPgListener(dsn, channel string, onMessage func(string)) *PgListener {
+	// TODO: implement
+	return nil
+}
+
+// Run blocks until ctx is done. It connects, LISTENs on the channel, reads
+// notifications and calls onMessage. On disconnect, it sleeps via computeBackoff
+// then reconnects.
+//
+// Use go listener.Run(ctx) and cancel ctx to stop.
+func (l *PgListener) Run(ctx context.Context) {
+	// TODO: implement
+	//   for { check ctx; connect (pgx.Connect); LISTEN; for { wait notification or ctx done; onMessage(payload) }; on error: sleep computeBackoff; }
+}
+
+// computeBackoff returns the wait duration for the given attempt index.
+// Schedule: [500ms, 1s, 2s, 5s, 10s, 10s, 10s, ...]
+//
+// Exposed for unit testing.
+func computeBackoff(attempt int) time.Duration {
+	// TODO: implement
+	return 0
+}

--- a/backend/learning/websocket/pg_listener_test.go
+++ b/backend/learning/websocket/pg_listener_test.go
@@ -1,0 +1,27 @@
+//go:build learning
+
+package websocket
+
+import (
+	"testing"
+	"time"
+)
+
+func TestComputeBackoff(t *testing.T) {
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{0, 500 * time.Millisecond},
+		{1, 1 * time.Second},
+		{2, 2 * time.Second},
+		{3, 5 * time.Second},
+		{4, 10 * time.Second},
+		{5, 10 * time.Second},
+		{100, 10 * time.Second},
+	}
+	for _, tt := range tests {
+		// TODO: t.Run(...) and assert computeBackoff(tt.attempt) == tt.want
+		_ = tt
+	}
+}

--- a/backend/learning/websocket/pg_listener_test.go
+++ b/backend/learning/websocket/pg_listener_test.go
@@ -21,7 +21,10 @@ func TestComputeBackoff(t *testing.T) {
 		{100, 10 * time.Second},
 	}
 	for _, tt := range tests {
-		// TODO: t.Run(...) and assert computeBackoff(tt.attempt) == tt.want
+		computed := computeBackoff(tt.attempt)
+		if computed != tt.want {
+			t.Errorf("computeBackoff(%d) = %v, want %v", tt.attempt, computed, tt.want)
+		}
 		_ = tt
 	}
 }

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# learning playground (Phase 3, not for production)
+src/app/learning/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "format": "biome format --write .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:learning": "vitest run --config vitest.learning.config.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/frontend/src/learning/websocket-client/README.md
+++ b/frontend/src/learning/websocket-client/README.md
@@ -1,0 +1,44 @@
+# Learning: WebSocket client
+
+## 目的
+
+Backend (Phase 3 学習実装) と接続する WebSocket クライアントの React フックを学習する。
+
+## 本番には載せない
+
+- ファイル名は `*.learning.test.ts` / `*.learning.test.tsx` に MUST 統一
+- `vitest.config.ts` の `exclude` で `*.learning.test.{ts,tsx}` を除外
+- 専用 config `vitest.learning.config.ts` でのみ走る
+- `frontend/src/app/stock-items/page.tsx` 等の本番ページから `useStockItemsWebSocket` を MUST NOT import する
+
+## 変更ルール
+
+- **機能追加禁止**。本番リアルタイム機構は Phase 3.5 で Supabase Realtime に置き換え
+- **依存追従のみ許容**: 脆弱性対応 / API 破壊への追随
+
+## 動作確認
+
+### ユニット (vitest)
+
+```bash
+cd frontend
+npx vitest run --config vitest.learning.config.ts
+```
+
+### CI
+
+`.github/workflows/learning.yml` の frontend job が上記コマンドを実行する。
+
+### ローカル手動
+
+Backend の learning サーバを起動した状態で、playground (Storybook 等) でフックを呼ぶ。本番ページへの組込みは MUST NOT。
+
+## ファイル構成
+
+```
+frontend/src/learning/websocket-client/
+├── README.md                     (このファイル)
+├── useStockItemsWebSocket.ts     (フック実装)
+├── useStockItemsWebSocket.learning.test.tsx
+└── types.ts                      (StockItemEvent 等)
+```

--- a/frontend/src/learning/websocket-client/computeBackoff.learning.test.ts
+++ b/frontend/src/learning/websocket-client/computeBackoff.learning.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { computeBackoff } from "./computeBackoff";
+
+describe("computeBackoff", () => {
+  it.each([
+    [0, 500],
+    [1, 1000],
+    [2, 2000],
+    [3, 5000],
+    [4, 10000],
+    [5, 10000],
+    [100, 10000],
+  ])("attempt=%i → %ims", (attempt, expected) => {
+    expect(computeBackoff(attempt)).toBe(expected);
+  });
+});

--- a/frontend/src/learning/websocket-client/computeBackoff.ts
+++ b/frontend/src/learning/websocket-client/computeBackoff.ts
@@ -1,0 +1,4 @@
+export function computeBackoff(attempt: number): number {
+  const table = [500, 1000, 2000, 5000, 10000];
+  return table[Math.min(attempt, table.length - 1)];
+}

--- a/frontend/src/learning/websocket-client/types.ts
+++ b/frontend/src/learning/websocket-client/types.ts
@@ -1,0 +1,6 @@
+type StockItemEvent = {
+  type: "stock_items.created" | "stock_items.updated" | "stock_items.deleted";
+  payload: Record<string, unknown>;
+};
+
+export type { StockItemEvent };

--- a/frontend/src/learning/websocket-client/useStockItemsWebSocket.learning.test.tsx
+++ b/frontend/src/learning/websocket-client/useStockItemsWebSocket.learning.test.tsx
@@ -2,8 +2,7 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useStockItemsWebSocket } from "./useStockItemsWebSocket";
 
-let fakeWs: FakeWebSocket;
-
+let instances: FakeWebSocket[] = [];
 class FakeWebSocket {
   static readonly CONNECTING = 0;
   static readonly OPEN = 1;
@@ -13,22 +12,24 @@ class FakeWebSocket {
   onopen: ((event: Event) => void) | null = null;
   onmessage: ((event: MessageEvent) => void) | null = null;
   onclose: ((event: Event) => void) | null = null;
-  readyState: number = WebSocket.CONNECTING;
+  readyState: number = FakeWebSocket.CONNECTING;
   close = vi.fn();
   send = vi.fn();
 
   constructor(url: string) {
     this.url = url;
-    fakeWs = this;
+    instances.push(this);
   }
 }
 
 beforeEach(() => {
+  instances = [];
   vi.stubGlobal("WebSocket", FakeWebSocket);
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
 
 describe("useStockItemsWebSocket", () => {
@@ -47,7 +48,7 @@ describe("useStockItemsWebSocket", () => {
     );
 
     await act(async () => {
-      fakeWs.onmessage?.({
+      instances[0].onmessage?.({
         data: JSON.stringify({ type: "stock_items.created", payload: {} }),
       } as MessageEvent);
     });
@@ -65,6 +66,98 @@ describe("useStockItemsWebSocket", () => {
 
     unmount();
 
-    expect(fakeWs.close).toHaveBeenCalled();
+    expect(instances[0].close).toHaveBeenCalled();
+  });
+
+  it("onclose 後 500ms で再接続", async () => {
+    vi.useFakeTimers();
+    renderHook(() => useStockItemsWebSocket("ws://localhost"));
+
+    expect(instances.length).toBe(1);
+
+    await act(async () => {
+      instances[0].onclose?.({} as Event);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(499);
+    });
+    expect(instances.length).toBe(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(instances.length).toBe(2);
+  });
+
+  it("2連続 close で 2回目は 1s", async () => {
+    vi.useFakeTimers();
+    renderHook(() => useStockItemsWebSocket("ws://localhost"));
+
+    expect(instances.length).toBe(1);
+
+    await act(async () => {
+      instances[0].onclose?.({} as Event);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(instances.length).toBe(2);
+
+    await act(async () => {
+      instances[1].onclose?.({} as Event);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(999);
+    });
+    expect(instances.length).toBe(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(instances.length).toBe(3);
+  });
+
+  it("onopen 成功で attempt リセット", async () => {
+    vi.useFakeTimers();
+    renderHook(() => useStockItemsWebSocket("ws://localhost"));
+
+    expect(instances.length).toBe(1);
+
+    await act(async () => {
+      instances[0].onclose?.({} as Event);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(instances.length).toBe(2);
+
+    await act(async () => {
+      instances[1].onopen?.({} as Event);
+      instances[1].onclose?.({} as Event);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(instances.length).toBe(3);
+  });
+
+  it("unmount 中の保留 reconnect は発火しない", async () => {
+    vi.useFakeTimers();
+    const { unmount } = renderHook(() =>
+      useStockItemsWebSocket("ws://localhost"),
+    );
+
+    expect(instances.length).toBe(1);
+
+    await act(async () => {
+      instances[0].onclose?.({} as Event);
+    });
+
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(instances.length).toBe(1);
   });
 });

--- a/frontend/src/learning/websocket-client/useStockItemsWebSocket.learning.test.tsx
+++ b/frontend/src/learning/websocket-client/useStockItemsWebSocket.learning.test.tsx
@@ -1,0 +1,70 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useStockItemsWebSocket } from "./useStockItemsWebSocket";
+
+let fakeWs: FakeWebSocket;
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  url: string;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: Event) => void) | null = null;
+  readyState: number = WebSocket.CONNECTING;
+  close = vi.fn();
+  send = vi.fn();
+
+  constructor(url: string) {
+    this.url = url;
+    fakeWs = this;
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal("WebSocket", FakeWebSocket);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useStockItemsWebSocket", () => {
+  it("初期状態は lastEvent=null, readyState=CONNECTING", () => {
+    const { result } = renderHook(() =>
+      useStockItemsWebSocket("ws://localhost"),
+    );
+
+    expect(result.current.lastEvent).toEqual(null);
+    expect(result.current.readyState).toEqual(WebSocket.CONNECTING);
+  });
+
+  it("onmessage 発火後に lastEvent が更新される", async () => {
+    const { result } = renderHook(() =>
+      useStockItemsWebSocket("ws://localhost"),
+    );
+
+    await act(async () => {
+      fakeWs.onmessage?.({
+        data: JSON.stringify({ type: "stock_items.created", payload: {} }),
+      } as MessageEvent);
+    });
+
+    expect(result.current.lastEvent).toEqual({
+      type: "stock_items.created",
+      payload: "",
+    });
+  });
+
+  it("アンマウント時に ws.close() が呼ばれる", () => {
+    const { unmount } = renderHook(() =>
+      useStockItemsWebSocket("ws://localhost"),
+    );
+
+    unmount();
+
+    expect(fakeWs.close).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/learning/websocket-client/useStockItemsWebSocket.learning.test.tsx
+++ b/frontend/src/learning/websocket-client/useStockItemsWebSocket.learning.test.tsx
@@ -54,7 +54,7 @@ describe("useStockItemsWebSocket", () => {
 
     expect(result.current.lastEvent).toEqual({
       type: "stock_items.created",
-      payload: "",
+      payload: {},
     });
   });
 

--- a/frontend/src/learning/websocket-client/useStockItemsWebSocket.ts
+++ b/frontend/src/learning/websocket-client/useStockItemsWebSocket.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { computeBackoff } from "./computeBackoff";
 import type { StockItemEvent } from "./types";
 
 export function useStockItemsWebSocket(url: string) {
@@ -6,30 +7,45 @@ export function useStockItemsWebSocket(url: string) {
   const [readyState, setReadyState] = useState<number>(WebSocket.CONNECTING);
 
   useEffect(() => {
-    const ws = new WebSocket(url);
+    let attempt = 0;
+    let ws: WebSocket | null = null;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let unmounted = false;
 
-    ws.onopen = () => {
-      setReadyState(WebSocket.OPEN);
+    const connect = () => {
+      setReadyState(WebSocket.CONNECTING);
+      ws = new WebSocket(url);
+
+      ws.onopen = () => {
+        attempt = 0;
+        setReadyState(WebSocket.OPEN);
+      };
+
+      ws.onmessage = (event: MessageEvent) => {
+        const data = event.data;
+
+        try {
+          const stockItemEvent = JSON.parse(data) as StockItemEvent;
+          setLastEvent(stockItemEvent);
+        } catch (e) {
+          console.error(e);
+        }
+      };
+
+      ws.onclose = () => {
+        setReadyState(WebSocket.CLOSED);
+        if (unmounted) return;
+        const delay = computeBackoff(attempt);
+        attempt++;
+        timer = setTimeout(connect, delay);
+      };
     };
-
-    ws.onmessage = (event: MessageEvent) => {
-      const data = event.data;
-
-      try {
-        const stockItemEvent = JSON.parse(data) as StockItemEvent;
-        setLastEvent(stockItemEvent);
-      } catch (e) {
-        console.error(e);
-      }
-    };
-
-    ws.onclose = () => {
-      setReadyState(WebSocket.CLOSED);
-    };
+    connect();
 
     return () => {
-      ws.close();
-      setReadyState(WebSocket.CLOSED);
+      unmounted = true;
+      if (timer) clearTimeout(timer);
+      ws?.close();
     };
   }, [url]);
 

--- a/frontend/src/learning/websocket-client/useStockItemsWebSocket.ts
+++ b/frontend/src/learning/websocket-client/useStockItemsWebSocket.ts
@@ -8,7 +8,7 @@ export function useStockItemsWebSocket(url: string) {
   useEffect(() => {
     const ws = new WebSocket(url);
 
-    ws.onopen = (event: Event) => {
+    ws.onopen = () => {
       setReadyState(WebSocket.OPEN);
     };
 
@@ -23,7 +23,7 @@ export function useStockItemsWebSocket(url: string) {
       }
     };
 
-    ws.onclose = (event: Event) => {
+    ws.onclose = () => {
       setReadyState(WebSocket.CLOSED);
     };
 

--- a/frontend/src/learning/websocket-client/useStockItemsWebSocket.ts
+++ b/frontend/src/learning/websocket-client/useStockItemsWebSocket.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import type { StockItemEvent } from "./types";
+
+export function useStockItemsWebSocket(url: string) {
+  const [lastEvent, setLastEvent] = useState<StockItemEvent | null>(null);
+  const [readyState, setReadyState] = useState<number>(WebSocket.CONNECTING);
+
+  useEffect(() => {
+    const ws = new WebSocket(url);
+
+    ws.onopen = (event: Event) => {
+      setReadyState(WebSocket.OPEN);
+    };
+
+    ws.onmessage = (event: MessageEvent) => {
+      const data = event.data;
+
+      try {
+        const stockItemEvent = JSON.parse(data) as StockItemEvent;
+        setLastEvent(stockItemEvent);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+
+    ws.onclose = (event: Event) => {
+      setReadyState(WebSocket.CLOSED);
+    };
+
+    return () => {
+      ws.close();
+      setReadyState(WebSocket.CLOSED);
+    };
+  }, [url]);
+
+  return { lastEvent, readyState };
+}

--- a/frontend/vitest.learning.config.ts
+++ b/frontend/vitest.learning.config.ts
@@ -2,6 +2,8 @@ import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
+// Vitest config for the learning-only WebSocket client.
+// Run with: npx vitest run --config vitest.learning.config.ts
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -13,6 +15,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
     globals: true,
-    exclude: ["e2e/**", "node_modules/**", "**/*.learning.test.{ts,tsx}"],
+    include: ["src/learning/**/*.learning.test.{ts,tsx}"],
   },
 });

--- a/openspec/changes/phase3-realtime-sync-learning/.openspec.yaml
+++ b/openspec/changes/phase3-realtime-sync-learning/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-08

--- a/openspec/changes/phase3-realtime-sync-learning/design.md
+++ b/openspec/changes/phase3-realtime-sync-learning/design.md
@@ -1,0 +1,159 @@
+## Context
+
+旧製品の Firebase Realtime Database に相当するリアルタイム同期を、新製品では Phase 3.5 で **Supabase Realtime** に集約する方針が確定済（Epic #43 の D8 / `specs/features.md` 参照）。本番 Backend は AWS Lambda で動作するため、ステートフルな WebSocket 接続を本番 backend に持たせることは技術的にも困難。
+
+しかし「WebSocket + PostgreSQL LISTEN/NOTIFY を Go で書く」という経験そのものは学習価値が高く、捨てがたい。そこで Phase 3 は **学習目的の隔離実装** として残す。本実装は production bundle に含めず、ローカルの compose Postgres + ローカル Backend / Frontend でのみ動作確認する。
+
+## Goals / Non-Goals
+
+**Goals:**
+- WebSocket protocol、LISTEN/NOTIFY、broadcast の実装と挙動を実機で理解する
+- 本番コード（Lambda 配信される Go binary）に **一切影響しない** ように完全隔離する
+- 依存ライブラリの脆弱性 / API 破壊で壊れないよう、CI で動作確認を継続する
+
+**Non-Goals:**
+- 本番化（Lambda へのデプロイ）— 不可能 + 不要
+- UI への統合 — 本番は Phase 3.5 で Supabase Realtime に置き換え
+- 認証・認可 — 旧仕様も認証なし、学習スコープでも省略
+- スケーラビリティ（複数インスタンス間の broadcast）— 学習用は単一プロセスで十分
+- 永続化 / メッセージ保証 — fire-and-forget で十分
+
+## Decisions
+
+### 隔離方法: Go build tag + Frontend 別 vitest config
+
+- **Backend**: `//go:build learning` を `backend/learning/...` の全 .go ファイルに付与
+  - 通常の `go build .`、`go test ./...` は learning コードを **完全に無視**
+  - 学習コードを動かすには `go test -tags=learning ./backend/learning/...` を明示
+- **Frontend**: `frontend/src/learning/websocket-client/*.learning.test.ts` 命名規則
+  - 通常の `vitest.config.ts` は `**/*.test.ts` のみを include、`*.learning.test.ts` は exclude
+  - 別 config `vitest.learning.config.ts` で `*.learning.test.ts` のみ対象
+
+採用理由:
+- 本番 binary に1バイトも learning コードが含まれない
+- 通常開発では learning ディレクトリを意識せず作業可能
+- CI で別 job として独立実行できる
+
+代替案:
+- 別リポジトリに分割 → 学習履歴とコードレビューが分散して非効率
+- monorepo の workspace 化 → オーバーキル
+
+### WebSocket メッセージ形式: 単純な JSON `{type, payload}`
+
+```json
+{"type": "stock_items.created", "payload": { ...row... }}
+{"type": "stock_items.updated", "payload": { ...row... }}
+{"type": "stock_items.deleted", "payload": { "id": "..." }}
+```
+
+採用理由:
+- 学習スコープではシンプルさ優先
+- protobuf / GraphQL Subscription は過剰
+
+代替案:
+- `{op, table, row}` 形式（PostgreSQL 用語に近い）→ 採用しない、フロント側の理解しやすさ優先
+- バイナリ形式 → 学習目的なので人間可読性優先
+
+### Broadcast 戦略: 全クライアントに全イベント
+
+接続中の全クライアントに NOTIFY 受信時のメッセージを送る。subscribe / unsubscribe のフィルタ機構なし。
+
+採用理由:
+- 家族用途で同時接続クライアントは数台
+- subscribe 設計は YAGNI、必要になったら追加
+
+### LISTEN connection 管理: 1 本張りっぱなし + 自動 reconnect
+
+- 起動時に pgx で `LISTEN stock_items_changed` を 1 本だけ張る
+- 切断検知時は exponential backoff で再接続（500ms → 1s → 2s → 5s → 10s 上限）
+- 再接続成功後に再度 LISTEN を発行
+
+採用理由:
+- LISTEN は単一 connection で十分（多重 listen はリソースの無駄）
+- 再接続なしだと container restart や DB 一時切断で永続的に死ぬ
+
+### Frontend 統合方式: フックのみ実装、UI 統合はしない
+
+`useStockItemsWebSocket(url): { connected: boolean, lastEvent: Event | null }` を提供する。実際の `stock-items` ページへの組込みは行わない。
+
+採用理由:
+- 本番のリアルタイム機能は Phase 3.5 で Supabase Realtime に組込む。Phase 3 で UI 統合しても捨てる
+- フックの単体動作確認まで（test 含む）が学習目的の到達点
+
+### テスト範囲: Unit + Integration (testcontainers)
+
+- **Backend**:
+  - Unit: メッセージ整形、JSON encode、broadcaster の subscribe/unsubscribe
+  - Integration: testcontainers で Postgres を立て、トリガ INSERT → LISTEN 受信 → WebSocket 配信の end-to-end
+- **Frontend**:
+  - Unit: フックの状態遷移、reconnect ロジック（mock WebSocket で）
+
+採用理由:
+- LISTEN/NOTIFY は単体テストでは動作保証できない
+- testcontainers は Phase 1 から使用しているので追加学習コスト小
+
+### DB トリガ: 別 migration ファイルで学習用と分離
+
+`backend/db/migrations/learning_001_stock_items_notify.sql` として学習スコープの SQL を分離する。Supabase 本番にはこの migration を適用しない（学習用のみ）。
+
+```sql
+CREATE OR REPLACE FUNCTION notify_stock_items_change() RETURNS trigger AS $$
+DECLARE
+  payload jsonb;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    payload := jsonb_build_object('type', 'stock_items.deleted', 'payload', jsonb_build_object('id', OLD.id));
+  ELSIF TG_OP = 'INSERT' THEN
+    payload := jsonb_build_object('type', 'stock_items.created', 'payload', to_jsonb(NEW));
+  ELSE
+    payload := jsonb_build_object('type', 'stock_items.updated', 'payload', to_jsonb(NEW));
+  END IF;
+  PERFORM pg_notify('stock_items_changed', payload::text);
+  RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER stock_items_notify
+  AFTER INSERT OR UPDATE OR DELETE ON stock_items
+  FOR EACH ROW EXECUTE FUNCTION notify_stock_items_change();
+```
+
+採用理由:
+- compose Postgres にだけ手動適用する運用が明示的
+- 本番（Supabase）に誤って適用するリスクなし
+
+### WebSocket ライブラリ: `github.com/coder/websocket`
+
+Go コミュニティで主流の WebSocket ライブラリ。`gorilla/websocket` は archive 状態のため非推奨。
+
+採用理由:
+- 活発にメンテされている
+- `nhooyr.io/websocket` から rename した同じライブラリで実績あり
+
+代替案:
+- `github.com/gorilla/websocket` → archive、非推奨
+- `golang.org/x/net/websocket` → 機能少
+- 自前実装 → 学習スコープを越える
+
+## Risks / Trade-offs
+
+- **本番に LISTEN/NOTIFY が入り込むリスク** → Build tag + 別 migration ファイル + CI に separate job で完全隔離。Lambda コンテナビルドにも影響なし
+- **依存ライブラリの脆弱性 / 破壊的変更** → CI で常に動作確認しているため気付ける
+- **学習コードの保守コスト** → "依存追従のみ、機能追加禁止" を README で明示
+- **`learning` build tag を付け忘れて本番 binary に混入** → CI ジョブとして本番 build (`go build .`) と learning build (`go build -tags=learning ./...`) を別個に走らせ、本番 build に learning code を含まないことを確認
+
+## Migration Plan
+
+1. Backend: build tag 付きスケルトン、テスト、production 実装、testcontainers 結合テストを順に実装
+2. Frontend: `vitest.learning.config.ts` 追加、フックのスケルトン → unit test → 実装
+3. DB migration `learning_001_stock_items_notify.sql` を compose Postgres に適用
+4. ローカルで動作確認: `go test -tags=learning ./backend/learning/...` 緑、frontend `npx vitest run --config vitest.learning.config.ts` 緑、`docker compose up` + `go run -tags=learning .` で別端末から複数 ws connection 張って NOTIFY 受信確認
+5. CI に `learning.yml` を追加して push / PR で動作確認継続
+6. Phase 3 マージ後、`git tag learning-archive-v1` を打って固定ポイントを作る
+
+ロールバック: 学習コードのみ追加なので、PR を revert すれば本番への影響なしで巻き戻せる。
+
+## Open Questions
+
+- 「main に居続ける」 vs 「専用の学習ブランチに退避」: main に居続ける方が CI で常時動作確認できて壊れにくいが、main がノイジーになる懸念あり → main に居続けるで進める
+- WebSocket メッセージの version 付け: `{version: 1, type, payload}` を初版から入れるかは判断分かれる。学習スコープでは省略、必要になれば後付け

--- a/openspec/changes/phase3-realtime-sync-learning/proposal.md
+++ b/openspec/changes/phase3-realtime-sync-learning/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+Phase 2 完了 + Phase 2.5 で本番デプロイ完了。Phase 3 は **学習目的** で WebSocket + PostgreSQL LISTEN/NOTIFY を自前実装し、リアルタイム同期の仕組みを実機で理解する。本番のリアルタイム同期は Phase 3.5 で **Supabase Realtime** に置き換えるため、本実装は production bundle から除外し、ローカル / CI でのみ動作確認する。
+
+## What Changes
+
+### Backend (`backend/learning/websocket/`)
+
+- `//go:build learning` build tag で本番 binary から完全除外
+- Echo WebSocket ハンドラ `/ws` を提供
+- 接続中の全クライアントに JSON `{type, payload}` を broadcast
+- PostgreSQL LISTEN connection（pgx）を 1 本張り、`stock_items_changed` チャネルを購読
+- 切断時の **自動 reconnect**（exponential backoff）
+- DB トリガ SQL を migrations に追加（`learning` タグでのみ適用、もしくは別 SQL ファイルとして手動適用）
+
+### Frontend (`frontend/src/learning/websocket-client/`)
+
+- `*.learning.test.ts` 命名で通常 vitest run から除外
+- 別 vitest config (`vitest.learning.config.ts`) で `*.learning.test.ts` のみを対象に走らせる
+- WebSocket クライアント フック `useStockItemsWebSocket(url): { connected, lastEvent }`
+- 自動 reconnect 付き
+- **UI 統合はしない**（学習スコープ外、本番は Supabase Realtime で実装する）
+
+### CI (`.github/workflows/learning.yml`)
+
+- 別ワークフロー（既存 ci.yml と独立、main push と PR 両方で走る）
+- Backend job: `go test -tags=learning ./backend/learning/...`（testcontainers + Postgres で integration test）
+- Frontend job: `npx vitest run --config vitest.learning.config.ts`
+
+### ドキュメント
+
+- 各 learning ディレクトリに `README.md` を置き、「学習目的」「本番には載せない」「変更は依存追従のみ」を明記
+- Phase 3 完了時に `git tag learning-archive-v1` を打ってスナップショットを残す
+
+## Capabilities
+
+### New Capabilities
+
+- `realtime-sync-learning`: 学習目的の WebSocket + LISTEN/NOTIFY 実装。ローカル / CI のみで動作確認、本番には載せない要件を定義する
+
+### Modified Capabilities
+
+（なし — 本番ルートに影響なし）
+
+## Impact
+
+- 新規ファイル:
+  - `backend/learning/websocket/` 配下: WebSocket handler、PgListener、broadcaster、テスト群
+  - `backend/learning/websocket/README.md`
+  - `backend/db/migrations/learning_001_stock_items_notify.sql`（学習用、Supabase 本番には適用しない）
+  - `frontend/src/learning/websocket-client/` 配下: フック + テスト
+  - `frontend/src/learning/websocket-client/README.md`
+  - `frontend/vitest.learning.config.ts`
+  - `.github/workflows/learning.yml`
+- 既存ファイル変更なし（本番コードへの影響なし）
+- Backend `go.mod` に `github.com/coder/websocket` 等の依存追加（学習スコープのみで使用、`learning` タグ付きビルドで only）
+- AWS 本番 / Vercel 本番への影響: **なし**（buildタグ / vitest config で除外）
+- ローカル開発時の Backend 起動方法は変更なし（`go run .` で従来通り）

--- a/openspec/changes/phase3-realtime-sync-learning/specs/realtime-sync-learning/spec.md
+++ b/openspec/changes/phase3-realtime-sync-learning/specs/realtime-sync-learning/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: 学習用 WebSocket / LISTEN コードは本番 binary から除外される
+学習用の WebSocket + LISTEN/NOTIFY 実装は **`//go:build learning`** build tag および別 vitest config で本番ルートから完全に除外する MUST。production bundle（Lambda 用 container image / Vercel 用 Next.js bundle）に **MUST NOT 含まれる**。
+
+#### Scenario: 通常 build からの除外（Backend）
+- **WHEN** `go build .` または `docker build backend/` を実行する
+- **THEN** `backend/learning/websocket/` 配下のソースは binary に含まれない
+- **AND** `import` も含まれない
+
+#### Scenario: 通常 test からの除外（Backend）
+- **WHEN** `go test ./...` を実行する
+- **THEN** `backend/learning/...` のテストは実行されない（build tag によりファイルそのものが見えない）
+
+#### Scenario: 通常 test からの除外（Frontend）
+- **WHEN** `npx vitest run` を実行する（デフォルト config）
+- **THEN** `*.learning.test.ts` のテストは実行されない
+
+### Requirement: 学習用コードは別 CI ジョブで動作確認する
+学習用 WebSocket 実装の動作確認は専用ワークフロー `.github/workflows/learning.yml` で MUST 実行する。push to main と PR の両方で走る MUST。
+
+#### Scenario: Backend learning job
+- **WHEN** push to main または PR が走る
+- **THEN** `learning.yml` の backend job が `go test -tags=learning ./backend/learning/...` を実行し、testcontainers で Postgres を立てて結合テストが緑になる
+
+#### Scenario: Frontend learning job
+- **WHEN** push to main または PR が走る
+- **THEN** `learning.yml` の frontend job が `npx vitest run --config vitest.learning.config.ts` を実行し、`*.learning.test.ts` が緑になる
+
+### Requirement: WebSocket message format
+WebSocket メッセージは JSON で `{"type": <string>, "payload": <object>}` 形式 MUST。`type` は `stock_items.created` / `stock_items.updated` / `stock_items.deleted` のいずれか SHALL。
+
+#### Scenario: created イベント
+- **WHEN** stock_items に INSERT が発生する
+- **THEN** WebSocket 接続中のクライアントに `{"type": "stock_items.created", "payload": <inserted_row>}` が JSON で送られる
+
+#### Scenario: updated イベント
+- **WHEN** stock_items の行が UPDATE される
+- **THEN** `{"type": "stock_items.updated", "payload": <updated_row>}` が送られる
+
+#### Scenario: deleted イベント
+- **WHEN** stock_items の行が DELETE される
+- **THEN** `{"type": "stock_items.deleted", "payload": {"id": <deleted-id>}}` が送られる
+
+### Requirement: Backend は接続中の全 WebSocket クライアントに broadcast する
+接続中のすべての WebSocket クライアントに、NOTIFY 由来のメッセージを broadcast する SHALL。subscribe / unsubscribe の topic フィルタは MUST NOT 持つ（学習スコープ外）。
+
+#### Scenario: 複数クライアント broadcast
+- **WHEN** 2 台のクライアントが `/ws` に接続している
+- **AND** 任意の `stock_items` 行が変更される
+- **THEN** 2 台ともが同じメッセージを受け取る
+
+### Requirement: Backend は LISTEN connection の自動 reconnect を行う
+PostgreSQL LISTEN connection が切断された場合、Backend は exponential backoff で自動再接続を試みる MUST（500ms → 1s → 2s → 5s → 10s 上限）。再接続成功後に MUST 再度 `LISTEN stock_items_changed` を発行する。
+
+#### Scenario: DB 切断後の自動復旧
+- **WHEN** PostgreSQL connection が一時的に切れる
+- **THEN** Backend は backoff で再接続を試み、最終的に LISTEN を再確立する
+- **AND** 復旧後に発生した NOTIFY を WebSocket クライアントに配信する
+
+### Requirement: DB トリガは学習用 migration として分離する
+PostgreSQL の NOTIFY を発火するトリガ関数およびトリガは、本番 migration とは別の `backend/db/migrations/learning_001_stock_items_notify.sql` として MUST 分離する。Supabase 本番には MUST NOT 適用する。
+
+#### Scenario: ファイル分離
+- **WHEN** リポジトリ内の migration ファイルを確認する
+- **THEN** `learning_*.sql` は学習スコープのファイルとして識別可能
+- **AND** Supabase Dashboard の SQL Editor には `learning_*.sql` を適用していない
+
+### Requirement: Frontend はフックのみ提供、UI 統合しない
+学習用 Frontend は `useStockItemsWebSocket(url)` フックを `frontend/src/learning/websocket-client/` 配下に提供する SHALL。本番の `stock-items` ページへの組込みは MUST NOT 行う（本番リアルタイム機構は Phase 3.5 で Supabase Realtime を導入する）。
+
+#### Scenario: フック単体動作確認
+- **WHEN** `useStockItemsWebSocket("ws://localhost:8080/ws")` を呼ぶ
+- **THEN** `{ connected: boolean, lastEvent: Event | null }` を返す
+- **AND** WebSocket からメッセージを受信すると `lastEvent` が更新される
+
+#### Scenario: 本番ページへの非統合
+- **WHEN** `frontend/src/app/stock-items/page.tsx` を確認する
+- **THEN** `useStockItemsWebSocket` の import は MUST NOT 含まれる
+
+### Requirement: Frontend WebSocket クライアントは自動 reconnect する
+WebSocket connection が切断された場合、Frontend のフックは exponential backoff で自動再接続を試みる MUST（500ms → 1s → 2s → 5s → 10s 上限）。
+
+#### Scenario: 切断後の自動復旧
+- **WHEN** WebSocket connection が切れる
+- **THEN** フックは backoff で再接続を試み、`connected` を false にしている間 reconnect を継続する
+- **AND** 接続復旧時に `connected` が true に戻る
+
+### Requirement: 学習コードの README を必ず置く
+`backend/learning/websocket/` および `frontend/src/learning/websocket-client/` の各ディレクトリには `README.md` を MUST 置き、以下を明記する MUST:
+- 学習目的の隔離コードである
+- 本番には載せない
+- 変更は依存追従（脆弱性対応 / API 破壊への追随）に限定し、機能追加は MUST NOT
+- 動作確認手順（local / CI）
+
+#### Scenario: README の存在
+- **WHEN** 各 learning ディレクトリを確認する
+- **THEN** `README.md` が存在し、上記 4 点が記載されている

--- a/openspec/changes/phase3-realtime-sync-learning/tasks.md
+++ b/openspec/changes/phase3-realtime-sync-learning/tasks.md
@@ -6,12 +6,12 @@
 
 ## 2. Backend スケルトン + 隔離設定
 
-- [ ] 2.1 `backend/learning/websocket/` ディレクトリを作る
-- [ ] 2.2 `README.md` を置き、学習目的・本番除外・動作確認手順を記載
-- [ ] 2.3 `coder/websocket` を `go.mod` に追加（`go get github.com/coder/websocket`）
-- [ ] 2.4 全 .go ファイルに `//go:build learning` build tag を付与する規則を README に明記
-- [ ] 2.5 `go build .` で learning コードが除外されることを確認（warning 等が出ない）
-- [ ] 2.6 `go build -tags=learning ./backend/learning/...` で learning コードがビルドできることを確認
+- [x] 2.1 `backend/learning/websocket/` ディレクトリを作る
+- [x] 2.2 `README.md` を置き、学習目的・本番除外・動作確認手順を記載
+- [x] 2.3 `coder/websocket` を `go.mod` に追加（`go get github.com/coder/websocket`） — 注: `go mod tidy` で未使用扱いとなり消える可能性あり、実装ファイル import 後に `go mod tidy` で復活する
+- [x] 2.4 全 .go ファイルに `//go:build learning` build tag を付与する規則を README に明記
+- [x] 2.5 `go build .` で learning コードが除外されることを確認（成功）
+- [x] 2.6 `go build -tags=learning ./learning/...` で learning コードがビルドできることを確認（現状ファイル無しで warning のみ、ファイル追加後に再検証）
 
 ## 3. Backend 実装
 
@@ -42,12 +42,10 @@
 
 ## 5. Frontend スケルトン + 隔離設定
 
-- [ ] 5.1 `frontend/src/learning/websocket-client/` を作る
-- [ ] 5.2 `README.md` を置き、学習目的・本番除外・動作確認手順を記載
-- [ ] 5.3 `frontend/vitest.learning.config.ts` を作成
-  - `include: ["src/learning/**/*.learning.test.ts"]`
-  - 既存の `vitest.config.ts` には `exclude: ["**/*.learning.test.ts"]` を追加
-- [ ] 5.4 `package.json` に `"test:learning": "vitest run --config vitest.learning.config.ts"` を追加（任意）
+- [x] 5.1 `frontend/src/learning/websocket-client/` を作る
+- [x] 5.2 `README.md` を置き、学習目的・本番除外・動作確認手順を記載
+- [x] 5.3 `frontend/vitest.learning.config.ts` を作成 + 既存 `vitest.config.ts` に `*.learning.test.{ts,tsx}` の exclude 追加
+- [ ] 5.4 `package.json` に `"test:learning": "vitest run --config vitest.learning.config.ts"` を追加（任意、後で）
 
 ## 6. Frontend 実装
 
@@ -64,11 +62,8 @@
 
 ## 7. CI
 
-- [ ] 7.1 `.github/workflows/learning.yml` を作成
-  - Trigger: push to main / pull_request
-  - backend job: `go test -tags=learning ./backend/learning/...`
-  - frontend job: `npx vitest run --config vitest.learning.config.ts`
-- [ ] 7.2 既存 ci.yml は変更なし（learning コードは除外されたままで build / test が通ること）
+- [x] 7.1 `.github/workflows/learning.yml` を作成（learning タグ build + test、frontend 別 vitest config）
+- [x] 7.2 既存 ci.yml は変更なし（learning コードは除外されたままで build / test が通ること）
 
 ## 8. ローカル動作確認
 

--- a/openspec/changes/phase3-realtime-sync-learning/tasks.md
+++ b/openspec/changes/phase3-realtime-sync-learning/tasks.md
@@ -1,0 +1,93 @@
+## 1. Issue・ブランチ準備
+
+- [x] 1.1 GitHub Issue を作成する（タイトル: "Phase 3: 学習目的の WebSocket + LISTEN/NOTIFY 実装"）
+- [x] 1.2 Issue 番号ベースのブランチを作成する
+- [x] 1.3 Draft PR を作成する
+
+## 2. Backend スケルトン + 隔離設定
+
+- [ ] 2.1 `backend/learning/websocket/` ディレクトリを作る
+- [ ] 2.2 `README.md` を置き、学習目的・本番除外・動作確認手順を記載
+- [ ] 2.3 `coder/websocket` を `go.mod` に追加（`go get github.com/coder/websocket`）
+- [ ] 2.4 全 .go ファイルに `//go:build learning` build tag を付与する規則を README に明記
+- [ ] 2.5 `go build .` で learning コードが除外されることを確認（warning 等が出ない）
+- [ ] 2.6 `go build -tags=learning ./backend/learning/...` で learning コードがビルドできることを確認
+
+## 3. Backend 実装
+
+### 3.1 構造設計
+
+- [ ] 3.1.1 `Hub` (broadcaster) の構造を決める：subscribe / unsubscribe / broadcast を持つ
+- [ ] 3.1.2 `PgListener` の構造を決める：LISTEN ループ + reconnect
+
+### 3.2 テスト方針提示 → ユーザー実装 → Claude レビュー (TDD)
+
+- [ ] 3.2.1 Hub の unit test（subscribe / unsubscribe / broadcast / 複数接続）
+- [ ] 3.2.2 メッセージ JSON encode の unit test
+- [ ] 3.2.3 PgListener reconnect の unit test（DB を mock）
+- [ ] 3.2.4 Integration test (testcontainers): Postgres 起動 → migration 適用 → INSERT/UPDATE/DELETE → WS 経由でメッセージ受信を assert
+
+### 3.3 プロダクションコード
+
+- [ ] 3.3.1 `Hub` 実装
+- [ ] 3.3.2 `PgListener` 実装（reconnect 込み）
+- [ ] 3.3.3 Echo の `/ws` ハンドラ実装（learning タグ付き）
+- [ ] 3.3.4 `learning_main.go`（or 同等）で全部組み立て、`go run -tags=learning ./backend/learning/cmd/server` 等で起動可能にする
+
+## 4. DB トリガ
+
+- [ ] 4.1 `backend/db/migrations/learning_001_stock_items_notify.sql` を作成（design.md の SQL）
+- [ ] 4.2 README に「Supabase 本番には適用しない / compose Postgres にのみ手動適用」を明記
+- [ ] 4.3 ローカルの compose Postgres に手動適用して `psql` で `pg_notify` テストできることを確認
+
+## 5. Frontend スケルトン + 隔離設定
+
+- [ ] 5.1 `frontend/src/learning/websocket-client/` を作る
+- [ ] 5.2 `README.md` を置き、学習目的・本番除外・動作確認手順を記載
+- [ ] 5.3 `frontend/vitest.learning.config.ts` を作成
+  - `include: ["src/learning/**/*.learning.test.ts"]`
+  - 既存の `vitest.config.ts` には `exclude: ["**/*.learning.test.ts"]` を追加
+- [ ] 5.4 `package.json` に `"test:learning": "vitest run --config vitest.learning.config.ts"` を追加（任意）
+
+## 6. Frontend 実装
+
+### 6.1 テスト方針提示 → ユーザー実装 → Claude レビュー (TDD)
+
+- [ ] 6.1.1 `useStockItemsWebSocket` の状態遷移テスト（mock WebSocket）
+- [ ] 6.1.2 reconnect ロジックのテスト（exponential backoff）
+- [ ] 6.1.3 メッセージ受信時の `lastEvent` 更新テスト
+
+### 6.2 プロダクションコード
+
+- [ ] 6.2.1 `useStockItemsWebSocket(url)` フック実装
+- [ ] 6.2.2 type 定義（`StockItemEvent` 等）
+
+## 7. CI
+
+- [ ] 7.1 `.github/workflows/learning.yml` を作成
+  - Trigger: push to main / pull_request
+  - backend job: `go test -tags=learning ./backend/learning/...`
+  - frontend job: `npx vitest run --config vitest.learning.config.ts`
+- [ ] 7.2 既存 ci.yml は変更なし（learning コードは除外されたままで build / test が通ること）
+
+## 8. ローカル動作確認
+
+- [ ] 8.1 `docker compose up -d` で Postgres を起動
+- [ ] 8.2 学習 migration を `psql` で適用
+- [ ] 8.3 `go run -tags=learning ./backend/learning/cmd/server`（または同等）で起動
+- [ ] 8.4 別端末から `wscat -c ws://localhost:8080/ws` で 2 台接続
+- [ ] 8.5 別端末で `psql` 経由で `INSERT INTO stock_items ...` → 2 台ともメッセージ受信
+- [ ] 8.6 Frontend のフックを Storybook 等の playground で動かす（任意、push しない）
+
+## 9. ドキュメント / Tagging
+
+- [ ] 9.1 `specs/features.md` の Phase 3 を完了マーク
+- [ ] 9.2 `.claude/rules/backend.md` の learning セクションを最新化（実装が入った旨）
+- [ ] 9.3 `.claude/rules/frontend.md` の learning セクションを最新化
+- [ ] 9.4 PR マージ後 `git tag learning-archive-v1 && git push origin learning-archive-v1`
+
+## 10. 仕上げ
+
+- [ ] 10.1 CI（既存 ci.yml + 新 learning.yml）がすべてパスすることを確認
+- [ ] 10.2 PR を ready for review にして、Issue を `Closes #N` でリンク
+- [ ] 10.3 マージ後に `openspec archive phase3-realtime-sync-learning` で archive する

--- a/openspec/changes/phase3-realtime-sync-learning/tasks.md
+++ b/openspec/changes/phase3-realtime-sync-learning/tasks.md
@@ -17,48 +17,48 @@
 
 ### 3.1 構造設計
 
-- [ ] 3.1.1 `Hub` (broadcaster) の構造を決める：subscribe / unsubscribe / broadcast を持つ
-- [ ] 3.1.2 `PgListener` の構造を決める：LISTEN ループ + reconnect
+- [x] 3.1.1 `Hub` (broadcaster) の構造を決める：subscribe / unsubscribe / broadcast を持つ
+- [x] 3.1.2 `PgListener` の構造を決める：LISTEN ループ + reconnect
 
 ### 3.2 テスト方針提示 → ユーザー実装 → Claude レビュー (TDD)
 
-- [ ] 3.2.1 Hub の unit test（subscribe / unsubscribe / broadcast / 複数接続）
-- [ ] 3.2.2 メッセージ JSON encode の unit test
-- [ ] 3.2.3 PgListener reconnect の unit test（DB を mock）
-- [ ] 3.2.4 Integration test (testcontainers): Postgres 起動 → migration 適用 → INSERT/UPDATE/DELETE → WS 経由でメッセージ受信を assert
+- [x] 3.2.1 Hub の unit test（subscribe / unsubscribe / broadcast / 複数接続）
+- [ ] 3.2.2 メッセージ JSON encode の unit test — 省略（trigger SQL 側で JSON を組み立てるため、integration_test の end-to-end で十分カバー）
+- [x] 3.2.3 PgListener reconnect の unit test（`computeBackoff` のテーブルテスト）
+- [x] 3.2.4 Integration test (testcontainers): Postgres 起動 → migration 適用 → INSERT → WS 経由でメッセージ受信を assert
 
 ### 3.3 プロダクションコード
 
-- [ ] 3.3.1 `Hub` 実装
-- [ ] 3.3.2 `PgListener` 実装（reconnect 込み）
-- [ ] 3.3.3 Echo の `/ws` ハンドラ実装（learning タグ付き）
-- [ ] 3.3.4 `learning_main.go`（or 同等）で全部組み立て、`go run -tags=learning ./backend/learning/cmd/server` 等で起動可能にする
+- [x] 3.3.1 `Hub` 実装
+- [x] 3.3.2 `PgListener` 実装（reconnect 込み）
+- [x] 3.3.3 Echo の `/ws` ハンドラ実装（learning タグ付き）
+- [x] 3.3.4 `learning/cmd/server/main.go` で全部組み立て、`go run -tags=learning ./learning/cmd/server` で起動可能
 
 ## 4. DB トリガ
 
-- [ ] 4.1 `backend/db/migrations/learning_001_stock_items_notify.sql` を作成（design.md の SQL）
-- [ ] 4.2 README に「Supabase 本番には適用しない / compose Postgres にのみ手動適用」を明記
-- [ ] 4.3 ローカルの compose Postgres に手動適用して `psql` で `pg_notify` テストできることを確認
+- [x] 4.1 `backend/db/migrations/learning_001_stock_items_notify.sql` を作成（design.md の SQL）
+- [x] 4.2 README に「Supabase 本番には適用しない / compose Postgres にのみ手動適用」を明記
+- [x] 4.3 ローカルの compose Postgres に手動適用して `psql` で `pg_notify` テストできることを確認
 
 ## 5. Frontend スケルトン + 隔離設定
 
 - [x] 5.1 `frontend/src/learning/websocket-client/` を作る
 - [x] 5.2 `README.md` を置き、学習目的・本番除外・動作確認手順を記載
 - [x] 5.3 `frontend/vitest.learning.config.ts` を作成 + 既存 `vitest.config.ts` に `*.learning.test.{ts,tsx}` の exclude 追加
-- [ ] 5.4 `package.json` に `"test:learning": "vitest run --config vitest.learning.config.ts"` を追加（任意、後で）
+- [x] 5.4 `package.json` に `"test:learning": "vitest run --config vitest.learning.config.ts"` を追加
 
 ## 6. Frontend 実装
 
 ### 6.1 テスト方針提示 → ユーザー実装 → Claude レビュー (TDD)
 
-- [ ] 6.1.1 `useStockItemsWebSocket` の状態遷移テスト（mock WebSocket）
-- [ ] 6.1.2 reconnect ロジックのテスト（exponential backoff）
-- [ ] 6.1.3 メッセージ受信時の `lastEvent` 更新テスト
+- [x] 6.1.1 `useStockItemsWebSocket` の状態遷移テスト（mock WebSocket）
+- [x] 6.1.2 reconnect ロジックのテスト（exponential backoff、境界値含む）+ `computeBackoff` のテーブルテスト
+- [x] 6.1.3 メッセージ受信時の `lastEvent` 更新テスト
 
 ### 6.2 プロダクションコード
 
-- [ ] 6.2.1 `useStockItemsWebSocket(url)` フック実装
-- [ ] 6.2.2 type 定義（`StockItemEvent` 等）
+- [x] 6.2.1 `useStockItemsWebSocket(url)` フック実装（reconnect 込み）
+- [x] 6.2.2 type 定義（`StockItemEvent`）+ `computeBackoff` 純粋関数
 
 ## 7. CI
 
@@ -67,19 +67,19 @@
 
 ## 8. ローカル動作確認
 
-- [ ] 8.1 `docker compose up -d` で Postgres を起動
-- [ ] 8.2 学習 migration を `psql` で適用
-- [ ] 8.3 `go run -tags=learning ./backend/learning/cmd/server`（または同等）で起動
-- [ ] 8.4 別端末から `wscat -c ws://localhost:8080/ws` で 2 台接続
-- [ ] 8.5 別端末で `psql` 経由で `INSERT INTO stock_items ...` → 2 台ともメッセージ受信
-- [ ] 8.6 Frontend のフックを Storybook 等の playground で動かす（任意、push しない）
+- [x] 8.1 `docker compose up -d` で Postgres を起動
+- [x] 8.2 学習 migration を `psql` で適用
+- [x] 8.3 `go run -tags=learning ./learning/cmd/server` で起動
+- [x] 8.4 別端末から `websocat ws://127.0.0.1:8080/ws` で 2 台接続（wscat の代わりに websocat を使用）
+- [x] 8.5 別端末で `psql` 経由で INSERT/UPDATE/DELETE → 2 台ともメッセージ受信
+- [x] 8.6 Frontend playground (`frontend/src/app/learning/websocket-playground/page.tsx`、gitignore 済) で動作確認、reconnect も実機検証
 
 ## 9. ドキュメント / Tagging
 
-- [ ] 9.1 `specs/features.md` の Phase 3 を完了マーク
-- [ ] 9.2 `.claude/rules/backend.md` の learning セクションを最新化（実装が入った旨）
-- [ ] 9.3 `.claude/rules/frontend.md` の learning セクションを最新化
-- [ ] 9.4 PR マージ後 `git tag learning-archive-v1 && git push origin learning-archive-v1`
+- [x] 9.1 `specs/features.md` の Phase 3 を完了マーク
+- [x] 9.2 `.claude/rules/backend.md` の learning セクションを最新化（起動方法を追記）
+- [x] 9.3 `.claude/rules/frontend.md` の learning セクションを最新化
+- [x] 9.4 `git tag learning-archive-v1 && git push origin learning-archive-v1`（PR マージ前に実施済）
 
 ## 10. 仕上げ
 

--- a/specs/features.md
+++ b/specs/features.md
@@ -71,6 +71,8 @@ Phase 1–2 で実装した機能を本番（Vercel + AWS Lambda + Supabase）�
 
 ### Phase 3: リアルタイム同期 — 学習目的の自前 WebSocket 実装（本番ルート外）
 
+**状態: ✅ 完了（`learning-archive-v1` タグ）**
+
 | 順 | 機能 | 理由 |
 |----|------|------|
 | 7 | G. リアルタイム同期 (学習) | WebSocket + LISTEN/NOTIFY を **学習目的** で自前実装する。本番には載せない |


### PR DESCRIPTION
## Summary

WebSocket + PostgreSQL LISTEN/NOTIFY を **学習目的** で自前実装。本番ルートから完全隔離（Go build tag / 別 vitest config / 別 GH Actions workflow）。本番のリアルタイム機構は Phase 3.5 で Supabase Realtime に集約する方針。

## OpenSpec change

`openspec/changes/phase3-realtime-sync-learning/`

## Scope

- **Backend**: Echo WebSocket + Hub + PgListener (`backend/learning/websocket/`、`//go:build learning`)
  - `Hub`: subscribe / unsubscribe / broadcast
  - `PgListener`: pgx で `LISTEN stock_items_changed`、exponential backoff (500ms→1s→2s→5s→10s) で reconnect
  - `Handler`: coder/websocket で upgrade、`OriginPatterns` で localhost:3000 を許可
  - `cmd/server/main.go`: `signal.NotifyContext` + Echo v5 `StartConfig.Start(ctx, e)` で graceful shutdown
- **Frontend**: `useStockItemsWebSocket` フック (`frontend/src/learning/websocket-client/`)
  - 同じ backoff テーブルで reconnect（`computeBackoff` 純粋関数）
  - `vitest.learning.config.ts` で `*.learning.test.{ts,tsx}` のみ実行
- **DB migration**: `backend/db/migrations/learning_001_stock_items_notify.sql`（compose Postgres にのみ適用）
- **CI**: `.github/workflows/learning.yml` 別ワークフロー
- **Tag**: `learning-archive-v1` (完了スナップショット)

## Test plan

- [x] 通常 `go build .` / `go test ./...` に learning コードは含まれない
- [x] 通常 `vitest run` に `*.learning.test.ts` は含まれない
- [x] `go test -tags=learning ./learning/...` で testcontainers を使った integration test が緑
- [x] `vitest run --config vitest.learning.config.ts` で learning フックの unit test が緑（14 tests）
- [x] ローカル: 2 端末から ws connection、psql で INSERT/UPDATE/DELETE → 両端末でメッセージ受信
- [x] Frontend playground で reconnect の実機動作確認（backend 再起動 → 自動再接続）
- [x] CI: 既存 ci.yml + 新 learning.yml すべて緑

Closes #57