### PR TITLE
Reduce token usage in .claude/rules

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -1,3 +1,7 @@
+---
+paths:
+  - "backend/**"
+---
 # Backend
 
 ## 技術スタック

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,3 +1,7 @@
+---
+paths:
+  - "frontend/**"
+---
 # Frontend
 
 ## 技術スタック

--- a/.claude/rules/general.md
+++ b/.claude/rules/general.md
@@ -24,65 +24,20 @@ AWS マネージドサービスを利用する。
 
 ## テスト戦略
 
-テストピラミッドに従い、Unit を厚く、E2E を薄く保つ。
-
-```
-        /  E2E  \         ← 少数: 主要ユーザーフロー + リアルタイム同期
-       /----------\
-      / Integration \      ← 中程度: DB操作、API結合
-     /----------------\
-    /      Unit        \   ← 多数: ロジック、バリデーション、コンポーネント
-```
-
-詳細は各 rules ファイル（frontend.md, backend.md）を参照。
+Unit を厚く、Integration 中程度、E2E を薄く保つ（テストピラミッド）。詳細は frontend.md / backend.md 参照。
 
 ## CI (GitHub Actions)
 
-### ci.yml — push to main / pull_request
-
-frontend と backend を**並列ジョブ**で実行。各ジョブ内は lint → test の順で直列（lint 失敗で早期終了）。
-
-| Job | Steps |
-|-----|-------|
-| frontend | Biome (lint + format) → tsc (型チェック) → Vitest (unit test) |
-| backend | golangci-lint → go test (unit) → testcontainers + PG (integration) |
-
-### e2e.yml — pull_request (main へのマージ時のみ)
-
-backend + DB (testcontainers) + frontend を起動し、Playwright で E2E テストを実行。実行コストが高いため main への PR 時のみに限定する。
-
-### deploy-backend.yml — push to main (`backend/**`) / workflow_dispatch
-
-OIDC で `pantry-panel-deploy-role` を assume → ECR build & push (`linux/amd64`、`provenance=false`) → `aws lambda update-function-code` → `function-updated` waiter → `/health` smoke test。3 ジョブ直列。`backend/` 配下の変更時のみトリガ。手動再実行は `workflow_dispatch`。
+- **ci.yml**: frontend (Biome → tsc → Vitest) / backend (golangci-lint → go test → testcontainers) を並列実行
+- **e2e.yml**: main への PR 時のみ Playwright E2E
+- **deploy-backend.yml**: `backend/**` push → ECR → Lambda 自動デプロイ（OIDC、`workflow_dispatch` で手動再実行可）
 
 ## ブランチ・Issue・PR の運用
 
-### フロー
-
-| Step | 作業 | 担当 |
-|------|------|------|
-| 1 | やりたいことを提示 | ユーザー |
-| 2 | 意図の深堀り・goal 提案 | Claude |
-| 3 | goal 合意 → GitHub Issue 作成 | Claude |
-| 4 | Issue ベースでブランチ作成 | Claude |
-| 5 | 作業開始、早期に Draft PR 作成 | 協業 |
-| 6 | goal 変更時は Issue を更新 | 都度 |
-| 7 | PR マージで Issue 自動クローズ | Claude |
-
-### ルール
-
 - ブランチ名: `{issue番号}-{概要}`（例: `4-stock-item-crud`）
-- PR 本文に `Closes #N` を記載し、マージ時に Issue を自動クローズする
-- 作業が長期化する場合は Draft PR を早めに作成し、CI 実行と進捗の可視化に活用する
-
-### Epic / Sub-Issue
-
-大きなテーマは Epic Issue（親）と Sub-Issue（子）に分割して管理する。
-
-- **Epic Issue**: テーマの全体像を記述し、タスクリストで Sub-Issue を参照する
-- **Sub-Issue**: 各 Sub-Issue が独自のブランチ・PR を持つ。PR は main にマージする
-- **粒度の目安**: 1 Issue = 1 PR でレビュー可能なサイズ（目安: 差分 300 行以内）
-- **Epic のクローズ**: 全 Sub-Issue がクローズされたら Epic をクローズする
+- PR 本文に `Closes #N` でマージ時に Issue 自動クローズ
+- 大きなテーマは Epic（親）と Sub-Issue（子）に分割。1 Issue = 1 PR、差分 300 行以内目安
+- 作業が長期化する場合は Draft PR を早めに作成
 
 ## 旧仕様の参照
 
@@ -102,20 +57,6 @@ TypeScript / Go の実装はユーザーがメインで記述する（言語・F
 | 4.5 | 動作確認（サーバー起動、手動テスト） | ユーザーが実施 |
 | 5 | リファクタリング | 協業（観点を事前に明示） |
 
-### 各ステップの補足
-
-- **Step 1.5**: API のリクエスト/レスポンス型、コンポーネントの props/state 型、DB テーブルスキーマを先に定義する。テスト設計の前提を明確にするため。
-- **Step 3**: Claude はテストで使うべきライブラリ、アサーション手法、モック手法を提示する。ユーザーがテストコードを書くことで言語・FW の学習効果を高める。
-- **Step 4**: Claude はレビュー時に、利用すべき言語・FW 機能も提案する。
-- **Step 4.5**: ユニットテストでは検出できない問題（WebSocket 接続、CORS、DB 接続など）を手動で確認する。
-- **Step 5**: リファクタリングの観点 — 命名の一貫性、責務の分離、エラーハンドリングの網羅性、テストの可読性。
-
 ### Claude の提案ルール
 
-- 可能な限り複数の選択肢を提示する
-- 複数提案がある場合、理由付きで最も推奨する選択肢を明示する
-
-### 動作確認の環境
-
-- 当面はローカルの作業環境でサーバー起動などを行い動作確認する
-- 将来的には Docker Compose やAWS 上の preview 環境を用意し、環境依存を減らす
+- 可能な限り複数の選択肢を提示し、理由付きで推奨を明示する

--- a/.claude/rules/overview.md
+++ b/.claude/rules/overview.md
@@ -26,8 +26,6 @@
 | Database | Supabase Postgres（Lambda は **Supavisor Session Pooler** 経由で接続、IPv4） |
 | インフラ | Vercel + AWS Lambda + Supabase |
 
-> 経緯: 当初 Backend は AWS App Runner / ECS Express Mode を予定したが、新規受付停止やコスト等の理由で Lambda + LWA に変更した（詳細は `openspec/changes/archive/` 参照）。
-
 ## リアルタイム同期の仕組み
 
 旧製品の Firebase Realtime Database を **Supabase Realtime** で再現する。Backend は介在せず、Frontend が Supabase Realtime に直接購読して Postgres の変更を受信する。
@@ -42,12 +40,3 @@
 - 変更検知時に画面を更新（or REST 再取得）
 - Backend は CRUD REST API のみ。リアルタイム経路には関与しない
 
-## デプロイ
-
-| 環境 | サービス | 備考 |
-|------|----------|------|
-| Frontend | Vercel | Next.js native、無料枠 |
-| Backend | AWS Lambda + LWA | container image (ECR)、Function URL で公開、Free Tier ~月 \$0 |
-| DB | Supabase | 無料枠。Lambda は **Supavisor Session Pooler (5432, IPv4)** 経由で接続 |
-
-初回デプロイは Phase 2.5（Phase 2 完了直後・Phase 3 着手前）で行う。詳細は `specs/features.md` を参照。


### PR DESCRIPTION
## Summary

- `frontend.md` / `backend.md` に `paths:` フロントマターを追加し、該当ディレクトリのファイルを Read したときのみロードされるよう変更（常時 ~4.3k トークンを削減）
- `general.md` のCI詳細・ブランチフロー表・開発フロー補足を圧縮（121行 → 62行）
- `overview.md` の歴史的経緯・デプロイ表を削除（53行 → 42行）

## Token savings

| ファイル | 変更前 | 変更後 |
|---------|--------|--------|
| frontend.md | 常時 ~1.4k tokens | frontend/ 作業時のみ |
| backend.md | 常時 ~2.9k tokens | backend/ 作業時のみ |
| general.md | ~2k tokens | ~0.7k tokens |
| overview.md | ~859 tokens | ~650 tokens |