### PR TITLE
Fix group_members RLS infinite recursion that broke Realtime sync

### DIFF
--- a/backend/db/migrations/010_fix_group_members_rls_recursion.sql
+++ b/backend/db/migrations/010_fix_group_members_rls_recursion.sql
@@ -1,0 +1,33 @@
+-- Fix infinite recursion in group_members RLS policy.
+-- Apply via Supabase Dashboard SQL Editor.
+--
+-- The previous policy used a self-referential subquery:
+--   group_id IN (SELECT group_id FROM group_members WHERE user_id = auth.uid())
+-- This caused infinite recursion when Supabase Realtime's apply_rls evaluated
+-- stock_items changes, crashing the Realtime pipeline and silently disabling
+-- all sync across every environment.
+--
+-- Fix: replace with a simple equality check. Each user sees only their own
+-- membership rows, which is sufficient for stock_items RLS to derive the
+-- caller's group_ids without triggering recursion.
+--
+-- Groups and members are read-only on the frontend (managed via backend API
+-- which runs as the postgres role and bypasses RLS), so this policy change
+-- has no visible effect on the application.
+--
+-- Rollback:
+--   DROP POLICY IF EXISTS "group_members authenticated select" ON public.group_members;
+--   CREATE POLICY "group_members authenticated select"
+--     ON public.group_members FOR SELECT TO authenticated
+--     USING (group_id IN (SELECT group_id FROM group_members WHERE user_id = auth.uid()));
+
+DROP POLICY IF EXISTS "group_members authenticated select" ON public.group_members;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    CREATE POLICY "group_members authenticated select"
+      ON public.group_members FOR SELECT TO authenticated
+      USING (user_id = auth.uid());
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

- `group_members` の RLS ポリシーが自己参照になっており、Supabase Realtime の `apply_rls` が `stock_items` の変更を評価するたびに無限再帰が発生していた
- これにより Realtime パイプラインがクラッシュし、prod/preview 両環境で Realtime sync が完全に無効化されていた
- ポリシーを `user_id = auth.uid()` に変更することで再帰を解消（Supabase に手動適用済み）
- この migration ファイルはその変更を記録するもの

## Root cause

```sql
-- 旧ポリシー（問題あり）
USING (
  group_id IN (
    SELECT group_id FROM group_members  -- group_members が自身を参照 → 無限再帰
    WHERE user_id = auth.uid()
  )
);
```

Realtime が `stock_items` の RLS を評価 → `group_members` を SELECT → `group_members` の RLS を評価 → `group_members` を SELECT → ∞

## Fix

```sql
USING (user_id = auth.uid());
```

## Test plan

- [x] Supabase に手動適用済み、prod/preview 両方で Realtime sync を手動確認済み
- [ ] PR #104 の E2E テスト（realtime-sync）が preview でパスすることを確認

Closes #105