### PR TITLE
style: modernize header group/invite/sign-out buttons

### DIFF
--- a/docs/superpowers/plans/2026-05-24-header-modern-design.md
+++ b/docs/superpowers/plans/2026-05-24-header-modern-design.md
@@ -1,0 +1,238 @@
+# Header Modern Design Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ヘッダー右側のグループ切り替え・招待リンク・サインアウトボタンを、統一感のあるアイコンボタンスタイルに変更する。
+
+**Architecture:** `GroupSwitcher.tsx` のトリガーボタンと `StockItemsClient.tsx` のヘッダー要素のみを修正する。機能変更なし、スタイルのみ。既存テストはクラス名に依存していないため変更不要。
+
+**Tech Stack:** Next.js (TypeScript), Tailwind CSS v4, react-icons v5
+
+---
+
+## File Map
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `frontend/src/components/GroupSwitcher.tsx` | トリガーボタンのクラスを新スタイルに変更 |
+| `frontend/src/app/stock-items/StockItemsClient.tsx` | 招待リンクとサインアウトボタンのスタイルを変更 |
+
+テストファイルへの変更は不要（テストはクラス名に依存していない）。
+
+---
+
+## 共通ボタンスタイル（参照）
+
+```
+bg-black/20 hover:bg-black/30 transition-colors rounded-lg
+h-8 flex items-center gap-1.5 px-2.5 text-sm cursor-pointer border-0 text-white
+```
+
+アイコンのみボタン（サインアウト）は `px-2.5` の代わりに `w-8 justify-center px-0`。
+
+---
+
+## Task 1: GroupSwitcher のトリガーボタンを更新
+
+**Files:**
+- Modify: `frontend/src/components/GroupSwitcher.tsx`
+
+### 背景
+
+現在のトリガーボタン（`GroupSwitcher.tsx:75-82`）は `opacity-80 hover:opacity-100` のシンプルな白テキスト。これを `MdGroup` アイコン + グループ名 + `MdExpandMore` アイコンの角丸ボックスに変更する。
+
+- [ ] **Step 1: ブランチを作成する**
+
+```bash
+gh issue create --title "モダンなヘッダーデザイン" --body "グループ・招待・サインアウトのスタイルをアイコンボタンに変更する。設計: docs/superpowers/specs/2026-05-24-header-modern-design.md"
+# 出力されたIssue番号を使ってブランチを作成（例: Issue #130 なら）
+git checkout -b 130-header-modern-design
+```
+
+- [ ] **Step 2: 既存テストがパスすることを確認する（ベースライン）**
+
+```bash
+cd frontend && npx vitest run src/components/GroupSwitcher.test.tsx
+```
+
+Expected: 6 tests pass。
+
+- [ ] **Step 3: GroupSwitcher.tsx のトリガーボタンを更新する**
+
+`frontend/src/components/GroupSwitcher.tsx` の先頭 import に追加:
+
+```tsx
+import { MdExpandMore, MdGroup } from "react-icons/md";
+```
+
+トリガーボタン部分（現在の `return` 内、`<div className="relative" ...>` の直下のボタン）を以下に置き換える:
+
+```tsx
+<button
+  type="button"
+  onClick={() => setOpen((v) => !v)}
+  className="flex items-center gap-1.5 h-8 px-2.5 rounded-lg bg-black/20 hover:bg-black/30 transition-colors text-sm text-white cursor-pointer border-0"
+>
+  <MdGroup aria-hidden size={16} />
+  {activeGroup?.name ?? "グループなし"}
+  <MdExpandMore aria-hidden size={16} className="opacity-70" />
+</button>
+```
+
+- [ ] **Step 4: テストを再実行して既存テストがパスすることを確認する**
+
+```bash
+cd frontend && npx vitest run src/components/GroupSwitcher.test.tsx
+```
+
+Expected: 6 tests pass（スタイル変更のみでテストへの影響なし）。
+
+- [ ] **Step 5: コミットする**
+
+```bash
+git add frontend/src/components/GroupSwitcher.tsx
+git commit -m "style: modernize GroupSwitcher trigger button with icon"
+git push -u origin HEAD
+```
+
+---
+
+## Task 2: StockItemsClient のヘッダー要素を更新
+
+**Files:**
+- Modify: `frontend/src/app/stock-items/StockItemsClient.tsx`
+
+### 背景
+
+ヘッダー内の招待リンク（`StockItemsClient.tsx:207-213`）とサインアウトボタン（`StockItemsClient.tsx:214-221`）を更新する。招待は `MdLink` + "招待" テキスト、サインアウトは `MdLogout` アイコンのみ。
+
+- [ ] **Step 1: 既存テストがパスすることを確認する（ベースライン）**
+
+```bash
+cd frontend && npx vitest run src/app/stock-items/page.test.tsx
+```
+
+Expected: すべてのテストがパスすること。
+
+- [ ] **Step 2: StockItemsClient.tsx の import を更新する**
+
+現在:
+```tsx
+import { MdLink } from "react-icons/md";
+```
+
+以下に変更:
+```tsx
+import { MdLink, MdLogout } from "react-icons/md";
+```
+
+- [ ] **Step 3: 招待リンクのスタイルを更新する**
+
+現在（`StockItemsClient.tsx:207-213` あたり）:
+```tsx
+{group?.role === "owner" && (
+  <a
+    href="/invite"
+    className="opacity-80 hover:opacity-100 underline"
+  >
+    招待
+  </a>
+)}
+```
+
+以下に変更:
+```tsx
+{group?.role === "owner" && (
+  <a
+    href="/invite"
+    className="flex items-center gap-1.5 h-8 px-2.5 rounded-lg bg-black/20 hover:bg-black/30 transition-colors text-sm text-white no-underline"
+  >
+    <MdLink aria-hidden size={16} />
+    招待
+  </a>
+)}
+```
+
+- [ ] **Step 4: サインアウトボタンのスタイルを更新する**
+
+現在（`StockItemsClient.tsx:214-221` あたり）:
+```tsx
+<button
+  type="button"
+  onClick={() => signOut()}
+  className="opacity-80 hover:opacity-100"
+>
+  サインアウト
+</button>
+```
+
+以下に変更:
+```tsx
+<button
+  type="button"
+  onClick={() => signOut()}
+  title="サインアウト"
+  className="flex items-center justify-center w-8 h-8 rounded-lg bg-black/20 hover:bg-black/30 transition-colors text-white border-0 cursor-pointer"
+>
+  <MdLogout aria-hidden size={18} />
+</button>
+```
+
+- [ ] **Step 5: テストを再実行して既存テストがパスすることを確認する**
+
+```bash
+cd frontend && npx vitest run src/app/stock-items/page.test.tsx
+```
+
+Expected: すべてのテストがパスすること。
+
+- [ ] **Step 6: ローカルで動作確認する**
+
+```bash
+cd frontend && npm run dev
+```
+
+ブラウザで `http://localhost:3000/stock-items` を開き、以下を確認する:
+- グループ切り替えボタンがアイコン+名前+chevron の角丸ボックスで表示される
+- 招待リンク（オーナーのみ）がアイコン+"招待" の角丸ボックスで表示される
+- サインアウトがアイコンのみの正方形ボタンで表示される
+- ホバー時にボタンが少し濃くなる
+- サインアウトボタンにカーソルを当てると title ツールチップが出る
+
+- [ ] **Step 7: コミットしてプッシュする**
+
+```bash
+git add frontend/src/app/stock-items/StockItemsClient.tsx
+git commit -m "style: modernize header invite link and sign-out button"
+git push
+```
+
+---
+
+## Task 3: PR を作成して CI を確認する
+
+- [ ] **Step 1: PR を作成する**
+
+```bash
+gh pr create \
+  --title "style: modernize header group/invite/signout buttons" \
+  --body "$(cat <<'EOF'
+## Summary
+- グループ切り替えトリガーを MdGroup アイコン + グループ名 + chevron の角丸ボックスに変更
+- 招待リンクを MdLink アイコン + "招待" テキストの角丸ボックスに変更（オーナーのみ）
+- サインアウトを MdLogout アイコンのみの正方形ボタンに変更
+
+機能変更なし。スタイルのみ。
+
+Closes #ISSUE番号
+EOF
+)"
+```
+
+- [ ] **Step 2: CI を確認する**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: すべてのチェックがパスすること。失敗があれば原因を調査して修正する。

--- a/docs/superpowers/specs/2026-05-24-header-modern-design.md
+++ b/docs/superpowers/specs/2026-05-24-header-modern-design.md
@@ -1,0 +1,60 @@
+# Header Modern Design
+
+**Date:** 2026-05-24
+**Scope:** `StockItemsClient.tsx` のヘッダー右側 — グループ切り替え・招待リンク・サインアウトボタン
+
+## 概要
+
+ヘッダー右側の3要素（GroupSwitcher・招待リンク・サインアウト）を、現在の opacity のみのスタイルから、統一感のあるアイコンボタンスタイルに変更する。
+
+## 現状
+
+```jsx
+<div className="flex items-center gap-3 text-sm">
+  <GroupSwitcher ... />   {/* 白テキスト + ▾ */}
+  <a className="opacity-80 hover:opacity-100 underline">招待</a>
+  <button className="opacity-80 hover:opacity-100">サインアウト</button>
+</div>
+```
+
+## 新デザイン仕様
+
+### ボタン共通スタイル
+
+| プロパティ | 値 |
+|-----------|-----|
+| 背景色 | `bg-black/20 hover:bg-black/30` |
+| 角丸 | `rounded-lg` (8px) |
+| 高さ | `h-8` (32px) |
+| トランジション | `transition-colors` |
+
+### 各要素
+
+| 要素 | 表示内容 | 補足 |
+|------|---------|------|
+| グループ切り替え | UsersIcon + グループ名 + ChevronDownIcon | 既存 GroupSwitcher のトリガーボタン部分を変更 |
+| 招待リンク | MdLink + "招待" | オーナーのみ表示。`<a href="/invite">` を維持（ページ遷移のため button ではなく anchor） |
+| サインアウト | LogOutIcon のみ | `title="サインアウト"` でツールチップ |
+
+### アイコンライブラリ
+
+既存の `react-icons/md` を使用する（すでに `MdLink` が使われている）。
+
+使用アイコン：
+- `MdGroup` — グループ切り替えトリガー
+- `MdLink` — 招待（すでに使用中）
+- `MdLogout` — サインアウト
+- `MdExpandMore` — グループ名右の chevron
+
+### GroupSwitcher への影響
+
+`GroupSwitcher` のトリガーボタン（現在 `opacity-80` の白テキスト）のクラスを上記共通スタイルに変更する。ドロップダウン部分（白背景カード）は変更しない。
+
+## 変更ファイル
+
+- `frontend/src/app/stock-items/StockItemsClient.tsx` — 招待・サインアウトのスタイル変更
+- `frontend/src/components/GroupSwitcher.tsx` — トリガーボタンのスタイル変更
+
+## テスト方針
+
+既存の GroupSwitcher テストはトリガーのクラス変更に伴い更新が必要な場合がある。機能変化はないため Unit テストの修正のみで対応する。E2E は不要。

--- a/frontend/src/app/stock-items/StockItemsClient.tsx
+++ b/frontend/src/app/stock-items/StockItemsClient.tsx
@@ -2,7 +2,7 @@
 
 import { AnimatePresence, motion } from "framer-motion";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { MdLink } from "react-icons/md";
+import { MdLink, MdLogout } from "react-icons/md";
 import AuthGuard from "@/components/AuthGuard";
 import CreateItemModal from "@/components/CreateItemModal";
 import EditItemModal from "@/components/EditItemModal";
@@ -207,17 +207,19 @@ export default function StockItemsClient() {
               {group?.role === "owner" && (
                 <a
                   href="/invite"
-                  className="opacity-80 hover:opacity-100 underline"
+                  className="flex items-center gap-1.5 h-8 px-2.5 rounded-lg bg-black/20 hover:bg-black/30 transition-colors text-sm text-white no-underline"
                 >
+                  <MdLink aria-hidden size={16} />
                   招待
                 </a>
               )}
               <button
                 type="button"
                 onClick={() => signOut()}
-                className="opacity-80 hover:opacity-100"
+                title="サインアウト"
+                className="flex items-center justify-center w-8 h-8 rounded-lg bg-black/20 hover:bg-black/30 transition-colors text-white border-0 cursor-pointer"
               >
-                サインアウト
+                <MdLogout aria-hidden size={18} />
               </button>
             </div>
           </div>

--- a/frontend/src/app/stock-items/StockItemsClient.tsx
+++ b/frontend/src/app/stock-items/StockItemsClient.tsx
@@ -217,6 +217,7 @@ export default function StockItemsClient() {
                 type="button"
                 onClick={() => signOut()}
                 title="サインアウト"
+                aria-label="サインアウト"
                 className="flex items-center justify-center w-8 h-8 rounded-lg bg-black/20 hover:bg-black/30 transition-colors text-white border-0 cursor-pointer"
               >
                 <MdLogout aria-hidden size={18} />

--- a/frontend/src/components/GroupSwitcher.tsx
+++ b/frontend/src/components/GroupSwitcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { MdExpandMore, MdGroup } from "react-icons/md";
 import type { GroupInfo } from "@/types/group";
 
 type Props = {
@@ -75,10 +76,11 @@ export default function GroupSwitcher({
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-1 opacity-80 hover:opacity-100 text-sm text-white"
+        className="flex items-center gap-1.5 h-8 px-2.5 rounded-lg bg-black/20 hover:bg-black/30 transition-colors text-sm text-white cursor-pointer border-0"
       >
+        <MdGroup aria-hidden size={16} />
         {activeGroup?.name ?? "グループなし"}
-        <span className="text-xs">▾</span>
+        <MdExpandMore aria-hidden size={16} className="opacity-70" />
       </button>
 
       {open && (


### PR DESCRIPTION
## Summary
- グループ切り替えトリガーを MdGroup アイコン + グループ名 + chevron の角丸ボックスに変更
- 招待リンクを MdLink アイコン + "招待" テキストの角丸ボックスに変更（オーナーのみ）
- サインアウトを MdLogout アイコンのみの正方形ボタンに変更（aria-label でアクセシビリティ対応）

機能変更なし。スタイルのみ。

Closes #126