### PR TITLE
Prefill CreateItemModal with filter conditions on open

### DIFF
--- a/backend/handler/stock_item.go
+++ b/backend/handler/stock_item.go
@@ -14,8 +14,9 @@ import (
 )
 
 type CreateStockItemRequest struct {
-	Name     string `json:"name"`
-	Category string `json:"category"`
+	Name      string `json:"name"`
+	Category  string `json:"category"`
+	WantToBuy *bool  `json:"wantToBuy"`
 }
 
 type UpdateStockItemRequest struct {
@@ -56,7 +57,7 @@ func (h *StockItemHandler) Create(c *echo.Context) error {
 		return c.JSON(http.StatusBadRequest, ErrorResponse{Message: "Name and category are required"})
 	}
 
-	item, err := h.repo.Create(c.Request().Context(), req.Name, req.Category)
+	item, err := h.repo.Create(c.Request().Context(), req.Name, req.Category, req.WantToBuy)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {

--- a/backend/handler/stock_item_test.go
+++ b/backend/handler/stock_item_test.go
@@ -23,7 +23,7 @@ import (
 type mockStockItemRepo struct {
 	listFn   func(ctx context.Context) ([]repository.StockItem, error)
 	getFn    func(ctx context.Context, id uuid.UUID) (*repository.StockItem, error)
-	createFn func(ctx context.Context, name, category string) (*repository.StockItem, error)
+	createFn func(ctx context.Context, name, category string, wantToBuy *bool) (*repository.StockItem, error)
 	updateFn func(ctx context.Context, id uuid.UUID, params repository.UpdateParams) (*repository.StockItem, error)
 	deleteFn func(ctx context.Context, id uuid.UUID) error
 }
@@ -34,8 +34,8 @@ func (m *mockStockItemRepo) List(ctx context.Context) ([]repository.StockItem, e
 func (m *mockStockItemRepo) Get(ctx context.Context, id uuid.UUID) (*repository.StockItem, error) {
 	return m.getFn(ctx, id)
 }
-func (m *mockStockItemRepo) Create(ctx context.Context, name, category string) (*repository.StockItem, error) {
-	return m.createFn(ctx, name, category)
+func (m *mockStockItemRepo) Create(ctx context.Context, name, category string, wantToBuy *bool) (*repository.StockItem, error) {
+	return m.createFn(ctx, name, category, wantToBuy)
 }
 func (m *mockStockItemRepo) Update(ctx context.Context, id uuid.UUID, params repository.UpdateParams) (*repository.StockItem,
 	error) {
@@ -129,7 +129,7 @@ func TestCreate_Success(t *testing.T) {
 		UpdatedAt: now,
 	}
 	mock := &mockStockItemRepo{
-		createFn: func(ctx context.Context, name, category string) (*repository.StockItem, error) {
+		createFn: func(ctx context.Context, name, category string, wantToBuy *bool) (*repository.StockItem, error) {
 			assert.Equal(t, "醤油", name)
 			assert.Equal(t, "調味料", category)
 			return expected, nil
@@ -155,9 +155,43 @@ func TestCreate_Success(t *testing.T) {
 	assert.Equal(t, expected.WantToBuy, body.WantToBuy)
 }
 
+func TestCreate_WithWantToBuyTrue(t *testing.T) {
+	now := time.Now()
+	expected := &repository.StockItem{
+		ID:        uuid.New(),
+		Name:      "醤油",
+		Category:  "調味料",
+		WantToBuy: true,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	mock := &mockStockItemRepo{
+		createFn: func(ctx context.Context, name, category string, wantToBuy *bool) (*repository.StockItem, error) {
+			require.NotNil(t, wantToBuy)
+			assert.True(t, *wantToBuy)
+			return expected, nil
+		},
+	}
+	h := NewStockItemHandler(mock)
+	e := setupRouter(h)
+
+	reqBody := strings.NewReader(`{"name": "醤油", "category": "調味料", "wantToBuy": true}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/stock-items", reqBody)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	var body repository.StockItem
+	err := json.NewDecoder(rec.Body).Decode(&body)
+	require.NoError(t, err)
+	assert.True(t, body.WantToBuy)
+}
+
 func TestCreate_EmptyName(t *testing.T) {
 	mock := &mockStockItemRepo{
-		createFn: func(ctx context.Context, name, category string) (*repository.StockItem, error) {
+		createFn: func(ctx context.Context, name, category string, wantToBuy *bool) (*repository.StockItem, error) {
 			return nil, nil
 		},
 	}
@@ -175,7 +209,7 @@ func TestCreate_EmptyName(t *testing.T) {
 
 func TestCreate_EmptyCategory(t *testing.T) {
 	mock := &mockStockItemRepo{
-		createFn: func(ctx context.Context, name, category string) (*repository.StockItem, error) {
+		createFn: func(ctx context.Context, name, category string, wantToBuy *bool) (*repository.StockItem, error) {
 			return nil, nil
 		},
 	}
@@ -193,7 +227,7 @@ func TestCreate_EmptyCategory(t *testing.T) {
 
 func TestCreate_DuplicateName(t *testing.T) {
 	mock := &mockStockItemRepo{
-		createFn: func(ctx context.Context, name, category string) (*repository.StockItem, error) {
+		createFn: func(ctx context.Context, name, category string, wantToBuy *bool) (*repository.StockItem, error) {
 			return nil, &pgconn.PgError{Code: "23505"}
 		},
 	}

--- a/backend/repository/stock_item.go
+++ b/backend/repository/stock_item.go
@@ -20,7 +20,7 @@ type StockItem struct {
 type StockItemRepository interface {
 	List(ctx context.Context) ([]StockItem, error)
 	Get(ctx context.Context, id uuid.UUID) (*StockItem, error)
-	Create(ctx context.Context, name, category string) (*StockItem, error)
+	Create(ctx context.Context, name, category string, wantToBuy *bool) (*StockItem, error)
 	Update(ctx context.Context, id uuid.UUID, params UpdateParams) (*StockItem, error)
 	Delete(ctx context.Context, id uuid.UUID) error
 }

--- a/backend/repository/stock_item_pg.go
+++ b/backend/repository/stock_item_pg.go
@@ -30,10 +30,10 @@ func (r *PgStockItemRepository) Get(ctx context.Context, id uuid.UUID) (*StockIt
 	return pgx.CollectExactlyOneRow(rows, pgx.RowToAddrOfStructByName[StockItem])
 }
 
-func (r *PgStockItemRepository) Create(ctx context.Context, name, category string) (*StockItem, error) {
+func (r *PgStockItemRepository) Create(ctx context.Context, name, category string, wantToBuy *bool) (*StockItem, error) {
 	rows, _ := r.pool.Query(ctx,
-		"INSERT INTO stock_items (name, category) VALUES ($1, $2) RETURNING id, name, category, image_url, want_to_buy, created_at, updated_at",
-		name, category)
+		"INSERT INTO stock_items (name, category, want_to_buy) VALUES ($1, $2, COALESCE($3, false)) RETURNING id, name, category, image_url, want_to_buy, created_at, updated_at",
+		name, category, wantToBuy)
 
 	return pgx.CollectExactlyOneRow(rows, pgx.RowToAddrOfStructByName[StockItem])
 }

--- a/backend/repository/stock_item_test.go
+++ b/backend/repository/stock_item_test.go
@@ -83,7 +83,7 @@ func TestCreate_Success(t *testing.T) {
 	pool := setupTestDB(t)
 	repo := NewPgStockItemRepository(pool)
 
-	item, err := repo.Create(context.Background(), "醤油", "調味料")
+	item, err := repo.Create(context.Background(), "醤油", "調味料", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "醤油", item.Name)
 	assert.Equal(t, "調味料", item.Category)
@@ -92,13 +92,22 @@ func TestCreate_Success(t *testing.T) {
 	assert.NotEqual(t, uuid.Nil, item.ID)
 }
 
+func TestCreate_WithWantToBuyTrue(t *testing.T) {
+	pool := setupTestDB(t)
+	repo := NewPgStockItemRepository(pool)
+
+	item, err := repo.Create(context.Background(), "醤油", "調味料", boolPtr(true))
+	require.NoError(t, err)
+	assert.True(t, item.WantToBuy)
+}
+
 func TestCreate_DuplicateName(t *testing.T) {
 	pool := setupTestDB(t)
 	repo := NewPgStockItemRepository(pool)
 
-	_, err := repo.Create(context.Background(), "醤油", "調味料")
+	_, err := repo.Create(context.Background(), "醤油", "調味料", nil)
 	require.NoError(t, err)
-	_, err = repo.Create(context.Background(), "醤油", "飲み物")
+	_, err = repo.Create(context.Background(), "醤油", "飲み物", nil)
 	require.Error(t, err)
 	assert.Error(t, err, "should not allow duplicate names")
 }
@@ -116,9 +125,9 @@ func TestList_OrderByUpdatedAtDesc(t *testing.T) {
 	pool := setupTestDB(t)
 	repo := NewPgStockItemRepository(pool)
 
-	_, err := repo.Create(context.Background(), "醤油", "調味料")
+	_, err := repo.Create(context.Background(), "醤油", "調味料", nil)
 	require.NoError(t, err)
-	_, err = repo.Create(context.Background(), "味噌", "調味料")
+	_, err = repo.Create(context.Background(), "味噌", "調味料", nil)
 	require.NoError(t, err)
 	_, err = pool.Exec(context.Background(),
 		"UPDATE stock_items SET updated_at = NOW() + INTERVAL '1 second' WHERE name = '醤油'")
@@ -171,7 +180,7 @@ func TestUpdate_Success(t *testing.T) {
 			pool := setupTestDB(t)
 			repo := NewPgStockItemRepository(pool)
 
-			item, err := repo.Create(context.Background(), "醤油", "調味料")
+			item, err := repo.Create(context.Background(), "醤油", "調味料", nil)
 			require.NoError(t, err)
 			updatedItem, err := repo.Update(context.Background(), item.ID, tt.params)
 			require.NoError(t, err)
@@ -186,7 +195,7 @@ func TestUpdate_ImageURL_SetValue(t *testing.T) {
 	pool := setupTestDB(t)
 	repo := NewPgStockItemRepository(pool)
 
-	item, err := repo.Create(context.Background(), "醤油", "調味料")
+	item, err := repo.Create(context.Background(), "醤油", "調味料", nil)
 	require.NoError(t, err)
 
 	url := "https://example.com/a.jpg"
@@ -202,7 +211,7 @@ func TestUpdate_ImageURL_ClearToNull(t *testing.T) {
 	pool := setupTestDB(t)
 	repo := NewPgStockItemRepository(pool)
 
-	item, err := repo.Create(context.Background(), "醤油", "調味料")
+	item, err := repo.Create(context.Background(), "醤油", "調味料", nil)
 	require.NoError(t, err)
 
 	url := "https://example.com/a.jpg"
@@ -222,7 +231,7 @@ func TestUpdate_ImageURL_UnspecifiedKeepsExisting(t *testing.T) {
 	pool := setupTestDB(t)
 	repo := NewPgStockItemRepository(pool)
 
-	item, err := repo.Create(context.Background(), "醤油", "調味料")
+	item, err := repo.Create(context.Background(), "醤油", "調味料", nil)
 	require.NoError(t, err)
 
 	url := "https://example.com/b.jpg"
@@ -256,9 +265,9 @@ func TestUpdate_DuplicateName(t *testing.T) {
 	pool := setupTestDB(t)
 	repo := NewPgStockItemRepository(pool)
 
-	item1, err := repo.Create(context.Background(), "醤油", "調味料")
+	item1, err := repo.Create(context.Background(), "醤油", "調味料", nil)
 	require.NoError(t, err)
-	item2, err := repo.Create(context.Background(), "味噌", "調味料")
+	item2, err := repo.Create(context.Background(), "味噌", "調味料", nil)
 	require.NoError(t, err)
 
 	updateParams := UpdateParams{
@@ -273,7 +282,7 @@ func TestDelete_Success(t *testing.T) {
 	pool := setupTestDB(t)
 	repo := NewPgStockItemRepository(pool)
 
-	item, err := repo.Create(context.Background(), "醤油", "調味料")
+	item, err := repo.Create(context.Background(), "醤油", "調味料", nil)
 	require.NoError(t, err)
 	err = repo.Delete(context.Background(), item.ID)
 	require.NoError(t, err)

--- a/frontend/src/app/stock-items/page.tsx
+++ b/frontend/src/app/stock-items/page.tsx
@@ -40,8 +40,12 @@ export default function StockItemsPage() {
 
   const Card = viewMode === "simple" ? ItemCardSimple : ItemCard;
 
-  const handleCreate = async (name: string, category: string) => {
-    await createStockItem({ name, category });
+  const handleCreate = async (
+    name: string,
+    category: string,
+    wantToBuy: boolean,
+  ) => {
+    await createStockItem({ name, category, wantToBuy });
     const data = await fetchStockItems();
     setItems(data);
   };
@@ -134,7 +138,9 @@ export default function StockItemsPage() {
             </div>
             <CreateItemModal
               isOpen={isModalOpen}
+              initialName={filter.searchText}
               initialCategory={filter.category ?? "★"}
+              initialWantToBuy={filter.wantToBuyOnly}
               onClose={() => setIsModalOpen(false)}
               onCreate={handleCreate}
             />

--- a/frontend/src/components/CreateItemModal.test.tsx
+++ b/frontend/src/components/CreateItemModal.test.tsx
@@ -3,55 +3,36 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import CreateItemModal from "./CreateItemModal";
 
+const defaultProps = {
+  isOpen: true,
+  initialName: "",
+  initialCategory: "★",
+  initialWantToBuy: false,
+  onClose: vi.fn(),
+  onCreate: vi.fn(),
+};
+
 describe("CreateItemModal", () => {
   it("isOpen=falseのとき何も表示しない", () => {
-    render(
-      <CreateItemModal
-        isOpen={false}
-        initialCategory="★"
-        onClose={vi.fn()}
-        onCreate={vi.fn()}
-      />,
-    );
+    render(<CreateItemModal {...defaultProps} isOpen={false} />);
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("isOpen=true のとき名前・カテゴリ・送信ボタンが表示される", () => {
-    render(
-      <CreateItemModal
-        isOpen={true}
-        initialCategory="★"
-        onClose={vi.fn()}
-        onCreate={vi.fn()}
-      />,
-    );
+    render(<CreateItemModal {...defaultProps} />);
     expect(screen.getByLabelText("名前")).toBeInTheDocument();
     expect(screen.getByLabelText("カテゴリ")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "追加" })).toBeInTheDocument();
   });
 
   it("名前が空のとき送信ボタンが disabled", () => {
-    render(
-      <CreateItemModal
-        isOpen={true}
-        initialCategory="★"
-        onClose={vi.fn()}
-        onCreate={vi.fn()}
-      />,
-    );
+    render(<CreateItemModal {...defaultProps} />);
     expect(screen.getByRole("button", { name: "追加" })).toBeDisabled();
   });
 
   it("名前を入力すると送信ボタンが enabled になる（カテゴリは初期値で常に有効）", async () => {
     const user = userEvent.setup();
-    render(
-      <CreateItemModal
-        isOpen={true}
-        initialCategory="★"
-        onClose={vi.fn()}
-        onCreate={vi.fn()}
-      />,
-    );
+    render(<CreateItemModal {...defaultProps} />);
     await user.type(screen.getByLabelText("名前"), "醤油");
     expect(screen.getByRole("button", { name: "追加" })).toBeEnabled();
   });
@@ -62,8 +43,7 @@ describe("CreateItemModal", () => {
     const onClose = vi.fn();
     render(
       <CreateItemModal
-        isOpen={true}
-        initialCategory="★"
+        {...defaultProps}
         onClose={onClose}
         onCreate={onCreate}
       />,
@@ -72,7 +52,7 @@ describe("CreateItemModal", () => {
     await user.selectOptions(screen.getByLabelText("カテゴリ"), "調味料");
     await user.click(screen.getByRole("button", { name: "追加" }));
     await waitFor(() => {
-      expect(onCreate).toHaveBeenCalledWith("醤油", "調味料");
+      expect(onCreate).toHaveBeenCalledWith("醤油", "調味料", false);
       expect(onClose).toHaveBeenCalled();
     });
   });
@@ -80,14 +60,7 @@ describe("CreateItemModal", () => {
   it("重複エラーでエラーメッセージが表示される", async () => {
     const user = userEvent.setup();
     const onCreate = vi.fn().mockRejectedValue(new Error("HTTP 409"));
-    render(
-      <CreateItemModal
-        isOpen={true}
-        initialCategory="★"
-        onClose={vi.fn()}
-        onCreate={onCreate}
-      />,
-    );
+    render(<CreateItemModal {...defaultProps} onCreate={onCreate} />);
     await user.type(screen.getByLabelText("名前"), "醤油");
     await user.click(screen.getByRole("button", { name: "追加" }));
 
@@ -99,45 +72,17 @@ describe("CreateItemModal", () => {
   it("キャンセルボタンを押すと onClose が呼ばれる", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    render(
-      <CreateItemModal
-        isOpen={true}
-        initialCategory="★"
-        onClose={onClose}
-        onCreate={vi.fn()}
-      />,
-    );
+    render(<CreateItemModal {...defaultProps} onClose={onClose} />);
     await user.click(screen.getByRole("button", { name: "キャンセル" }));
     expect(onClose).toHaveBeenCalled();
   });
 
   it("キャンセル後に再度開くと入力がリセットされる", async () => {
     const user = userEvent.setup();
-    const { rerender } = render(
-      <CreateItemModal
-        isOpen={true}
-        initialCategory="★"
-        onClose={vi.fn()}
-        onCreate={vi.fn()}
-      />,
-    );
+    const { rerender } = render(<CreateItemModal {...defaultProps} />);
     await user.type(screen.getByLabelText("名前"), "醤油");
-    rerender(
-      <CreateItemModal
-        isOpen={false}
-        initialCategory="★"
-        onClose={vi.fn()}
-        onCreate={vi.fn()}
-      />,
-    );
-    rerender(
-      <CreateItemModal
-        isOpen={true}
-        initialCategory="★"
-        onClose={vi.fn()}
-        onCreate={vi.fn()}
-      />,
-    );
+    rerender(<CreateItemModal {...defaultProps} isOpen={false} />);
+    rerender(<CreateItemModal {...defaultProps} isOpen={true} />);
     expect(screen.getByLabelText("名前")).toHaveValue("");
   });
 
@@ -145,97 +90,108 @@ describe("CreateItemModal", () => {
     const user = userEvent.setup();
     const onCreate = vi.fn().mockResolvedValue(undefined);
     const { rerender } = render(
-      <CreateItemModal
-        isOpen={true}
-        initialCategory="★"
-        onClose={vi.fn()}
-        onCreate={onCreate}
-      />,
+      <CreateItemModal {...defaultProps} onCreate={onCreate} />,
     );
     await user.type(screen.getByLabelText("名前"), "醤油");
     await user.click(screen.getByRole("button", { name: "追加" }));
     rerender(
-      <CreateItemModal
-        isOpen={false}
-        initialCategory="★"
-        onClose={vi.fn()}
-        onCreate={onCreate}
-      />,
+      <CreateItemModal {...defaultProps} isOpen={false} onCreate={onCreate} />,
     );
     rerender(
-      <CreateItemModal
-        isOpen={true}
-        initialCategory="★"
-        onClose={vi.fn()}
-        onCreate={onCreate}
-      />,
+      <CreateItemModal {...defaultProps} isOpen={true} onCreate={onCreate} />,
     );
     expect(screen.getByLabelText("名前")).toHaveValue("");
   });
 
   it("初期カテゴリは initialCategory で選択される (★)", () => {
-    render(
-      <CreateItemModal
-        isOpen={true}
-        initialCategory="★"
-        onClose={vi.fn()}
-        onCreate={vi.fn()}
-      />,
-    );
+    render(<CreateItemModal {...defaultProps} initialCategory="★" />);
     expect(screen.getByLabelText("カテゴリ")).toHaveValue("★");
   });
 
   it("初期カテゴリは initialCategory で選択される (調味料)", () => {
-    render(
-      <CreateItemModal
-        isOpen={true}
-        initialCategory="調味料"
-        onClose={vi.fn()}
-        onCreate={vi.fn()}
-      />,
-    );
+    render(<CreateItemModal {...defaultProps} initialCategory="調味料" />);
     expect(screen.getByLabelText("カテゴリ")).toHaveValue("調味料");
   });
 
   it("「選択してください」option は存在しない", () => {
-    render(
-      <CreateItemModal
-        isOpen={true}
-        initialCategory="★"
-        onClose={vi.fn()}
-        onCreate={vi.fn()}
-      />,
-    );
+    render(<CreateItemModal {...defaultProps} />);
     const select = screen.getByLabelText("カテゴリ") as HTMLSelectElement;
     const optionValues = Array.from(select.options).map((o) => o.value);
     expect(optionValues).not.toContain("");
   });
 
   it("再度開くときに新しい initialCategory にリセットされる", () => {
-    const { rerender } = render(
-      <CreateItemModal
-        isOpen={true}
-        initialCategory="★"
-        onClose={vi.fn()}
-        onCreate={vi.fn()}
-      />,
-    );
+    const { rerender } = render(<CreateItemModal {...defaultProps} />);
+    rerender(<CreateItemModal {...defaultProps} isOpen={false} />);
     rerender(
       <CreateItemModal
-        isOpen={false}
-        initialCategory="★"
-        onClose={vi.fn()}
-        onCreate={vi.fn()}
-      />,
-    );
-    rerender(
-      <CreateItemModal
+        {...defaultProps}
         isOpen={true}
         initialCategory="調味料"
-        onClose={vi.fn()}
-        onCreate={vi.fn()}
       />,
     );
     expect(screen.getByLabelText("カテゴリ")).toHaveValue("調味料");
+  });
+
+  it("initialName が指定されると名前フィールドに初期入力される", () => {
+    render(<CreateItemModal {...defaultProps} initialName="醤油" />);
+    expect(screen.getByLabelText("名前")).toHaveValue("醤油");
+  });
+
+  it("initialName が空文字の場合は名前フィールドも空", () => {
+    render(<CreateItemModal {...defaultProps} initialName="" />);
+    expect(screen.getByLabelText("名前")).toHaveValue("");
+  });
+
+  it("initialWantToBuy=true のとき買いたいトグルが ON になる", () => {
+    render(<CreateItemModal {...defaultProps} initialWantToBuy={true} />);
+    expect(screen.getByRole("button", { name: "買いたい" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("initialWantToBuy=false のとき買いたいトグルが OFF になる", () => {
+    render(<CreateItemModal {...defaultProps} initialWantToBuy={false} />);
+    expect(screen.getByRole("button", { name: "買いたい" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("モーダルを閉じて再度開くと initialName / initialWantToBuy で再初期化される", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <CreateItemModal
+        {...defaultProps}
+        initialName="醤油"
+        initialWantToBuy={true}
+      />,
+    );
+    await user.clear(screen.getByLabelText("名前"));
+    await user.click(screen.getByRole("button", { name: "買いたい" }));
+
+    rerender(
+      <CreateItemModal
+        {...defaultProps}
+        isOpen={false}
+        initialName="醤油"
+        initialWantToBuy={true}
+      />,
+    );
+    rerender(
+      <CreateItemModal
+        {...defaultProps}
+        isOpen={true}
+        initialName="醤油"
+        initialWantToBuy={true}
+      />,
+    );
+
+    expect(screen.getByLabelText("名前")).toHaveValue("醤油");
+    expect(screen.getByRole("button", { name: "買いたい" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 });

--- a/frontend/src/components/CreateItemModal.tsx
+++ b/frontend/src/components/CreateItemModal.tsx
@@ -1,32 +1,43 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { MdShoppingCart } from "react-icons/md";
 import { CATEGORIES } from "@/constants/categories";
 
 type CreateItemModalProps = {
   isOpen: boolean;
+  initialName: string;
   initialCategory: string;
+  initialWantToBuy: boolean;
   onClose: () => void;
-  onCreate: (name: string, category: string) => Promise<void>;
+  onCreate: (
+    name: string,
+    category: string,
+    wantToBuy: boolean,
+  ) => Promise<void>;
 };
 
 export default function CreateItemModal({
   isOpen,
+  initialName,
   initialCategory,
+  initialWantToBuy,
   onClose,
   onCreate,
 }: CreateItemModalProps) {
-  const [name, setName] = useState("");
+  const [name, setName] = useState(initialName);
   const [category, setCategory] = useState(initialCategory);
+  const [wantToBuy, setWantToBuy] = useState(initialWantToBuy);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (isOpen) {
-      setName("");
+      setName(initialName);
       setCategory(initialCategory);
+      setWantToBuy(initialWantToBuy);
       setError(null);
     }
-  }, [isOpen, initialCategory]);
+  }, [isOpen, initialName, initialCategory, initialWantToBuy]);
 
   if (!isOpen) return null;
   return (
@@ -40,7 +51,7 @@ export default function CreateItemModal({
         <form
           onSubmit={(e) => {
             e.preventDefault();
-            onCreate(name, category)
+            onCreate(name, category, wantToBuy)
               .then(onClose)
               .catch((err) => {
                 const error =
@@ -70,7 +81,7 @@ export default function CreateItemModal({
               onChange={(e) => setName(e.target.value)}
             />
           </div>
-          <div className="mb-6">
+          <div className="mb-4">
             <label
               htmlFor="category"
               className="block text-sm font-medium text-gray-700 mb-1"
@@ -91,6 +102,24 @@ export default function CreateItemModal({
                 </option>
               ))}
             </select>
+          </div>
+          <div className="mb-6">
+            <span className="block text-sm font-medium text-gray-700 mb-1">
+              買いたい
+            </span>
+            <button
+              type="button"
+              aria-label="買いたい"
+              aria-pressed={wantToBuy}
+              onClick={() => setWantToBuy((v) => !v)}
+              className={
+                wantToBuy
+                  ? "inline-flex items-center justify-center rounded bg-[#00d1b2] hover:bg-[#00c4a7] px-3 py-2 text-white"
+                  : "inline-flex items-center justify-center rounded bg-gray-200 hover:bg-gray-300 px-3 py-2 text-gray-500"
+              }
+            >
+              <MdShoppingCart aria-hidden size={20} />
+            </button>
           </div>
           <div className="flex justify-end gap-2">
             <button

--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -56,7 +56,7 @@ export default function FilterBar({
             type="button"
             aria-label="クリア"
             onClick={handleClearSearchText}
-            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 focus:outline-none"
+            className="absolute right-0 top-1/2 -translate-y-1/2 flex h-full items-center px-3 text-xl leading-none text-gray-500 hover:text-gray-700 focus:outline-none"
           >
             ×
           </button>

--- a/frontend/src/types/stockItem.ts
+++ b/frontend/src/types/stockItem.ts
@@ -11,6 +11,7 @@ type StockItem = {
 type CreateStockItemRequest = {
   name: string;
   category: string;
+  wantToBuy?: boolean;
 };
 
 type UpdateStockItemRequest = {

--- a/openspec/changes/prefill-create-modal-from-filter/.openspec.yaml
+++ b/openspec/changes/prefill-create-modal-from-filter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/prefill-create-modal-from-filter/design.md
+++ b/openspec/changes/prefill-create-modal-from-filter/design.md
@@ -1,0 +1,41 @@
+## Context
+
+`CreateItemModal` はすでに `initialCategory` prop を受け取り、`useEffect` で `isOpen` 変化時に state を初期化している。同パターンで `initialName` / `initialWantToBuy` prop を追加する。
+
+backend の `CreateStockItemRequest` struct と repository の `Create()` は現在 `name` / `category` のみ受け付けており、`wantToBuy` のサポートが必要。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `CreateItemModal` に `initialName` / `initialWantToBuy` prop を追加し、モーダルオープン時に各 state を初期化する
+- `CreateItemModal` に `wantToBuy` トグル UI を追加し、作成リクエストに含める
+- backend の `POST /api/stock-items` が `wantToBuy` を受け付けるよう拡張する
+- `stock-items/page.tsx` で `filter.searchText` / `filter.wantToBuyOnly` を各 initial prop として渡す
+
+**Non-Goals:**
+- フィルタークリアの自動化
+- カテゴリ以外のフィルター条件（wantToBuyOnly）を filter 表示 UI 側に反映させること
+
+## Decisions
+
+**`initialWantToBuy` の型は `boolean`（undefined なし）**
+- `filter.wantToBuyOnly` は常に `boolean` であり undefined の考慮不要
+- backend のデフォルト値（false）と合わせる
+
+**既存の `useEffect` を拡張する**
+- `isOpen` 変化時にまとめて state をリセットする既存の `useEffect` に `initialName` / `initialWantToBuy` の初期化を追加する
+
+**backend `CreateStockItemRequest.WantToBuy` は `*bool`（ポインタ）**
+- nil の場合は既存の DB デフォルト（`DEFAULT false`）に従う
+- 既存の `UpdateStockItemRequest` と一貫したパターン
+
+**`wantToBuy` トグルの UI は既存の ItemCard のトグルスタイルに合わせる**
+- MdShoppingCart アイコン + teal/gray 背景で統一感を出す
+
+## Risks / Trade-offs
+
+**ユーザーが検索テキストを意図せず商品名に確定してしまうリスク**
+→ モーダル内で name フィールドは自由編集可能なので問題なし。
+
+**backend の `want_to_buy` DB カラムにデフォルト値がない場合 NOT NULL エラー**
+→ `stock_items` テーブルは `want_to_buy` が `DEFAULT false NOT NULL` である（既存データから確認済み）ので、`WantToBuy` が nil の場合は DB デフォルトが使われ安全。

--- a/openspec/changes/prefill-create-modal-from-filter/proposal.md
+++ b/openspec/changes/prefill-create-modal-from-filter/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+フィルターで検索テキストを入力しながら「商品を追加」ボタンを押す操作は、探している商品が見つからず新規追加する典型的なフローだが、現状では名前欄が空・wantToBuy が false で始まるため再入力が必要になる。searchText・category・wantToBuyOnly の 3 つをモーダルの初期値として引き継ぐことで、この余分な手順を省く。
+
+## What Changes
+
+- `CreateItemModal` に `initialName` / `initialWantToBuy` prop を追加し、モーダルを開いたときに各フィールドを初期化する
+- `CreateItemModal` に `wantToBuy` トグル UI を追加し、`onCreate` の引数に含める
+- `stock-items/page.tsx` で `initialName={filter.searchText}` / `initialWantToBuy={filter.wantToBuyOnly}` を渡し、`handleCreate` で `wantToBuy` を受け取る
+- `CreateStockItemRequest`（frontend 型・backend struct）に `wantToBuy` を追加する
+- backend の `Create` repository / handler を `wantToBuy` に対応させ、INSERT に `want_to_buy` を含める
+- 各層のテストを更新・追加する
+
+## Capabilities
+
+### New Capabilities
+
+なし（既存のモーダル動作の拡張のみ）
+
+### Modified Capabilities
+
+- `stock-items-list`: 商品追加モーダルを開くときにフィルター条件（searchText / wantToBuyOnly）を名前・wantToBuy フィールドの初期値として引き継ぐ要件を追加
+- `stock-items-api`: `POST /api/stock-items` が `wantToBuy` を受け付ける要件を追加
+
+## Impact
+
+- `frontend/src/components/CreateItemModal.tsx`
+- `frontend/src/app/stock-items/page.tsx`
+- `frontend/src/components/CreateItemModal.test.tsx`
+- `frontend/src/types/stockItem.ts`
+- `backend/handler/stock_item.go`
+- `backend/repository/stock_item_pg.go`（および interface）
+- backend テストファイル

--- a/openspec/changes/prefill-create-modal-from-filter/specs/stock-items-api/spec.md
+++ b/openspec/changes/prefill-create-modal-from-filter/specs/stock-items-api/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Create stock item
+The system SHALL create a new stock item via `POST /api/stock-items` with name, category, and optional wantToBuy.
+
+#### Scenario: Successful creation
+- **WHEN** a valid request with name and category is sent
+- **THEN** the API returns 201 with the created item
+- **AND** the item has wantToBuy=false, imageUrl=null, and generated id/timestamps
+
+#### Scenario: Successful creation with wantToBuy=true
+- **WHEN** a valid request with name, category, and wantToBuy=true is sent
+- **THEN** the API returns 201 with the created item
+- **AND** the item has wantToBuy=true
+
+#### Scenario: Duplicate name
+- **WHEN** a request with a name that already exists is sent
+- **THEN** the API returns 409 Conflict with an error message
+
+#### Scenario: Missing name
+- **WHEN** a request without a name is sent
+- **THEN** the API returns 400 Bad Request with an error message
+
+#### Scenario: Missing category
+- **WHEN** a request without a category is sent
+- **THEN** the API returns 400 Bad Request with an error message

--- a/openspec/changes/prefill-create-modal-from-filter/specs/stock-items-list/spec.md
+++ b/openspec/changes/prefill-create-modal-from-filter/specs/stock-items-list/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: CreateItemModal は filter のカテゴリをデフォルト選択にする
+`CreateItemModal` を開いた時の各フィールドの初期値は、現在の `FilterCondition` に応じて決定する SHALL。
+
+- `カテゴリ`: `category: null`（「全部」）→ `"★"` / `category: <値>` → 同じ値
+- `名前`: `searchText: ""` → 空文字 / `searchText: <値>` → 同じ値
+- `買いたい`: `wantToBuyOnly: false` → false / `wantToBuyOnly: true` → true
+
+「選択してください」プレースホルダ option は MUST NOT 表示する（常に有効なカテゴリがデフォルト選択されるため）。
+
+#### Scenario: フィルタ全部の場合
+- **WHEN** フィルタが `category: null` の状態で「商品を追加」ボタンを押す
+- **THEN** モーダルのカテゴリ select は `"★"` が選択された状態で開く
+
+#### Scenario: フィルタが特定カテゴリの場合
+- **WHEN** フィルタが `category: "調味料"` の状態で「商品を追加」ボタンを押す
+- **THEN** モーダルのカテゴリ select は `"調味料"` が選択された状態で開く
+
+#### Scenario: 「選択してください」option が存在しない
+- **WHEN** モーダルが描画される
+- **THEN** カテゴリ select の option に `value=""` のものは存在しない
+
+#### Scenario: 検索テキストが名前フィールドに初期入力される
+- **WHEN** フィルタの `searchText` が `"醤油"` の状態で「商品を追加」ボタンを押す
+- **THEN** モーダルの名前 input は `"醤油"` が入力された状態で開く
+
+#### Scenario: 検索テキストが空の場合は名前フィールドも空
+- **WHEN** フィルタの `searchText` が `""` の状態で「商品を追加」ボタンを押す
+- **THEN** モーダルの名前 input は空の状態で開く
+
+#### Scenario: wantToBuyOnly ON のとき買いたいトグルが ON で開く
+- **WHEN** フィルタの `wantToBuyOnly` が `true` の状態で「商品を追加」ボタンを押す
+- **THEN** モーダルの買いたいトグルは ON（pressed）の状態で開く
+
+#### Scenario: wantToBuyOnly OFF のとき買いたいトグルが OFF で開く
+- **WHEN** フィルタの `wantToBuyOnly` が `false` の状態で「商品を追加」ボタンを押す
+- **THEN** モーダルの買いたいトグルは OFF の状態で開く
+
+#### Scenario: モーダルを閉じて再度開くとフィルタ条件が再反映される
+- **WHEN** モーダルを一度閉じて、フィルタ条件が変わっていない状態で再度「商品を追加」ボタンを押す
+- **THEN** 名前・買いたいトグルは再度フィルタ条件の値で初期化される

--- a/openspec/changes/prefill-create-modal-from-filter/tasks.md
+++ b/openspec/changes/prefill-create-modal-from-filter/tasks.md
@@ -1,0 +1,29 @@
+## 1. Backend: Create API に wantToBuy を追加
+
+- [x] 1.1 `backend/handler/stock_item.go` の `CreateStockItemRequest` struct に `WantToBuy *bool` フィールドを追加する
+- [x] 1.2 `backend/repository/stock_item_pg.go` の `Create()` シグネチャに `wantToBuy *bool` 引数を追加し、INSERT クエリに `want_to_buy` を含める（nil の場合は DB デフォルト `false` を使用）
+- [x] 1.3 repository interface が別ファイルにある場合、その `Create()` シグネチャも更新する
+- [x] 1.4 `backend/handler/stock_item.go` の `Create` ハンドラで `req.WantToBuy` を repository の `Create()` に渡す
+
+## 2. Frontend 型・API クライアント更新
+
+- [x] 2.1 `frontend/src/types/stockItem.ts` の `CreateStockItemRequest` に `wantToBuy?: boolean` を追加する
+
+## 3. CreateItemModal に initialName / initialWantToBuy を追加
+
+- [x] 3.1 `CreateItemModalProps` に `initialName: string` と `initialWantToBuy: boolean` を追加する
+- [x] 3.2 `wantToBuy` state と UI トグル（MdShoppingCart アイコン）を追加する
+- [x] 3.3 `useEffect` 内で `setName(initialName)` / `setWantToBuy(initialWantToBuy)` を呼び、モーダルオープン時に各 state を初期化する
+- [x] 3.4 `onCreate` コールバックの引数に `wantToBuy` を追加する（シグネチャ変更）
+
+## 4. page.tsx の配線更新
+
+- [x] 4.1 `<CreateItemModal>` に `initialName={filter.searchText}` と `initialWantToBuy={filter.wantToBuyOnly}` を追加する
+- [x] 4.2 `handleCreate` の引数に `wantToBuy: boolean` を追加し、`createStockItem({ name, category, wantToBuy })` に渡す
+
+## 5. テスト追加・更新
+
+- [x] 5.1 `CreateItemModal.test.tsx` に `initialName` が名前フィールドに初期入力されるテストを追加する
+- [x] 5.2 `CreateItemModal.test.tsx` に `initialWantToBuy=true` で買いたいトグルが ON になるテストを追加する
+- [x] 5.3 `CreateItemModal.test.tsx` に「モーダルを閉じて再度開くと各 initial prop で再初期化される」テストを追加する
+- [x] 5.4 backend の `Create` ハンドラ / repository テストに `wantToBuy=true` で作成するケースを追加する


### PR DESCRIPTION
## Summary

- フィルターで入力した検索テキストを `CreateItemModal` の名前フィールドに初期入力
- フィルターのカテゴリ選択をモーダルのカテゴリに初期反映（既存）
- フィルターの「買いたいのみ」トグルをモーダルの買いたいトグルに初期反映
- `POST /api/stock-items` が `wantToBuy` を受け付けるよう backend を拡張
- FilterBar の検索クリアボタン（×）のタップ領域を拡大

Closes #68

## Test plan

- [x] frontend: `npx vitest run` がすべて通る
- [x] backend: `go test ./handler/... ./repository/...` がすべて通る
- [x] 検索テキスト「醤油」入力後に追加ボタン → 名前欄に「醤油」が入っている
- [x] 「買いたいのみ」ON 後に追加ボタン → 買いたいトグルが ON で開く
- [x] カテゴリフィルター「調味料」選択後に追加ボタン → カテゴリが「調味料」で開く
- [x] CI (GitHub Actions) が通る