### PR TITLE
test: add retries: 1 to preview E2E project for external API flakiness

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
   projects: [
     {
       name: "preview",
+      retries: 1,
       use: {
         storageState: ".auth/user.json",
         baseURL: process.env.PREVIEW_URL,


### PR DESCRIPTION
## Summary

- preview E2E project に `retries: 1` を追加
- Google CSE API の一時的なエラー・タイムアウトによる Flakiness（例: `image-selection.spec.ts:124`）に対処
- `afterEach` がクリーンアップを行うため、再試行時に新しい `itemName` が生成されても安全

## Test plan

- [x] 既存の preview E2E テストが引き続きパスすること
- [ ] CSE 失敗時（エラー状態）に再試行が行われ、成功すること

Closes #117