### PR TITLE
feat: optimistic update for want-to-buy toggle

### DIFF
--- a/frontend/src/app/stock-items/StockItemsClient.tsx
+++ b/frontend/src/app/stock-items/StockItemsClient.tsx
@@ -91,6 +91,11 @@ export default function StockItemsClient() {
   };
 
   const handleToggleWantToBuy = async (item: StockItem) => {
+    setItems((prev) =>
+      prev.map((i) =>
+        i.id === item.id ? { ...i, wantToBuy: !item.wantToBuy } : i,
+      ),
+    );
     await updateStockItem(
       item.id,
       { wantToBuy: !item.wantToBuy },


### PR DESCRIPTION
## Summary

- `handleToggleWantToBuy` にて、APIコール前に `setItems` で楽観的更新を追加
- トグルボタンを押した瞬間にUIが切り替わり、バックグラウンドで更新・再fetchが走る

## Before / After

**Before:** ボタン押下 → API完了 → 再fetch完了 → UI更新（遅延あり）  
**After:** ボタン押下 → UI即時切り替え → バックグラウンドで同期

Closes #90