### PR TITLE
feat: name candidate selection UI + Playwright report GHA upload (#120)

### DIFF
--- a/.github/workflows/e2e-preview.yml
+++ b/.github/workflows/e2e-preview.yml
@@ -76,3 +76,10 @@ jobs:
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
           E2E_TEST_GROUP_ID: ${{ secrets.E2E_TEST_GROUP_ID }}
           VERCEL_BYPASS_TOKEN: ${{ secrets.VERCEL_BYPASS_TOKEN }}
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-preview
+          path: frontend/playwright-report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,3 +63,10 @@ jobs:
           E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
           E2E_TEST_GROUP_ID: ${{ secrets.E2E_TEST_GROUP_ID }}
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-mock
+          path: frontend/playwright-report

--- a/backend/handler/url_extract.go
+++ b/backend/handler/url_extract.go
@@ -22,8 +22,9 @@ type ExtractFromURLRequest struct {
 }
 
 type ExtractFromURLResponse struct {
-	Name     string  `json:"name"`
-	ImageURL *string `json:"imageUrl"` // null when empty
+	Name           string   `json:"name"`
+	ImageURL       *string  `json:"imageUrl"`           // null when empty
+	NameCandidates []string `json:"nameCandidates,omitempty"`
 }
 
 func (h *UrlExtractHandler) Extract(c *echo.Context) error {
@@ -55,7 +56,8 @@ func (h *UrlExtractHandler) Extract(c *echo.Context) error {
 	log.Printf("extract-from-url: success url=%s name=%q hasImage=%v", req.URL, result.Name, result.ImageURL != "")
 
 	resp := ExtractFromURLResponse{
-		Name: result.Name,
+		Name:           result.Name,
+		NameCandidates: result.NameCandidates,
 	}
 	if result.ImageURL != "" {
 		resp.ImageURL = &result.ImageURL

--- a/backend/handler/url_extract_stream.go
+++ b/backend/handler/url_extract_stream.go
@@ -30,8 +30,9 @@ type sseProgressData struct {
 }
 
 type sseDoneData struct {
-	Name     string  `json:"name"`
-	ImageURL *string `json:"imageUrl"`
+	Name           string   `json:"name"`
+	ImageURL       *string  `json:"imageUrl"`
+	NameCandidates []string `json:"nameCandidates,omitempty"`
 }
 
 type sseErrorData struct {
@@ -57,8 +58,8 @@ func writeProgressEvent(w http.ResponseWriter, step, message string) error {
 	return writeSSEEvent(w, "progress", sseProgressData{Step: step, Message: message})
 }
 
-func writeDoneEvent(w http.ResponseWriter, name string, imageURL *string) error {
-	return writeSSEEvent(w, "done", sseDoneData{Name: name, ImageURL: imageURL})
+func writeDoneEvent(w http.ResponseWriter, name string, imageURL *string, candidates []string) error {
+	return writeSSEEvent(w, "done", sseDoneData{Name: name, ImageURL: imageURL, NameCandidates: candidates})
 }
 
 func writeErrorEvent(w http.ResponseWriter, kind, message, detail string) error {
@@ -107,6 +108,6 @@ func (h *UrlExtractStreamHandler) ExtractStream(c *echo.Context) error {
 	if result.ImageURL != "" {
 		imageURL = &result.ImageURL
 	}
-	_ = writeDoneEvent(w, result.Name, imageURL)
+	_ = writeDoneEvent(w, result.Name, imageURL, result.NameCandidates)
 	return nil
 }

--- a/backend/handler/url_extract_stream_test.go
+++ b/backend/handler/url_extract_stream_test.go
@@ -130,6 +130,57 @@ func TestExtractStream_ErrorPath_ErrorEventNoDone(t *testing.T) {
 	assert.Contains(t, errEvent["data"], `"kind":"fetchFailed"`)
 }
 
+func TestExtractStream_WithCandidates_DoneIncludesCandidates(t *testing.T) {
+	mock := &mockProgressExtractor{
+		result: urlextract.Result{
+			Name:           "長い商品名テストサンプル二十五文字以上",
+			ImageURL:       "",
+			NameCandidates: []string{"候補1", "候補2", "候補3"},
+		},
+	}
+	h := &UrlExtractStreamHandler{extractor: mock}
+	e := setupStreamRouter(h)
+
+	rec := postExtractStream(e, `{"url":"https://example.com/product"}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	events := parseSSEEvents(rec.Body.String())
+
+	var doneEvent map[string]string
+	for _, ev := range events {
+		if ev["event"] == "done" {
+			doneEvent = ev
+			break
+		}
+	}
+	require.NotNil(t, doneEvent, "done event must be present")
+	assert.Contains(t, doneEvent["data"], `"nameCandidates"`)
+	assert.Contains(t, doneEvent["data"], "候補1")
+}
+
+func TestExtractStream_WithoutCandidates_DoneOmitsCandidates(t *testing.T) {
+	mock := &mockProgressExtractor{
+		result: urlextract.Result{Name: "牛乳", ImageURL: ""},
+	}
+	h := &UrlExtractStreamHandler{extractor: mock}
+	e := setupStreamRouter(h)
+
+	rec := postExtractStream(e, `{"url":"https://example.com/product"}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	events := parseSSEEvents(rec.Body.String())
+
+	var doneEvent map[string]string
+	for _, ev := range events {
+		if ev["event"] == "done" {
+			doneEvent = ev
+			break
+		}
+	}
+	require.NotNil(t, doneEvent, "done event must be present")
+	assert.NotContains(t, doneEvent["data"], `"nameCandidates"`)
+}
+
 func TestExtractStream_EmptyURL_Returns400(t *testing.T) {
 	h := &UrlExtractStreamHandler{extractor: &mockProgressExtractor{}}
 	e := setupStreamRouter(h)

--- a/backend/handler/url_extract_test.go
+++ b/backend/handler/url_extract_test.go
@@ -69,6 +69,39 @@ func TestUrlExtract_200_noImage(t *testing.T) {
 	assert.Nil(t, resp.ImageURL)
 }
 
+func TestUrlExtract_200_withCandidates(t *testing.T) {
+	h := NewUrlExtractHandler(&mockExtractor{
+		result: urlextract.Result{
+			Name:           "長い商品名テストサンプル二十五文字以上",
+			ImageURL:       "https://example.com/img.jpg",
+			NameCandidates: []string{"候補A", "候補B"},
+		},
+	})
+	e := setupUrlExtractRouter(h)
+
+	rec := postExtractFromURL(e, `{"url":"https://example.com/product"}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp ExtractFromURLResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, []string{"候補A", "候補B"}, resp.NameCandidates)
+}
+
+func TestUrlExtract_200_noCandidates(t *testing.T) {
+	h := NewUrlExtractHandler(&mockExtractor{
+		result: urlextract.Result{Name: "牛乳", ImageURL: ""},
+	})
+	e := setupUrlExtractRouter(h)
+
+	rec := postExtractFromURL(e, `{"url":"https://example.com/product"}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var raw map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&raw))
+	_, present := raw["nameCandidates"]
+	assert.False(t, present, "nameCandidates key must be absent from JSON when there are no candidates")
+}
+
 func TestUrlExtract_400_emptyBody(t *testing.T) {
 	h := NewUrlExtractHandler(&mockExtractor{})
 	e := setupUrlExtractRouter(h)

--- a/backend/urlextract/claude_extractor.go
+++ b/backend/urlextract/claude_extractor.go
@@ -31,6 +31,19 @@ Rules:
 - If you cannot find an image URL, set "imageUrl" to an empty string
 - Do not include any other text or explanation`
 
+// candidatePrompt is the system prompt for name candidate generation.
+// It is marked with cache_control so the token cost is amortized across requests.
+const candidatePrompt = `You are a product name shortener. Given a long product name, generate up to 3 short, clean candidate names that a user could choose from.
+
+Respond ONLY with a JSON array of strings in this exact format:
+["candidate1", "candidate2", "candidate3"]
+
+Rules:
+- Each candidate must be 15 characters or fewer
+- Remove store/site suffixes, brand qualifiers, and model numbers where possible
+- Return between 1 and 3 candidates; fewer is fine if the name cannot be shortened meaningfully
+- Do not include any other text or explanation`
+
 // truncateText safely truncates a string to maxRunes characters, respecting UTF-8 rune boundaries.
 // This prevents panic when truncating multi-byte UTF-8 strings (e.g., Japanese text).
 func truncateText(s string, maxRunes int) string {
@@ -43,8 +56,9 @@ func truncateText(s string, maxRunes int) string {
 
 // ClaudeExtractor uses Claude Haiku to extract product name and image URL from page content.
 type ClaudeExtractor struct {
-	client    *anthropic.Client
-	extractFn func(ctx context.Context, content string, meta Result) (Result, error) // override for testing
+	client     *anthropic.Client
+	extractFn  func(ctx context.Context, content string, meta Result) (Result, error) // override for testing
+	generateFn func(ctx context.Context, name string) ([]string, error)               // override for testing
 }
 
 // NewClaudeExtractor returns a ClaudeExtractor if ANTHROPIC_API_KEY is set, otherwise nil.
@@ -123,4 +137,65 @@ func (e *ClaudeExtractor) Extract(ctx context.Context, content string, meta Resu
 		Name:     extracted.Name,
 		ImageURL: extracted.ImageURL,
 	}, nil
+}
+
+// GenerateCandidates asks Claude to generate up to 3 short name candidates for a long product name.
+// If the Claude call fails, it logs the error and returns ([]string{}, nil) for graceful degradation.
+func (e *ClaudeExtractor) GenerateCandidates(ctx context.Context, name string) ([]string, error) {
+	if e.generateFn != nil {
+		candidates, err := e.generateFn(ctx, name)
+		if err != nil {
+			log.Printf("claude: GenerateCandidates error (stub) err=%v", err)
+			return []string{}, nil
+		}
+		return candidates, nil
+	}
+
+	msg, err := e.client.Messages.New(ctx, anthropic.MessageNewParams{
+		Model:     claudeModel,
+		MaxTokens: 128,
+		System: []anthropic.TextBlockParam{
+			{
+				Text:         candidatePrompt,
+				CacheControl: anthropic.NewCacheControlEphemeralParam(),
+			},
+		},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(name)),
+		},
+	})
+	if err != nil {
+		log.Printf("claude: GenerateCandidates API error err=%v", err)
+		return []string{}, nil
+	}
+
+	var responseText string
+	for _, block := range msg.Content {
+		if block.Type == "text" {
+			responseText = block.Text
+			break
+		}
+	}
+
+	log.Printf("claude: GenerateCandidates raw response=%q", responseText)
+
+	if responseText == "" {
+		return []string{}, nil
+	}
+
+	responseText = strings.TrimSpace(responseText)
+	if strings.HasPrefix(responseText, "```") {
+		responseText = strings.TrimPrefix(responseText, "```json")
+		responseText = strings.TrimPrefix(responseText, "```")
+		responseText = strings.TrimSuffix(responseText, "```")
+		responseText = strings.TrimSpace(responseText)
+	}
+
+	var candidates []string
+	if err := json.Unmarshal([]byte(responseText), &candidates); err != nil {
+		log.Printf("claude: GenerateCandidates json unmarshal error err=%v response=%q", err, responseText)
+		return []string{}, nil
+	}
+
+	return candidates, nil
 }

--- a/backend/urlextract/claude_extractor_test.go
+++ b/backend/urlextract/claude_extractor_test.go
@@ -1,7 +1,9 @@
 package urlextract
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"unicode/utf8"
 
@@ -86,4 +88,31 @@ func TestClaudeResponseParsing_MalformedJSON(t *testing.T) {
 	err := json.Unmarshal([]byte(responseText), &extracted)
 	// Unmarshal should fail; ClaudeExtractor treats this as no result (returns empty Result)
 	assert.Error(t, err)
+}
+
+// TestGenerateCandidates_HappyPath verifies that GenerateCandidates returns the candidates
+// produced by generateFn when it succeeds.
+func TestGenerateCandidates_HappyPath(t *testing.T) {
+	want := []string{"候補1", "候補2", "候補3"}
+	e := &ClaudeExtractor{
+		generateFn: func(_ context.Context, _ string) ([]string, error) {
+			return want, nil
+		},
+	}
+	got, err := e.GenerateCandidates(context.Background(), "これは25文字以上の長い商品タイトルです")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+// TestGenerateCandidates_ErrorReturnsEmptySlice verifies that when generateFn returns an error,
+// GenerateCandidates swallows it and returns an empty (non-nil) slice with nil error.
+func TestGenerateCandidates_ErrorReturnsEmptySlice(t *testing.T) {
+	e := &ClaudeExtractor{
+		generateFn: func(_ context.Context, _ string) ([]string, error) {
+			return nil, errors.New("claude API down")
+		},
+	}
+	got, err := e.GenerateCandidates(context.Background(), "長い商品名テスト")
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, got)
 }

--- a/backend/urlextract/extractor.go
+++ b/backend/urlextract/extractor.go
@@ -95,6 +95,10 @@ func (e *DefaultExtractor) extractWithProgress(ctx context.Context, rawURL strin
 		if jinaErr != nil {
 			return Result{}, fmt.Errorf("step1: %v; %w", fetchErr, jinaErr)
 		}
+		if e.claude != nil && utf8.RuneCountInString(res.Name) >= 25 {
+			onProgress("generating_candidates", "名前の候補を生成中...")
+			res.NameCandidates, _ = e.claude.GenerateCandidates(ctx, res.Name)
+		}
 		return res, nil
 	}
 	log.Printf("urlextract: step1 fetch ok url=%s htmlBytes=%d", rawURL, len(htmlBytes))
@@ -121,7 +125,15 @@ func (e *DefaultExtractor) extractWithProgress(ctx context.Context, rawURL strin
 		if name == "" {
 			log.Printf("urlextract: step1 claude returned no name → trying Jina")
 			onProgress("fetching_jina", "別の方法でページを取得中...")
-			return e.extractViaJinaWithProgress(ctx, rawURL, onProgress)
+			res, jinaErr := e.extractViaJinaWithProgress(ctx, rawURL, onProgress)
+			if jinaErr != nil {
+				return Result{}, jinaErr
+			}
+			if utf8.RuneCountInString(res.Name) >= 25 {
+				onProgress("generating_candidates", "名前の候補を生成中...")
+				res.NameCandidates, _ = e.claude.GenerateCandidates(ctx, res.Name)
+			}
+			return res, nil
 		}
 		needImage := imageURL == ""
 		if utf8.RuneCountInString(name) >= 25 {

--- a/backend/urlextract/extractor.go
+++ b/backend/urlextract/extractor.go
@@ -23,8 +23,9 @@ var ErrExtractionFailed = errors.New("urlextract: extraction failed")
 type ProgressFunc func(step, message string)
 
 type Result struct {
-	Name     string
-	ImageURL string // empty if not found
+	Name           string
+	ImageURL       string   // empty if not found
+	NameCandidates []string // populated when name >= 25 runes and Claude is available
 }
 
 type Extractor interface {
@@ -36,9 +37,9 @@ type Extractor interface {
 //  2. Jina AI reader fallback (only when Step 1 fetch fails)
 //  3. Claude AI for clean product name extraction (when ANTHROPIC_API_KEY is configured)
 type DefaultExtractor struct {
-	fetcher      *Fetcher
-	jinaFetcher  *JinaFetcher
-	claude       *ClaudeExtractor // may be nil if ANTHROPIC_API_KEY is not set
+	fetcher     *Fetcher
+	jinaFetcher *JinaFetcher
+	claude      *ClaudeExtractor // may be nil if ANTHROPIC_API_KEY is not set
 }
 
 // NewDefaultExtractor creates a DefaultExtractor with all configured sub-extractors.
@@ -122,21 +123,21 @@ func (e *DefaultExtractor) extractWithProgress(ctx context.Context, rawURL strin
 			onProgress("fetching_jina", "別の方法でページを取得中...")
 			return e.extractViaJinaWithProgress(ctx, rawURL, onProgress)
 		}
-		// Supplement with Jina if name is too long or image is missing
-		needShorterName := utf8.RuneCountInString(name) >= 25
 		needImage := imageURL == ""
-		if needShorterName || needImage {
-			log.Printf("urlextract: step1 supplementing with Jina (needShorterName=%v needImage=%v nameRunes=%d)", needShorterName, needImage, utf8.RuneCountInString(name))
-			if needShorterName {
-				onProgress("generating_candidates", "名前の候補を生成中...")
+		if utf8.RuneCountInString(name) >= 25 {
+			onProgress("generating_candidates", "名前の候補を生成中...")
+			candidates, _ := e.claude.GenerateCandidates(ctx, name)
+			result := Result{Name: name, ImageURL: imageURL, NameCandidates: candidates}
+			if needImage {
+				if jinaRes, jinaErr := e.extractViaJina(ctx, rawURL); jinaErr == nil && jinaRes.ImageURL != "" {
+					result.ImageURL = jinaRes.ImageURL
+				}
 			}
-			if jinaRes, jinaErr := e.extractViaJina(ctx, rawURL); jinaErr == nil {
-				if needShorterName && jinaRes.Name != "" {
-					name = jinaRes.Name
-				}
-				if needImage && jinaRes.ImageURL != "" {
-					imageURL = jinaRes.ImageURL
-				}
+			return result, nil
+		}
+		if needImage {
+			if jinaRes, jinaErr := e.extractViaJina(ctx, rawURL); jinaErr == nil && jinaRes.ImageURL != "" {
+				imageURL = jinaRes.ImageURL
 			}
 		}
 		return Result{Name: name, ImageURL: imageURL}, nil
@@ -179,15 +180,9 @@ func (e *DefaultExtractor) extractViaJinaWithProgress(ctx context.Context, rawUR
 		}
 		name := claudeResult.Name
 		imageURL := claudeResult.ImageURL
-		if utf8.RuneCountInString(name) >= 25 || imageURL == "" {
-			log.Printf("urlextract: jina result incomplete (nameRunes=%d hasImage=%v) → supplementing from raw Jina", utf8.RuneCountInString(name), imageURL != "")
-			if imageURL == "" {
-				imageURL = imageURLFromJina(jinaResult.Images, jinaResult.Content, name)
-			}
-			if utf8.RuneCountInString(name) >= 25 && jinaResult.Title != "" &&
-				utf8.RuneCountInString(jinaResult.Title) < utf8.RuneCountInString(name) {
-				name = jinaResult.Title
-			}
+		if imageURL == "" {
+			log.Printf("urlextract: jina result missing image → supplementing from raw Jina")
+			imageURL = imageURLFromJina(jinaResult.Images, jinaResult.Content, name)
 		}
 		return Result{Name: name, ImageURL: imageURL}, nil
 	}
@@ -227,17 +222,9 @@ func (e *DefaultExtractor) extractViaJina(ctx context.Context, rawURL string) (R
 		}
 		name := claudeResult.Name
 		imageURL := claudeResult.ImageURL
-		// Supplement from raw Jina data if result is incomplete
-		if utf8.RuneCountInString(name) >= 25 || imageURL == "" {
-			log.Printf("urlextract: jina result incomplete (nameRunes=%d hasImage=%v) → supplementing from raw Jina", utf8.RuneCountInString(name), imageURL != "")
-			if imageURL == "" {
-				imageURL = imageURLFromJina(jinaResult.Images, jinaResult.Content, name)
-			}
-			// Use raw Jina title if it is shorter than what Claude returned
-			if utf8.RuneCountInString(name) >= 25 && jinaResult.Title != "" &&
-				utf8.RuneCountInString(jinaResult.Title) < utf8.RuneCountInString(name) {
-				name = jinaResult.Title
-			}
+		if imageURL == "" {
+			log.Printf("urlextract: jina result missing image → supplementing from raw Jina")
+			imageURL = imageURLFromJina(jinaResult.Images, jinaResult.Content, name)
 		}
 		return Result{Name: name, ImageURL: imageURL}, nil
 	}

--- a/backend/urlextract/extractor_test.go
+++ b/backend/urlextract/extractor_test.go
@@ -292,6 +292,40 @@ func collectSteps(t *testing.T, e *DefaultExtractor, url string) []string {
 	return steps
 }
 
+// TestDefaultExtractor_JinaFallback_LongName_GeneratesCandidates verifies that when the direct
+// fetch fails and the Jina-path Claude extraction returns a name >= 25 runes, GenerateCandidates
+// is called and NameCandidates is set on the result.
+func TestDefaultExtractor_JinaFallback_LongName_GeneratesCandidates(t *testing.T) {
+	directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "blocked", http.StatusInternalServerError)
+	}))
+	defer directTS.Close()
+
+	jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintln(w, `{"code":200,"data":{"title":"Jina商品名","content":"jina page text","images":{}}}`)
+	}))
+	defer jinaTS.Close()
+
+	longName := "これは25文字以上の長い商品タイトルですよJina経由"
+	wantCandidates := []string{"Jina候補1", "Jina候補2"}
+	fake := &ClaudeExtractor{
+		extractFn: func(_ context.Context, _ string, _ Result) (Result, error) {
+			return Result{Name: longName}, nil
+		},
+		generateFn: func(_ context.Context, _ string) ([]string, error) {
+			return wantCandidates, nil
+		},
+	}
+	jina := &JinaFetcher{HTTPClient: jinaTS.Client(), BaseURL: jinaTS.URL + "/"}
+	e := NewDefaultExtractorWithDeps(&Fetcher{HTTPClient: directTS.Client()}, jina, fake)
+
+	got, err := e.Extract(context.Background(), directTS.URL)
+	require.NoError(t, err)
+	assert.Equal(t, longName, got.Name)
+	assert.Equal(t, wantCandidates, got.NameCandidates, "Jina fallback should generate candidates for long names")
+}
+
 // TestExtractWithProgress_NormalPath verifies that fetching and extracting steps are reported
 // when the direct fetch succeeds and og:title is found (no Claude).
 func TestExtractWithProgress_NormalPath(t *testing.T) {

--- a/backend/urlextract/extractor_test.go
+++ b/backend/urlextract/extractor_test.go
@@ -215,9 +215,10 @@ func newStubExtractor(directTS *httptest.Server, jina *JinaFetcher, claudeResult
 	)
 }
 
-// TestDefaultExtractor_Step1ClaudeLongName_SupplementsFromJina verifies that when Step 1
-// Claude returns a name >= 25 runes, the extractor also calls Jina and uses its shorter name.
-func TestDefaultExtractor_Step1ClaudeLongName_SupplementsFromJina(t *testing.T) {
+// TestDefaultExtractor_Step1ClaudeLongName_GeneratesCandidates verifies that when Step 1
+// Claude returns a name >= 25 runes, GenerateCandidates is called and NameCandidates is set.
+// Jina should NOT be called when an image is already present.
+func TestDefaultExtractor_Step1ClaudeLongName_GeneratesCandidates(t *testing.T) {
 	jinaCallCount := 0
 	jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		jinaCallCount++
@@ -232,14 +233,25 @@ func TestDefaultExtractor_Step1ClaudeLongName_SupplementsFromJina(t *testing.T) 
 	}))
 	defer directTS.Close()
 
-	jina := &JinaFetcher{HTTPClient: jinaTS.Client(), BaseURL: jinaTS.URL + "/"}
 	longName := "これは25文字以上の長い商品タイトルですよ追加テキスト" // 26 runes
-	e := newStubExtractor(directTS, jina, Result{Name: longName, ImageURL: "https://meta.example.com/img.jpg"})
+	wantCandidates := []string{"候補1", "候補2", "候補3"}
+	fake := &ClaudeExtractor{
+		extractFn: func(_ context.Context, _ string, _ Result) (Result, error) {
+			return Result{Name: longName, ImageURL: "https://meta.example.com/img.jpg"}, nil
+		},
+		generateFn: func(_ context.Context, _ string) ([]string, error) {
+			return wantCandidates, nil
+		},
+	}
+	jina := &JinaFetcher{HTTPClient: jinaTS.Client(), BaseURL: jinaTS.URL + "/"}
+	e := NewDefaultExtractorWithDeps(&Fetcher{HTTPClient: directTS.Client()}, jina, fake)
 
 	got, err := e.Extract(context.Background(), directTS.URL)
 	require.NoError(t, err)
-	assert.Equal(t, "短い商品名", got.Name, "should use Jina's shorter name")
-	assert.Equal(t, 1, jinaCallCount, "Jina should be called to supplement")
+	assert.Equal(t, longName, got.Name, "original long name is preserved")
+	assert.Equal(t, wantCandidates, got.NameCandidates, "candidates from GenerateCandidates should be set")
+	assert.Equal(t, "https://meta.example.com/img.jpg", got.ImageURL)
+	assert.Equal(t, 0, jinaCallCount, "Jina should NOT be called when image is already present")
 }
 
 // TestDefaultExtractor_Step1ClaudeNoImage_SupplementsFromJina verifies that when Step 1
@@ -334,9 +346,14 @@ func TestExtractWithProgress_GeneratingCandidates(t *testing.T) {
 	defer jinaTS.Close()
 
 	longName := "これは25文字以上の長い商品タイトルですよ追加テキスト" // >= 25 runes
-	fake := &ClaudeExtractor{extractFn: func(_ context.Context, _ string, _ Result) (Result, error) {
-		return Result{Name: longName}, nil
-	}}
+	fake := &ClaudeExtractor{
+		extractFn: func(_ context.Context, _ string, _ Result) (Result, error) {
+			return Result{Name: longName}, nil
+		},
+		generateFn: func(_ context.Context, _ string) ([]string, error) {
+			return []string{"候補1"}, nil
+		},
+	}
 	jina := &JinaFetcher{HTTPClient: jinaTS.Client(), BaseURL: jinaTS.URL + "/"}
 	e := NewDefaultExtractorWithDeps(&Fetcher{HTTPClient: directTS.Client()}, jina, fake)
 	steps := collectSteps(t, e, directTS.URL)

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -9,6 +9,7 @@ if (fs.existsSync(envFile)) {
 }
 
 export default defineConfig({
+  reporter: [["list"], ["html"]],
   testDir: "./e2e",
   globalSetup: "./e2e/global-setup.ts",
   globalTeardown: "./e2e/global-teardown.ts",

--- a/frontend/src/components/UrlRegistrationModal.test.tsx
+++ b/frontend/src/components/UrlRegistrationModal.test.tsx
@@ -127,7 +127,7 @@ describe("UrlRegistrationModal", () => {
   it("fetching_jina ステップが動的に追加される", async () => {
     const user = userEvent.setup();
     // Never resolves — keep streaming state visible after progress
-    let resolveStream: () => void;
+    let resolveStream!: () => void;
     vi.mocked(extractFromUrlStream).mockImplementation(
       (_url, onProgress) =>
         new Promise<void>((resolve) => {

--- a/frontend/src/components/UrlRegistrationModal.test.tsx
+++ b/frontend/src/components/UrlRegistrationModal.test.tsx
@@ -152,7 +152,7 @@ describe("UrlRegistrationModal", () => {
         screen.getByText("別の方法でページを取得中..."),
       ).toBeInTheDocument();
     });
-    resolveStream!();
+    resolveStream?.();
   });
 
   it("抽出成功で onExtracted(name, imageUrl, sourceUrl) が呼ばれる", async () => {
@@ -359,6 +359,136 @@ describe("UrlRegistrationModal", () => {
     expect(
       screen.getByRole("button", { name: "詳細を隠す" }),
     ).toBeInTheDocument();
+  });
+
+  it("candidates があるとき nameSelection 状態で候補ボタンが表示される", async () => {
+    const user = userEvent.setup();
+    vi.mocked(extractFromUrlStream).mockImplementation(
+      async (_url, _onProgress, onDone) => {
+        onDone({
+          name: "とても長い商品名のサンプルテキストです",
+          imageUrl: "https://example.com/img.jpg",
+          nameCandidates: ["商品A", "商品B", "商品C"],
+        });
+      },
+    );
+    const onExtracted = vi.fn();
+
+    render(
+      <UrlRegistrationModal {...defaultProps} onExtracted={onExtracted} />,
+    );
+    await user.type(
+      screen.getByLabelText("商品ページの URL"),
+      "https://example.com",
+    );
+    await user.click(screen.getByRole("button", { name: "抽出" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("商品名を選択してください")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "商品A" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "商品B" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "商品C" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "とても長い商品名のサンプルテキストです（元の名前）",
+      }),
+    ).toBeInTheDocument();
+    expect(onExtracted).not.toHaveBeenCalled();
+  });
+
+  it("候補ボタンをクリックすると onExtracted が候補名で呼ばれる", async () => {
+    const user = userEvent.setup();
+    vi.mocked(extractFromUrlStream).mockImplementation(
+      async (_url, _onProgress, onDone) => {
+        onDone({
+          name: "とても長い商品名のサンプルテキストです",
+          imageUrl: "https://example.com/img.jpg",
+          nameCandidates: ["商品A", "商品B"],
+        });
+      },
+    );
+    const onExtracted = vi.fn();
+
+    render(
+      <UrlRegistrationModal {...defaultProps} onExtracted={onExtracted} />,
+    );
+    await user.type(
+      screen.getByLabelText("商品ページの URL"),
+      "https://example.com",
+    );
+    await user.click(screen.getByRole("button", { name: "抽出" }));
+
+    await screen.findByText("商品名を選択してください");
+    await user.click(screen.getByRole("button", { name: "商品A" }));
+
+    expect(onExtracted).toHaveBeenCalledWith(
+      "商品A",
+      "https://example.com/img.jpg",
+      "https://example.com",
+    );
+  });
+
+  it("元の名前ボタンをクリックすると onExtracted が元の名前で呼ばれる", async () => {
+    const user = userEvent.setup();
+    vi.mocked(extractFromUrlStream).mockImplementation(
+      async (_url, _onProgress, onDone) => {
+        onDone({
+          name: "とても長い商品名のサンプルテキストです",
+          imageUrl: null,
+          nameCandidates: ["商品A"],
+        });
+      },
+    );
+    const onExtracted = vi.fn();
+
+    render(
+      <UrlRegistrationModal {...defaultProps} onExtracted={onExtracted} />,
+    );
+    await user.type(
+      screen.getByLabelText("商品ページの URL"),
+      "https://example.com",
+    );
+    await user.click(screen.getByRole("button", { name: "抽出" }));
+
+    await screen.findByText("商品名を選択してください");
+    await user.click(
+      screen.getByRole("button", {
+        name: "とても長い商品名のサンプルテキストです（元の名前）",
+      }),
+    );
+
+    expect(onExtracted).toHaveBeenCalledWith(
+      "とても長い商品名のサンプルテキストです",
+      null,
+      "https://example.com",
+    );
+  });
+
+  it("nameSelection 状態でキャンセルボタンをクリックすると onClose が呼ばれる", async () => {
+    const user = userEvent.setup();
+    vi.mocked(extractFromUrlStream).mockImplementation(
+      async (_url, _onProgress, onDone) => {
+        onDone({
+          name: "とても長い商品名のサンプルテキストです",
+          imageUrl: null,
+          nameCandidates: ["候補X"],
+        });
+      },
+    );
+    const onClose = vi.fn();
+
+    render(<UrlRegistrationModal {...defaultProps} onClose={onClose} />);
+    await user.type(
+      screen.getByLabelText("商品ページの URL"),
+      "https://example.com",
+    );
+    await user.click(screen.getByRole("button", { name: "抽出" }));
+
+    await screen.findByText("商品名を選択してください");
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    expect(onClose).toHaveBeenCalled();
   });
 
   it("モーダルを閉じて再度開くと入力と状態がリセットされる", async () => {

--- a/frontend/src/components/UrlRegistrationModal.tsx
+++ b/frontend/src/components/UrlRegistrationModal.tsx
@@ -19,7 +19,7 @@ type UrlRegistrationModalProps = {
   activeGroupId?: string;
 };
 
-type ModalState = "idle" | "streaming" | "error";
+type ModalState = "idle" | "streaming" | "error" | "nameSelection";
 
 type StepStatus = "done" | "active" | "pending";
 
@@ -123,6 +123,12 @@ export default function UrlRegistrationModal({
   const [error, setError] = useState<unknown>(null);
   const [showDetail, setShowDetail] = useState(false);
   const [steps, setSteps] = useState<ExtractionStep[]>(BASE_STEPS);
+  const [selectionData, setSelectionData] = useState<{
+    name: string;
+    imageUrl: string | null;
+    candidates: string[];
+    sourceUrl: string;
+  } | null>(null);
 
   useEffect(() => {
     if (isOpen) {
@@ -131,6 +137,7 @@ export default function UrlRegistrationModal({
       setError(null);
       setShowDetail(false);
       setSteps(BASE_STEPS);
+      setSelectionData(null);
     }
   }, [isOpen]);
 
@@ -146,7 +153,17 @@ export default function UrlRegistrationModal({
         setSteps((prev) => applyProgress(prev, ev.step, ev.message));
       },
       (ev) => {
-        onExtracted(ev.name, ev.imageUrl, urlToSubmit);
+        if (ev.nameCandidates && ev.nameCandidates.length > 0) {
+          setSelectionData({
+            name: ev.name,
+            imageUrl: ev.imageUrl,
+            candidates: ev.nameCandidates,
+            sourceUrl: urlToSubmit,
+          });
+          setState("nameSelection");
+        } else {
+          onExtracted(ev.name, ev.imageUrl, urlToSubmit);
+        }
       },
       (err) => {
         setError(err);
@@ -230,6 +247,45 @@ export default function UrlRegistrationModal({
             </ol>
           )}
 
+          {state === "nameSelection" && selectionData && (
+            <div className="mb-4">
+              <p className="text-sm font-medium text-gray-700 mb-3">
+                商品名を選択してください
+              </p>
+              <div className="flex flex-col gap-2">
+                {selectionData.candidates.map((c) => (
+                  <button
+                    key={c}
+                    type="button"
+                    onClick={() =>
+                      onExtracted(
+                        c,
+                        selectionData.imageUrl,
+                        selectionData.sourceUrl,
+                      )
+                    }
+                    className="bg-[#00d1b2] hover:bg-[#00c4a7] text-white px-4 py-2 rounded font-medium text-sm text-left"
+                  >
+                    {c}
+                  </button>
+                ))}
+                <button
+                  type="button"
+                  onClick={() =>
+                    onExtracted(
+                      selectionData.name,
+                      selectionData.imageUrl,
+                      selectionData.sourceUrl,
+                    )
+                  }
+                  className="bg-gray-200 hover:bg-gray-300 text-gray-800 px-4 py-2 rounded font-medium text-sm text-left"
+                >
+                  {selectionData.name}（元の名前）
+                </button>
+              </div>
+            </div>
+          )}
+
           {state === "error" && errInfo && (
             <div className="mb-4">
               <p className="text-red-600 text-sm">{errInfo.message}</p>
@@ -279,7 +335,9 @@ export default function UrlRegistrationModal({
             </button>
             <button
               type="submit"
-              disabled={!url || state === "streaming"}
+              disabled={
+                !url || state === "streaming" || state === "nameSelection"
+              }
               className="bg-[#00d1b2] hover:bg-[#00c4a7] text-white px-4 py-2 rounded font-medium disabled:bg-gray-300 disabled:cursor-not-allowed"
             >
               抽出

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -146,6 +146,7 @@ export type ExtractionProgressEvent = {
 export type ExtractionDoneEvent = {
   name: string;
   imageUrl: string | null;
+  nameCandidates?: string[];
 };
 
 export type ExtractionErrorEvent = {

--- a/openspec/changes/archive/2026-05-24-name-candidates-and-e2e-reports/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-24-name-candidates-and-e2e-reports/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-24

--- a/openspec/changes/archive/2026-05-24-name-candidates-and-e2e-reports/design.md
+++ b/openspec/changes/archive/2026-05-24-name-candidates-and-e2e-reports/design.md
@@ -1,0 +1,64 @@
+## Context
+
+### 現在の構成
+
+**バックエンド**:
+- `DefaultExtractor.extractWithProgress` が1st Claude コールで name を取得した後、`utf8.RuneCountInString(name) >= 25` のとき Jina を呼んで shorter name を上書きしている（精度が低い）
+- Jina は fetch fallback（直接取得失敗時）とimage fallback（画像が見つからない時）にも使われており、今回は name 短縮用途のみ廃止する
+- `Result` struct は `{ Name, ImageURL }` のみ保持
+
+**フロントエンド**:
+- `extractFromUrlStream` の done event で `onExtracted(name, imageUrl, sourceUrl)` が即時呼ばれる
+- `UrlRegistrationModal` は `"idle" | "streaming" | "error"` の 3 state しかない
+
+**CI**:
+- `e2e.yml`: mock テストのみ、Playwright レポート未保存
+- `e2e-preview.yml`: preview テストのみ、Playwright レポート未保存
+
+## Goals / Non-Goals
+
+**Goals:**
+- name >= 25 文字のとき Claude 2nd コールで短縮候補 3 件を生成し、ユーザーが選択できるようにする
+- `UrlRegistrationModal` に `nameSelection` ステップを追加して候補選択 UI を表示する
+- `e2e.yml` / `e2e-preview.yml` の両方で Playwright HTML レポートを GHA アーティファクトとして保存する
+
+**Non-Goals:**
+- Jina fetch fallback・image fallback の廃止（name 短縮用途のみ削除）
+- DB への name candidates 保存
+- 候補数の 3 件以上への拡張
+- 非同期 API (`/api/extract-from-url` non-stream) のレスポンス変更（stream エンドポイントのみ対応）
+
+## Decisions
+
+### 1. ClaudeExtractor に `GenerateCandidates` メソッドを追加
+
+`ClaudeExtractor` に `GenerateCandidates(ctx, name) ([]string, error)` を追加し、専用プロンプトで短縮候補 JSON 配列を返す。  
+**理由**: 既存の `Extract` とは責務が異なる。独立したメソッドにすることでテストが書きやすく、プロンプト調整も独立して行える。
+
+### 2. `Result` struct に `NameCandidates []string` を追加
+
+`Result.NameCandidates` を追加し、`extractWithProgress` が Jina 短縮の代わりに Claude candidates を格納して返す。  
+**理由**: 既存の呼び出し側 (handler, stream handler) は `Result` を受け取るだけなので、シグネチャ変更なしに candidates を伝播できる。
+
+### 3. done event に `nameCandidates?: string[]` を追加
+
+SSE `event: done` の data に `nameCandidates` フィールドを追加（空のときは省略）。  
+**理由**: フロントエンドが SSE から candidates を受け取るのが最も自然。non-stream エンドポイントは今回スコープ外（将来必要であれば同じ `Result` 構造から追加できる）。
+
+### 4. `ModalState` に `"nameSelection"` を追加
+
+done event で `nameCandidates` があるとき、`onExtracted` 呼び出しを遅延させ、modal 内で選択 UI を表示する。  
+**理由**: 新しいモーダルコンポーネントを作るより、既存の `UrlRegistrationModal` 内で state 遷移させるほうがシンプル。選択後に `onExtracted(selectedName, imageUrl, sourceUrl)` を呼ぶ。
+
+### 5. GHA に `if: always()` + `upload-artifact`
+
+`e2e.yml` と `e2e-preview.yml` の両方に `actions/upload-artifact` を追加（`if: always()`）。  
+mock と preview でアーティファクト名を分ける（例: `playwright-report-mock`, `playwright-report-preview`）。  
+**理由**: テスト失敗時もレポートを保存したいため `if: always()` が必須。
+
+## Risks / Trade-offs
+
+- **2nd Claude コール失敗**: `GenerateCandidates` が error または不正 JSON を返した場合、candidates なし（empty slice）で done event を送る。ユーザーは元の name をそのまま使う。
+- **候補が 15 文字制限を守らない可能性**: プロンプトで制約するが LLM は 100% 従わない。UI では候補をそのまま表示し、ユーザーが判断する。
+- **Playwright HTML reporter 設定**: `playwright.config.ts` に `reporter: 'html'` が設定されていない場合、`playwright-report/` が生成されない。実装前に確認が必要。
+- **e2e-preview.yml の実行権限**: `actions/upload-artifact` は `deployment_status` イベントでは `id-token: write` 不要だが、`permissions` ブロックに `contents: read` を追加する必要がある可能性がある。

--- a/openspec/changes/archive/2026-05-24-name-candidates-and-e2e-reports/proposal.md
+++ b/openspec/changes/archive/2026-05-24-name-candidates-and-e2e-reports/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+URL から商品登録する際、25 文字以上の商品名を Jina で短縮しようとしているが精度が低く、ユーザーに不正確な名前が提案される。代わりに Claude に短縮候補を複数生成させ、ユーザーが選べる UI に変更する。また、E2E テスト失敗時に Playwright レポートが GHA 上に残らないため、Flakiness の調査に手間がかかっている。
+
+## What Changes
+
+- **バックエンド**: `extractor.go` から Jina 経由の名前短縮ロジックを削除。代わりに抽出名が 25 文字以上のとき 2nd Claude コールで短縮候補 3 つを生成し、API レスポンスに `nameCandidates: string[]` を追加する（短い場合はフィールド省略）
+- **バックエンド**: `POST /api/extract-from-url` と `POST /api/extract-from-url/stream` の両方で `nameCandidates` を返す
+- **フロントエンド**: `UrlRegistrationModal` に `nameSelection` ステップを追加。`nameCandidates` が返ってきたとき、3 候補 ＋ 元の名前から 1 つを選択させる UI を表示する
+- **フロントエンド**: `UrlRegistrationModal` の「name ≥ 25 文字のとき step2 に移行」という条件分岐を削除（候補選択が同じ役割を担う）
+- **CI**: `e2e.yml` の Mock・Preview テストジョブに `actions/upload-artifact` を追加し、Playwright レポートを GHA アーティファクトとして保存・ダウンロード可能にする
+
+## Capabilities
+
+### New Capabilities
+
+- `name-candidates-selection`: URL 抽出後に長い商品名の短縮候補をユーザーが選択するフロー
+
+### Modified Capabilities
+
+- `url-product-extraction`: API レスポンスに `nameCandidates?: string[]` フィールドを追加。Jina 名前短縮は廃止
+- `extraction-progress-streaming`: SSE `event: done` のデータスキーマに `nameCandidates?: string[]` を追加
+
+## Impact
+
+- `backend/internal/extractor/extractor.go`: Jina 短縮ロジック削除、2nd Claude コール追加
+- `backend/internal/extractor/extractor_test.go`: 関連テスト更新
+- `frontend/src/components/UrlRegistrationModal.tsx`: nameSelection ステップ追加、step 条件削除
+- `frontend/src/components/UrlRegistrationModal.test.tsx`: 関連テスト追加
+- `.github/workflows/e2e.yml`: upload-artifact ステップ追加

--- a/openspec/changes/archive/2026-05-24-name-candidates-and-e2e-reports/specs/extraction-progress-streaming/spec.md
+++ b/openspec/changes/archive/2026-05-24-name-candidates-and-e2e-reports/specs/extraction-progress-streaming/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: SSE event frame schema
+The system SHALL use the following SSE frame schemas.
+
+#### Scenario: Progress frame schema is well-formed
+- **WHEN** a progress frame is emitted
+- **THEN** it has the format `event: progress\ndata: {"step":"<id>","message":"<ja-text>"}\n\n`
+- **AND** `step` SHALL be one of: `fetching`, `fetching_jina`, `extracting`, `generating_candidates`
+
+#### Scenario: Done frame schema is well-formed
+- **WHEN** a done frame is emitted and the extracted name is fewer than 25 Unicode characters
+- **THEN** it has the format `event: done\ndata: {"name":"<string>","imageUrl":"<string|null>"}\n\n`
+
+#### Scenario: Done frame includes nameCandidates when name is long
+- **WHEN** a done frame is emitted and the extracted name is 25 or more Unicode characters
+- **AND** Claude successfully generates name candidates
+- **THEN** the done frame data includes `"nameCandidates": ["<c1>","<c2>","<c3>"]` in addition to `name` and `imageUrl`
+- **AND** each candidate SHALL be 15 or fewer Unicode characters
+
+#### Scenario: Done frame omits nameCandidates when candidates call fails
+- **WHEN** a done frame is emitted and the extracted name is 25+ characters
+- **AND** the Claude candidates call fails
+- **THEN** the done frame data contains only `name` and `imageUrl` (no `nameCandidates` field)
+
+#### Scenario: Error frame schema is well-formed
+- **WHEN** an error frame is emitted
+- **THEN** it has the format `event: error\ndata: {"kind":"<kind>","message":"<string>","detail":"<string>"}\n\n`
+- **AND** `kind` SHALL be one of: `fetchFailed`, `extractionFailed`, `unknown`

--- a/openspec/changes/archive/2026-05-24-name-candidates-and-e2e-reports/specs/name-candidates-selection/spec.md
+++ b/openspec/changes/archive/2026-05-24-name-candidates-and-e2e-reports/specs/name-candidates-selection/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Show name candidate selection UI when candidates are returned
+The system SHALL display a name selection step in `UrlRegistrationModal` when the stream done event includes a non-empty `nameCandidates` array, allowing the user to choose one before proceeding to `CreateItemModal`.
+
+#### Scenario: Candidate selection shown after extraction completes
+- **WHEN** the SSE stream emits `event: done` with `nameCandidates: ["候補A", "候補B", "候補C"]`
+- **THEN** `UrlRegistrationModal` transitions to a `nameSelection` state
+- **AND** displays all candidates plus the original (extracted) name as selectable options
+- **AND** does NOT immediately call `onExtracted` or open `CreateItemModal`
+
+#### Scenario: User selects a candidate
+- **WHEN** the user clicks one of the candidate buttons or the original name button
+- **THEN** `UrlRegistrationModal` closes
+- **AND** `CreateItemModal` opens with the selected name as `initialName`
+
+#### Scenario: No candidate selection UI when name is short
+- **WHEN** the SSE stream emits `event: done` with no `nameCandidates` field (or empty array)
+- **THEN** `UrlRegistrationModal` behaves as before: immediately calls `onExtracted` and closes
+
+#### Scenario: User can cancel during candidate selection
+- **WHEN** the modal is in `nameSelection` state
+- **AND** the user clicks the cancel button
+- **THEN** `UrlRegistrationModal` closes without calling `onExtracted`

--- a/openspec/changes/archive/2026-05-24-name-candidates-and-e2e-reports/specs/url-product-extraction/spec.md
+++ b/openspec/changes/archive/2026-05-24-name-candidates-and-e2e-reports/specs/url-product-extraction/spec.md
@@ -1,0 +1,24 @@
+## REMOVED Requirements
+
+### Requirement: Jina-based name shortening
+**Reason**: Jina の名前短縮は精度が低い。Claude による候補生成に置き換える。
+**Migration**: 名前が 25 文字以上の場合は Claude 2nd コールで短縮候補を生成する（`nameCandidates` フィールド参照）。Jina は fetch fallback および image fallback としての用途のみ継続。
+
+## ADDED Requirements
+
+### Requirement: Return name candidates for long product names
+The system SHALL generate up to 3 shortened name candidates via a second Claude call when the extracted name is 25 or more Unicode characters, and include them in the API response as `nameCandidates: string[]`.
+
+#### Scenario: Candidates generated for long name via POST /api/extract-from-url
+- **WHEN** `POST /api/extract-from-url` succeeds and the extracted name has 25+ Unicode characters
+- **THEN** the response body includes `"nameCandidates": ["候補1", "候補2", "候補3"]` alongside `"name"` and `"imageUrl"`
+- **AND** each candidate SHALL be 15 or fewer Unicode characters
+
+#### Scenario: No candidates for short name
+- **WHEN** `POST /api/extract-from-url` succeeds and the extracted name is fewer than 25 Unicode characters
+- **THEN** the response body does NOT include a `nameCandidates` field
+
+#### Scenario: Candidates omitted when Claude call fails
+- **WHEN** the Claude candidates call fails (network error, API error, or invalid JSON response)
+- **THEN** the API returns 200 with `name` and `imageUrl` as normal
+- **AND** `nameCandidates` is omitted from the response (graceful degradation)

--- a/openspec/changes/archive/2026-05-24-name-candidates-and-e2e-reports/tasks.md
+++ b/openspec/changes/archive/2026-05-24-name-candidates-and-e2e-reports/tasks.md
@@ -1,0 +1,27 @@
+## 1. バックエンド: Result 型と候補生成ロジック
+
+- [x] 1.1 `Result` struct に `NameCandidates []string` フィールドを追加する (`urlextract/extractor.go`)
+- [x] 1.2 `ClaudeExtractor` に `GenerateCandidates(ctx, name string) ([]string, error)` メソッドを追加する（専用プロンプト、JSON 配列を返す）
+- [x] 1.3 `extractWithProgress` の Jina 名前短縮ブロック（`needShorterName` 判定）を削除し、代わりに name >= 25 文字のとき `GenerateCandidates` を呼んで `Result.NameCandidates` にセットする
+- [x] 1.4 `GenerateCandidates` の単体テストを追加する（正常系: 候補 3 件返却、エラー系: API 失敗時は empty slice）
+- [x] 1.5 `extractWithProgress` の統合テストを更新する（Jina 短縮の削除・candidates 生成のモック）
+
+## 2. バックエンド: ハンドラーと SSE レスポンス
+
+- [x] 2.1 `POST /api/extract-from-url` ハンドラーのレスポンス型に `NameCandidates []string` を追加し、`Result.NameCandidates` をマッピングする（空のときはフィールドを省略: `omitempty`）
+- [x] 2.2 `POST /api/extract-from-url/stream` ハンドラーの done event データ型に `NameCandidates []string` を追加し、`Result.NameCandidates` をマッピングする（`omitempty`）
+- [x] 2.3 ハンドラーの単体テスト・統合テストを更新する（candidates あり・なし両方）
+
+## 3. フロントエンド: API 型と候補選択 UI
+
+- [x] 3.1 `ExtractionDoneEvent` 型に `nameCandidates?: string[]` を追加する (`frontend/src/lib/api.ts`)
+- [x] 3.2 `UrlRegistrationModal` の `ModalState` に `"nameSelection"` を追加し、done event で `nameCandidates` があるとき `onExtracted` を遅延させて `nameSelection` 状態に遷移させる
+- [x] 3.3 `nameSelection` 状態時の候補選択 UI を実装する（候補ボタン一覧 ＋ 元の名前ボタン、選択後に `onExtracted(selected, imageUrl, sourceUrl)` を呼ぶ）
+- [x] 3.4 `nameSelection` 状態でキャンセルボタンが機能することを確認する（`onClose` 呼び出し）
+- [x] 3.5 `UrlRegistrationModal` のテストを追加・更新する（candidates あり: selection UI 表示、candidates なし: 従来フロー）
+
+## 4. CI: Playwright レポートの GHA 保存
+
+- [x] 4.1 `playwright.config.ts` に `reporter: [['list'], ['html']]` を追加して CI でも HTML レポートが生成されるようにする
+- [x] 4.2 `e2e.yml` の mock テストジョブに `if: always()` 付きで `actions/upload-artifact` ステップを追加する（アーティファクト名: `playwright-report-mock`、パス: `frontend/playwright-report`）
+- [x] 4.3 `e2e-preview.yml` の preview テストジョブに `if: always()` 付きで `actions/upload-artifact` ステップを追加する（アーティファクト名: `playwright-report-preview`、パス: `frontend/playwright-report`）

--- a/openspec/specs/extraction-progress-streaming/spec.md
+++ b/openspec/specs/extraction-progress-streaming/spec.md
@@ -37,8 +37,19 @@ The system SHALL use the following SSE frame schemas.
 - **AND** `step` SHALL be one of: `fetching`, `fetching_jina`, `extracting`, `generating_candidates`
 
 #### Scenario: Done frame schema is well-formed
-- **WHEN** a done frame is emitted
+- **WHEN** a done frame is emitted and the extracted name is fewer than 25 Unicode characters
 - **THEN** it has the format `event: done\ndata: {"name":"<string>","imageUrl":"<string|null>"}\n\n`
+
+#### Scenario: Done frame includes nameCandidates when name is long
+- **WHEN** a done frame is emitted and the extracted name is 25 or more Unicode characters
+- **AND** Claude successfully generates name candidates
+- **THEN** the done frame data includes `"nameCandidates": ["<c1>","<c2>","<c3>"]` in addition to `name` and `imageUrl`
+- **AND** each candidate SHALL be 15 or fewer Unicode characters
+
+#### Scenario: Done frame omits nameCandidates when candidates call fails
+- **WHEN** a done frame is emitted and the extracted name is 25+ characters
+- **AND** the Claude candidates call fails
+- **THEN** the done frame data contains only `name` and `imageUrl` (no `nameCandidates` field)
 
 #### Scenario: Error frame schema is well-formed
 - **WHEN** an error frame is emitted

--- a/openspec/specs/name-candidates-selection/spec.md
+++ b/openspec/specs/name-candidates-selection/spec.md
@@ -1,0 +1,29 @@
+# name-candidates-selection Specification
+
+## Purpose
+When the backend extracts a product name that is 25 or more Unicode characters long, the frontend presents a name candidate selection step, allowing the user to choose a shorter variant before creating the item.
+
+## Requirements
+
+### Requirement: Show name candidate selection UI when candidates are returned
+The system SHALL display a name selection step in `UrlRegistrationModal` when the stream done event includes a non-empty `nameCandidates` array, allowing the user to choose one before proceeding to `CreateItemModal`.
+
+#### Scenario: Candidate selection shown after extraction completes
+- **WHEN** the SSE stream emits `event: done` with `nameCandidates: ["候補A", "候補B", "候補C"]`
+- **THEN** `UrlRegistrationModal` transitions to a `nameSelection` state
+- **AND** displays all candidates plus the original (extracted) name as selectable options
+- **AND** does NOT immediately call `onExtracted` or open `CreateItemModal`
+
+#### Scenario: User selects a candidate
+- **WHEN** the user clicks one of the candidate buttons or the original name button
+- **THEN** `UrlRegistrationModal` closes
+- **AND** `CreateItemModal` opens with the selected name as `initialName`
+
+#### Scenario: No candidate selection UI when name is short
+- **WHEN** the SSE stream emits `event: done` with no `nameCandidates` field (or empty array)
+- **THEN** `UrlRegistrationModal` behaves as before: immediately calls `onExtracted` and closes
+
+#### Scenario: User can cancel during candidate selection
+- **WHEN** the modal is in `nameSelection` state
+- **AND** the user clicks the cancel button
+- **THEN** `UrlRegistrationModal` closes without calling `onExtracted`

--- a/openspec/specs/url-product-extraction/spec.md
+++ b/openspec/specs/url-product-extraction/spec.md
@@ -107,3 +107,20 @@ The system SHALL display a collapsible "詳細を表示" section in `UrlRegistra
 - **WHEN** an extraction error is shown
 - **AND** the response body has no `detail` field (or it is empty)
 - **THEN** no "詳細を表示" button is rendered
+
+### Requirement: Return name candidates for long product names
+The system SHALL generate up to 3 shortened name candidates via a second Claude call when the extracted name is 25 or more Unicode characters, and include them in the API response as `nameCandidates: string[]`.
+
+#### Scenario: Candidates generated for long name via POST /api/extract-from-url
+- **WHEN** `POST /api/extract-from-url` succeeds and the extracted name has 25+ Unicode characters
+- **THEN** the response body includes `"nameCandidates": ["候補1", "候補2", "候補3"]` alongside `"name"` and `"imageUrl"`
+- **AND** each candidate SHALL be 15 or fewer Unicode characters
+
+#### Scenario: No candidates for short name
+- **WHEN** `POST /api/extract-from-url` succeeds and the extracted name is fewer than 25 Unicode characters
+- **THEN** the response body does NOT include a `nameCandidates` field
+
+#### Scenario: Candidates omitted when Claude call fails
+- **WHEN** the Claude candidates call fails (network error, API error, or invalid JSON response)
+- **THEN** the API returns 200 with `name` and `imageUrl` as normal
+- **AND** `nameCandidates` is omitted from the response (graceful degradation)


### PR DESCRIPTION
## Summary

- **長い商品名の候補選択 UI**: 抽出名が 25 文字以上のとき Claude が短縮候補（最大 3 件）を生成し、`UrlRegistrationModal` で選択 UI を表示。Jina ベースの名前短縮を廃止
- **Playwright レポート GHA 保存**: `e2e.yml` / `e2e-preview.yml` の両方で HTML レポートをアーティファクトとして保存（`if: always()`）

## Changes

- `ci`: `playwright.config.ts` に `reporter: [['list'], ['html']]` 追加、`e2e.yml` / `e2e-preview.yml` に `upload-artifact` ステップ追加
- `backend/urlextract`: `Result.NameCandidates []string`、`ClaudeExtractor.GenerateCandidates` メソッド追加。Jina 名前短縮削除。Jina fallback パスでも candidates 生成
- `backend/handler`: `ExtractFromURLResponse` / `sseDoneData` に `NameCandidates` (`omitempty`) 追加
- `frontend`: `ExtractionDoneEvent.nameCandidates?: string[]`、`ModalState` に `"nameSelection"` 追加、候補選択 UI 実装

## Test plan

- [ ] Backend: `go test ./...` passes (unit + urlextract tests)
- [ ] Frontend: `npx vitest run` passes (197 tests)
- [ ] CI が green になることを確認
- [ ] 実際に長い名前の商品 URL を入力して候補選択 UI が表示されることを確認

Closes #120