### PR TITLE
UI tweaks: blue cart button and larger header font

### DIFF
--- a/frontend/src/app/stock-items/page.tsx
+++ b/frontend/src/app/stock-items/page.tsx
@@ -111,7 +111,7 @@ export default function StockItemsPage() {
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="bg-gradient-to-br from-[#009e6c] via-[#00d1b2] to-[#00e7eb] text-white py-2 px-4">
-        <h1 className="text-2xl font-bold text-center">Pantry Panel</h1>
+        <h1 className="text-3xl font-bold text-center">Pantry Panel</h1>
       </header>
       <main className="max-w-6xl mx-auto px-4 py-4">
         {loading ? (

--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -71,11 +71,11 @@ export default function FilterBar({
           onClick={toggleWantToBuyOnly}
           className={
             value.wantToBuyOnly
-              ? "w-full inline-flex items-center justify-center rounded bg-[#00d1b2] hover:bg-[#00c4a7] px-3 py-2 text-white"
+              ? "w-full inline-flex items-center justify-center rounded bg-blue-500 hover:bg-blue-600 px-3 py-2 text-white"
               : "w-full inline-flex items-center justify-center rounded bg-gray-200 hover:bg-gray-300 px-3 py-2 text-gray-500"
           }
         >
-          <MdShoppingCart aria-hidden size={20} />
+          <MdShoppingCart aria-hidden size={24} />
         </button>
         <select
           aria-label="カテゴリ"

--- a/frontend/src/components/ItemCard.tsx
+++ b/frontend/src/components/ItemCard.tsx
@@ -58,20 +58,20 @@ export default function ItemCard({
         onClick={() => onToggleWantToBuy(item)}
         className={
           item.wantToBuy
-            ? "rounded bg-transparent px-3 py-1.5 text-blue-500 hover:text-blue-600 inline-flex items-center"
-            : "rounded bg-transparent px-3 py-1.5 text-gray-300 hover:text-gray-400 inline-flex items-center"
+            ? "w-11 h-8 rounded bg-transparent p-0 text-blue-500 hover:text-blue-600 inline-flex items-center justify-center"
+            : "w-11 h-8 rounded bg-transparent p-0 text-gray-300 hover:text-gray-400 inline-flex items-center justify-center"
         }
       >
-        <MdShoppingCart aria-hidden size={20} />
+        <MdShoppingCart aria-hidden size={28} />
       </button>
       <button
         type="button"
         aria-label="削除"
         disabled={item.wantToBuy}
-        className="rounded bg-[#ff3860] hover:bg-[#ff2b56] px-3 py-1.5 text-white inline-flex items-center disabled:bg-gray-300 disabled:cursor-not-allowed"
+        className="w-11 h-8 rounded bg-[#ff3860] hover:bg-[#ff2b56] p-0 text-white inline-flex items-center justify-center disabled:bg-gray-300 disabled:cursor-not-allowed"
         onClick={() => onDelete(item.id)}
       >
-        <MdDelete aria-hidden size={20} />
+        <MdDelete aria-hidden size={28} />
       </button>
     </article>
   );

--- a/frontend/src/components/ItemCard.tsx
+++ b/frontend/src/components/ItemCard.tsx
@@ -58,8 +58,8 @@ export default function ItemCard({
         onClick={() => onToggleWantToBuy(item)}
         className={
           item.wantToBuy
-            ? "rounded bg-[#00d1b2] hover:bg-[#00c4a7] px-3 py-1.5 text-white inline-flex items-center"
-            : "rounded bg-gray-200 hover:bg-gray-300 px-3 py-1.5 text-gray-500 inline-flex items-center"
+            ? "rounded bg-transparent px-3 py-1.5 text-blue-500 hover:text-blue-600 inline-flex items-center"
+            : "rounded bg-transparent px-3 py-1.5 text-gray-300 hover:text-gray-400 inline-flex items-center"
         }
       >
         <MdShoppingCart aria-hidden size={20} />

--- a/frontend/src/components/ItemCardSimple.tsx
+++ b/frontend/src/components/ItemCardSimple.tsx
@@ -61,8 +61,8 @@ export default function ItemCardSimple({
         onClick={() => onToggleWantToBuy(item)}
         className={
           item.wantToBuy
-            ? "rounded bg-[#00d1b2] hover:bg-[#00c4a7] px-3 py-1 text-white inline-flex items-center"
-            : "rounded bg-gray-200 hover:bg-gray-300 px-3 py-1 text-gray-500 inline-flex items-center"
+            ? "rounded bg-transparent px-3 py-1 text-blue-500 hover:text-blue-600 inline-flex items-center"
+            : "rounded bg-transparent px-3 py-1 text-gray-300 hover:text-gray-400 inline-flex items-center"
         }
       >
         <MdShoppingCart aria-hidden size={20} />

--- a/frontend/src/components/ItemCardSimple.tsx
+++ b/frontend/src/components/ItemCardSimple.tsx
@@ -61,11 +61,11 @@ export default function ItemCardSimple({
         onClick={() => onToggleWantToBuy(item)}
         className={
           item.wantToBuy
-            ? "rounded bg-transparent px-3 py-1 text-blue-500 hover:text-blue-600 inline-flex items-center"
-            : "rounded bg-transparent px-3 py-1 text-gray-300 hover:text-gray-400 inline-flex items-center"
+            ? "w-11 h-7 rounded bg-transparent p-0 text-blue-500 hover:text-blue-600 inline-flex items-center justify-center"
+            : "w-11 h-7 rounded bg-transparent p-0 text-gray-300 hover:text-gray-400 inline-flex items-center justify-center"
         }
       >
-        <MdShoppingCart aria-hidden size={20} />
+        <MdShoppingCart aria-hidden size={24} />
       </button>
     </article>
   );


### PR DESCRIPTION
## Summary
- want-to-buy カートボタンを旧Appに合わせて変更（青アイコン・透明背景）
- ヘッダー「Pantry Panel」フォントサイズを `text-2xl` → `text-3xl` に拡大

## Changes
- `ItemCard.tsx`: active=`text-blue-500`, inactive=`text-gray-300`（どちらも `bg-transparent`）
- `ItemCardSimple.tsx`: 同上
- `stock-items/page.tsx`: ヘッダー `text-2xl` → `text-3xl`

Closes #75