### PR TITLE
Document CORS wildcard support

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -56,7 +56,7 @@ main への push で **`.github/workflows/deploy-backend.yml`** が自動実行�
 2. **ビルド**: GH Actions が `docker buildx build --platform linux/amd64 --provenance=false --push ...` を実行（Lambda 互換 manifest のため `--provenance=false` 必須）
 3. **ECR push**: `pantry-panel-backend` リポジトリ (`ap-northeast-1`)、タグは `${{ github.sha }}` と `latest`
 4. **Lambda Function**: container image source、Memory 512 MB、Timeout 30s、`x86_64`、IAM Role: `pantry-panel-lambda-role`
-5. **環境変数 (Lambda)**: `PORT=8080`、`AWS_LWA_PORT=8080`、`AWS_LWA_READINESS_CHECK_PATH=/health`、`CORS_ALLOWED_ORIGINS=...`、`DATABASE_URL=<pooler URL>`（KMS で暗号化保存）
+5. **環境変数 (Lambda)**: `PORT=8080`、`AWS_LWA_PORT=8080`、`AWS_LWA_READINESS_CHECK_PATH=/health`、`CORS_ALLOWED_ORIGINS=...`、`DATABASE_URL=<pooler URL>`（KMS で暗号化保存）。`CORS_ALLOWED_ORIGINS` は **wildcard `*` 対応**（`*` は `.` を跨がない）。Vercel preview URL は `https://pantry-panel-*-rictons-projects.vercel.app` のようにパターンで指定する
 6. **Function URL**: AuthType=NONE、CORS は **空 `{}`**（Echo の CORS middleware に一本化）
 7. **resource policy**: `lambda:InvokeFunctionUrl` + `lambda:InvokeFunction` の両方を Principal `*` に許可（過剰権限の TODO あり、後日強化予定）
 

--- a/openspec/specs/production-backend-runtime/spec.md
+++ b/openspec/specs/production-backend-runtime/spec.md
@@ -33,7 +33,7 @@ Backend は `PORT` 環境変数を読み取り、その値で listen する SHAL
 - **AND** LWA は `AWS_LWA_PORT=8080` で同じポートを参照する
 
 ### Requirement: Backend は CORS_ALLOWED_ORIGINS 環境変数で CORS 許可 origin を切り替える（既存）
-Backend は `CORS_ALLOWED_ORIGINS`（カンマ区切り）を読み取り、Echo の CORS middleware の `AllowOrigins` に設定する SHALL。未設定時は `http://localhost:3000` を使用する MUST。**本番環境では Vercel の本番 URL を MUST 含める**。
+Backend は `CORS_ALLOWED_ORIGINS`（カンマ区切り）を読み取り、Echo の CORS middleware の `UnsafeAllowOriginFunc` に渡す自前 matcher で照合する SHALL。各エントリは exact match（case-insensitive）か、`*` を含む場合は wildcard match として扱う MUST。`*` は `.` を跨がない（subdomain 跨ぎを防ぐため `[^.]*` 相当） MUST。未設定時は `http://localhost:3000` を使用する MUST。**本番環境では Vercel の本番 URL を MUST 含める**。
 
 #### Scenario: 単一 origin
 - **WHEN** Backend を `CORS_ALLOWED_ORIGINS=https://example.vercel.app` で起動する
@@ -50,6 +50,15 @@ Backend は `CORS_ALLOWED_ORIGINS`（カンマ区切り）を読み取り、Echo
 #### Scenario: 本番では Vercel URL を含む
 - **WHEN** Lambda の `CORS_ALLOWED_ORIGINS` 環境変数を確認する
 - **THEN** Vercel 本番 URL（例: `https://pantry-panel-xxxxx.vercel.app`）が含まれる
+
+#### Scenario: Vercel preview URL を wildcard で許可
+- **WHEN** Backend を `CORS_ALLOWED_ORIGINS=https://pantry-panel-*-rictons-projects.vercel.app` で起動する
+- **THEN** `https://pantry-panel-6how12g71-rictons-projects.vercel.app` からのリクエストに対応する CORS ヘッダを返す
+- **AND** `https://pantry-panel-evil.attacker.com-rictons-projects.vercel.app`（`.` を跨ぐ攻撃的 origin）はブロックする
+
+#### Scenario: 不許可 origin はヘッダなし
+- **WHEN** 許可されていない origin からプリフライトリクエストが来る
+- **THEN** `Access-Control-Allow-Origin` ヘッダを返さない（ブラウザ側でブロック）
 
 ### Requirement: Function URL は HTTPS で外部から到達可能
 Lambda Function URL（`https://<id>.lambda-url.ap-northeast-1.on.aws`）から HTTPS で API が応答する SHALL。Auth Type は初期構築では `NONE`（公開、後段で CORS により origin 制限）MUST とする。


### PR DESCRIPTION
## Summary

PR #60 でマージした CORS wildcard 対応をドキュメントに反映する。

## Changes

- `openspec/specs/production-backend-runtime/spec.md`
  - CORS Requirement の説明文を更新（`AllowOrigins` 直渡し → `UnsafeAllowOriginFunc` + 自前 matcher）
  - `*` は `.` を跨がない（subdomain 跨ぎ防止）を明記
  - 新 Scenario: Vercel preview URL を wildcard で許可 + dot-spanning 試行はブロック
  - 新 Scenario: 不許可 origin はヘッダなし
- `.claude/rules/backend.md`
  - Lambda 環境変数の項に wildcard 対応の補足を追加

## Test plan

- [x] PR #60 のローカル動作確認で wildcard / dot-spanning 拒否を検証済
- [x] PR #60 のユニットテスト 9 ケースで網羅
- [ ] CI 全 pass