### PR TITLE
Fix: forward accessToken to image search API to resolve 401

### DIFF
--- a/frontend/src/app/stock-items/page.tsx
+++ b/frontend/src/app/stock-items/page.tsx
@@ -195,6 +195,7 @@ export default function StockItemsPage() {
                 isOpen={!!imageEditingItem}
                 onClose={() => setImageEditingItem(null)}
                 onSelect={handleImageSelect}
+                accessToken={accessToken}
               />
               {items.length === 0 ? (
                 <p className="text-center py-12 text-gray-600">

--- a/frontend/src/components/ImageSelectionModal.test.tsx
+++ b/frontend/src/components/ImageSelectionModal.test.tsx
@@ -45,7 +45,11 @@ describe("ImageSelectionModal", () => {
     );
 
     await waitFor(() =>
-      expect(searchImages).toHaveBeenCalledWith("りんご", expect.any(Number)),
+      expect(searchImages).toHaveBeenCalledWith(
+        "りんご",
+        expect.any(Number),
+        undefined,
+      ),
     );
     expect(await screen.findByAltText("A")).toBeInTheDocument();
   });
@@ -225,7 +229,11 @@ describe("ImageSelectionModal", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /^検索$/ }));
     await waitFor(() =>
-      expect(searchImages).toHaveBeenCalledWith("もも", expect.any(Number)),
+      expect(searchImages).toHaveBeenCalledWith(
+        "もも",
+        expect.any(Number),
+        undefined,
+      ),
     );
   });
 });

--- a/frontend/src/components/ImageSelectionModal.tsx
+++ b/frontend/src/components/ImageSelectionModal.tsx
@@ -11,6 +11,7 @@ type Props = {
   isOpen: boolean;
   onClose: () => void;
   onSelect: (imageUrl: string | null) => void;
+  accessToken?: string;
 };
 
 type FetchState =
@@ -24,23 +25,27 @@ export default function ImageSelectionModal({
   isOpen,
   onClose,
   onSelect,
+  accessToken,
 }: Props) {
   const [query, setQuery] = useState(item.name);
   const [state, setState] = useState<FetchState>({ status: "idle" });
 
-  const runSearch = useCallback(async (q: string) => {
-    setState({ status: "loading" });
-    try {
-      const results = await searchImages(q, 10);
-      setState({ status: "success", results });
-    } catch (err) {
-      const kind =
-        err instanceof ImageSearchError && err.kind === "quota"
-          ? "quota"
-          : "other";
-      setState({ status: "error", kind });
-    }
-  }, []);
+  const runSearch = useCallback(
+    async (q: string) => {
+      setState({ status: "loading" });
+      try {
+        const results = await searchImages(q, 10, accessToken);
+        setState({ status: "success", results });
+      } catch (err) {
+        const kind =
+          err instanceof ImageSearchError && err.kind === "quota"
+            ? "quota"
+            : "other";
+        setState({ status: "error", kind });
+      }
+    },
+    [accessToken],
+  );
 
   useEffect(() => {
     if (!isOpen) return;


### PR DESCRIPTION
## Summary

- `ImageSelectionModal` が `searchImages` を呼ぶ際に `accessToken` を渡していなかったため、本番環境で画像検索が常に 401 Unauthorized を返していた
- `ImageSelectionModal` に `accessToken?: string` プロップを追加し、`searchImages(q, 10, accessToken)` として転送するよう修正
- 親コンポーネント `stock-items/page.tsx` から `accessToken={accessToken}` を渡すよう変更

## Test plan

- [ ] `npx vitest run src/components/ImageSelectionModal.test.tsx` が全件パスすること
- [ ] 本番環境で画像検索が正常に動作すること（401 が解消されること）

Closes #83