### PR TITLE
docs: move 改善4 (extraction progress SSE) to wishlist-implemented

### DIFF
--- a/specs/wishlist-implemented.md
+++ b/specs/wishlist-implemented.md
@@ -16,6 +16,12 @@ wishlist.md に記載していた機能のうち、実装が完了したもの�
 
 実装: PR #98 / Issue #109（openspec: `2026-05-23-url-extract-error-detail-and-source-url`）
 
+### URL 登録機能の改善4: 抽出処理の途中経過表示
+
+`/api/extract-from-url/stream` エンドポイント（SSE）を追加し、各ステップ（fetching / extracting 等）の開始時にイベントを配信。フロントエンドは `fetch` + ReadableStream で受信し、進捗ステップをリスト表示（完了済み・進行中・未着手を視覚的に区別）する。
+
+実装: PR #114 / Issue #111（openspec: `2026-05-24-extraction-progress-sse`）
+
 ### URL 登録機能の改善3: source_url の保存と ItemCard リンクアイコン
 
 `stock_items` テーブルに `source_url TEXT` カラムを追加。URL 登録した商品に対して `ItemCard` に外部リンクアイコン（別タブで開く）を表示する。

--- a/specs/wishlist.md
+++ b/specs/wishlist.md
@@ -32,24 +32,6 @@ URL から商品登録する機能（`/api/extract-from-url`）に対する改�
 
 ---
 
-#### 改善4: 抽出処理の途中経過表示
-
-**背景:** `/api/extract-from-url` は最大 4 ステップ・15〜20 秒かかる可能性があるが、現在は「解析中...」スピナーのみで進捗が不明。
-
-**変更内容:**
-
-- バックエンド: 新エンドポイント `POST /api/extract-from-url/stream` を追加し、SSE（Server-Sent Events）で各ステップ開始時にイベントを配信する。既存の `POST /api/extract-from-url` は後方互換のため維持する
-  - `event: progress` / `data: {"step":"fetching","message":"ページを取得中..."}`
-  - `event: progress` / `data: {"step":"fetching_jina","message":"別の方法でページを取得中..."}` （Jina fallback 時のみ）
-  - `event: progress` / `data: {"step":"extracting","message":"商品情報を解析中..."}`
-  - `event: progress` / `data: {"step":"generating_candidates","message":"名前の候補を生成中..."}` （name >= 25 文字時のみ）
-  - `event: done` / `data: {"name":"...","imageUrl":"...","nameCandidates":[...]}` （完了）
-  - `event: error` / `data: {"kind":"fetchFailed","message":"...","detail":"..."}` （エラー）
-- フロントエンド: `fetch` + ReadableStream で SSE を受信（EventSource は POST 非対応のため）。進捗ステップをリスト表示し、完了済み・進行中・未着手を視覚的に区別する
-
-**実装工数**: M（3〜5日）  
-**考慮事項**: Lambda Function URL はストリーミングレスポンスに対応済み。Echo での SSE 実装は `c.Response().Writer` への直接書き込みで実現できる。
-
 ### レシピからの材料一括登録
 
 料理のレシピ Web ページの URL を入力すると、材料一覧を AI で抽出し、調味料を除いた食材を商品として一括登録する。


### PR DESCRIPTION
`wishlist.md` に記載していた「改善4: 抽出処理の途中経過表示」を実装済みとして `wishlist-implemented.md` に移動する。

実装は PR #114 / Issue #111 で完了済み。

Closes #115