### PR TITLE
Allow wildcard patterns in CORS_ALLOWED_ORIGINS for Vercel previews

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/IsaoTakahashi/pantry-panel/backend/db"
@@ -30,9 +32,19 @@ func main() {
 	stockItemRepo := repository.NewPgStockItemRepository(pool)
 	stockItemHandler := handler.NewStockItemHandler(stockItemRepo)
 
+	matcher, err := compileOriginMatcher(parseCORSAllowedOrigins(os.Getenv("CORS_ALLOWED_ORIGINS")))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	e := echo.New()
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
-		AllowOrigins: parseCORSAllowedOrigins(os.Getenv("CORS_ALLOWED_ORIGINS")),
+		UnsafeAllowOriginFunc: func(c *echo.Context, origin string) (string, bool, error) {
+			if matcher(origin) {
+				return origin, true, nil
+			}
+			return "", false, nil
+		},
 	}))
 
 	e.GET("/health", handler.HealthCheck(pool))
@@ -68,4 +80,42 @@ func parseCORSAllowedOrigins(env string) []string {
 		return []string{"http://localhost:3000"}
 	}
 	return out
+}
+
+func compileOriginMatcher(patterns []string) (func(origin string) bool, error) {
+	type rule struct {
+		exact string
+		regex *regexp.Regexp
+	}
+
+	rules := make([]rule, 0, len(patterns))
+	for _, p := range patterns {
+		lower := strings.ToLower(p)
+		if !strings.Contains(lower, "*") {
+			rules = append(rules, rule{exact: lower})
+			continue
+		}
+
+		escaped := regexp.QuoteMeta(lower)
+		regexStr := strings.ReplaceAll(escaped, `\*`, `[^.]*`)
+		compiled, err := regexp.Compile("^" + regexStr + "$")
+		if err != nil {
+			return nil, fmt.Errorf("invalid CORS pattern %q: %w", p, err)
+		}
+		rules = append(rules, rule{regex: compiled})
+	}
+
+	return func(origin string) bool {
+		lower := strings.ToLower(origin)
+		for _, r := range rules {
+			if r.regex != nil {
+				if r.regex.MatchString(lower) {
+					return true
+				}
+			} else if r.exact == lower {
+				return true
+			}
+		}
+		return false
+	}, nil
 }

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"slices"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParsePort(t *testing.T) {
@@ -69,6 +72,82 @@ func TestParseCORSAllowedOrigins(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := parseCORSAllowedOrigins(tt.env); !slices.Equal(got, tt.expected) {
 				t.Errorf("parseCORSAllowedOrigins(%q) = %v, want %v", tt.env, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCompileOriginMatcher(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []string
+		origins  []string
+		wants    []bool
+	}{
+		{
+			name:     "exact match allows the same origin",
+			patterns: []string{"https://example.com"},
+			origins:  []string{"https://example.com"},
+			wants:    []bool{true},
+		},
+		{
+			name:     "exact match is case insensitive",
+			patterns: []string{"https://Example.com"},
+			origins:  []string{"https://example.com"},
+			wants:    []bool{true},
+		},
+		{
+			name:     "exact match rejects different origin",
+			patterns: []string{"https://Example.com"},
+			origins:  []string{"https://other.com"},
+			wants:    []bool{false},
+		},
+		{
+			name:     "wildcard matches a single segment",
+			patterns: []string{"https://app-*.vercel.app"},
+			origins:  []string{"https://app-abc123.vercel.app"},
+			wants:    []bool{true},
+		},
+		{
+			name:     "wildcard does not span dots",
+			patterns: []string{"https://app-*.vercel.app"},
+			origins:  []string{"https://app-evil.attacker.com.vercel.app"},
+			wants:    []bool{false},
+		},
+		{
+			name:     "wildcard rejects non-matching origin",
+			patterns: []string{"https://app-*.vercel.app"},
+			origins:  []string{"https://other-abc.vercel.app"},
+			wants:    []bool{false},
+		},
+		{
+			name:     "mixed exact and wildcard patterns",
+			patterns: []string{"https://app-123.vercel.app", "https://app-*.vercel.app"},
+			origins:  []string{"https://app-123.vercel.app", "https://app-abc123.vercel.app", "https://app.vercel.app"},
+			wants:    []bool{true, true, false},
+		},
+		{
+			name:     "empty patterns rejects everything",
+			patterns: []string{},
+			origins:  []string{"https://other-abc.vercel.app"},
+			wants:    []bool{false},
+		},
+		{
+			name:     "vercel preview url is allowed",
+			patterns: []string{"https://pantry-panel-*-rictons-projects.vercel.app"},
+			origins:  []string{"https://pantry-panel-6how12g71-rictons-projects.vercel.app"},
+			wants:    []bool{true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher, err := compileOriginMatcher(tt.patterns)
+			require.NoError(t, err)
+
+			require.Equal(t, len(tt.origins), len(tt.wants), "test data: origins/wants length mismatch")
+			for i, origin := range tt.origins {
+				assert.Equalf(t, tt.wants[i], matcher(origin), "origin=%q", origin)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Vercel preview deploy された frontend から AWS Lambda backend に接続できるよう、`CORS_ALLOWED_ORIGINS` env var で `*` wildcard パターンをサポートする。

Preview URL は `https://pantry-panel-<hash>-rictons-projects.vercel.app` の形式で、`<hash>` 部分が deploy 毎に変わるため、固定 origin の許可リストでは対応できなかった。

## Changes

- `backend/main.go`
  - `compileOriginMatcher` を追加: パターンに `*` を含む場合は wildcard マッチ、含まない場合は完全一致（case-insensitive）
  - `*` は `[^.]*` 相当（`.` を跨がない）→ subdomain takeover 防止
  - Echo の `UnsafeAllowOriginFunc` 経由で利用
- `backend/main_test.go`
  - `TestCompileOriginMatcher` でテーブルテストを追加
  - exact match / case-insensitive / wildcard / dot-spanning 拒否 / 混在パターン / 空入力 / Vercel preview URL の各ケースを網羅

## Lambda env var update (after merge)

main マージ後、Lambda の `CORS_ALLOWED_ORIGINS` を以下に更新する必要がある（手動）：

```
http://localhost:3000,https://pantry-panel-xi.vercel.app,https://pantry-panel-*-rictons-projects.vercel.app,https://pantry-panel-git-*-rictons-projects.vercel.app
```

## Test plan

- [x] `go test ./.` で 16 テスト全 pass
- [x] ローカルで起動し、curl で各 origin の preflight レスポンスを確認:
  - exact match (`http://localhost:3000`) → `Access-Control-Allow-Origin` 返る
  - wildcard match (`https://pantry-panel-6how12g71-rictons-projects.vercel.app`) → ヘッダ返る
  - subdomain takeover 試行 → ヘッダなし
  - random origin → ヘッダなし
- [ ] CI 全 pass
- [ ] main マージ後、Lambda の env var を更新
- [ ] Phase 3 ブランチの Vercel preview から backend へ通信できることを確認

Closes #59