### PR TITLE
Enable realtime-sync E2E tests in preview environment

### DIFF
--- a/frontend/e2e/realtime-sync.spec.ts
+++ b/frontend/e2e/realtime-sync.spec.ts
@@ -6,10 +6,6 @@ const AUTH_FILE = path.join(__dirname, "../.auth/user.json");
 
 test.describe
   .serial("Realtime sync", () => {
-    test.skip(
-      !process.env.PREVIEW_URL,
-      "preview only - realtime requires deployed Supabase environment",
-    );
     const itemName = "Realtime Test Item";
 
     test("Context A で INSERT → Context B にカードが出現する", async ({

--- a/frontend/e2e/realtime-sync.spec.ts
+++ b/frontend/e2e/realtime-sync.spec.ts
@@ -6,7 +6,10 @@ const AUTH_FILE = path.join(__dirname, "../.auth/user.json");
 
 test.describe
   .serial("Realtime sync", () => {
-    test.skip(true, "realtime subscription timing issue under investigation");
+    test.skip(
+      !process.env.PREVIEW_URL,
+      "preview only - realtime requires deployed Supabase environment",
+    );
     const itemName = "Realtime Test Item";
 
     test("Context A で INSERT → Context B にカードが出現する", async ({


### PR DESCRIPTION
## Summary

- `realtime-sync.spec.ts` の `test.skip(true, ...)` を preview 環境のみ実行するよう変更
- `PREVIEW_URL` が未設定（mock モード）の場合はスキップ、設定済み（preview）の場合は実行

## Test plan

- [ ] PR を push して preview デプロイ後、`e2e-preview.yml` で realtime-sync テストが実行されることを確認
- [ ] mock モード（ローカル）ではスキップされることを確認

Closes #103