### PR TITLE
Add migration 008: set group_id NOT NULL after data migration

### DIFF
--- a/backend/db/migrations/008_stock_items_group_id_not_null.sql
+++ b/backend/db/migrations/008_stock_items_group_id_not_null.sql
@@ -1,0 +1,3 @@
+-- group_id は Plan C のデータ移行で全行に設定済みのため NOT NULL に変更する。
+-- Apply after Plan C data migration is complete.
+ALTER TABLE stock_items ALTER COLUMN group_id SET NOT NULL;


### PR DESCRIPTION
## Summary
- Add `008_stock_items_group_id_not_null.sql` to enforce NOT NULL on `stock_items.group_id`
- Plan C data migration (all rows populated with group_id) was completed manually via Supabase Dashboard before this constraint was applied

## Test plan
- [x] Migration applied on Supabase production DB successfully
- [x] App shows stock items correctly after migration

Closes #81