### PR TITLE
ci: add dorny/test-reporter to E2E workflows for browser-viewable results

### DIFF
--- a/.github/workflows/e2e-preview.yml
+++ b/.github/workflows/e2e-preview.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   actions: read
+  checks: write
 
 jobs:
   e2e-preview:
@@ -76,6 +77,15 @@ jobs:
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
           E2E_TEST_GROUP_ID: ${{ secrets.E2E_TEST_GROUP_ID }}
           VERCEL_BYPASS_TOKEN: ${{ secrets.VERCEL_BYPASS_TOKEN }}
+
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: E2E Tests (preview)
+          path: frontend/results.xml
+          reporter: java-junit
+          fail-on-error: false
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/e2e-preview.yml
+++ b/.github/workflows/e2e-preview.yml
@@ -5,7 +5,6 @@ on:
 
 permissions:
   actions: read
-  checks: write
 
 jobs:
   e2e-preview:
@@ -78,14 +77,29 @@ jobs:
           E2E_TEST_GROUP_ID: ${{ secrets.E2E_TEST_GROUP_ID }}
           VERCEL_BYPASS_TOKEN: ${{ secrets.VERCEL_BYPASS_TOKEN }}
 
-      - name: Publish test results
-        uses: dorny/test-reporter@v1
+      - name: Write test summary
         if: always()
-        with:
-          name: E2E Tests (preview)
-          path: frontend/results.xml
-          reporter: java-junit
-          fail-on-error: false
+        working-directory: frontend
+        run: |
+          [ -f results.xml ] || exit 0
+          tests=$(grep -om1 'tests="[0-9]*"' results.xml | grep -o '[0-9]*')
+          failures=$(grep -om1 'failures="[0-9]*"' results.xml | grep -o '[0-9]*')
+          errors=$(grep -om1 'errors="[0-9]*"' results.xml | grep -o '[0-9]*')
+          skipped=$(grep -om1 'skipped="[0-9]*"' results.xml | grep -o '[0-9]*')
+          tests=${tests:-0}; failures=${failures:-0}; errors=${errors:-0}; skipped=${skipped:-0}
+          failed=$((failures + errors))
+          passed=$((tests - failed - skipped))
+          if [ "$failed" -gt 0 ]; then icon="❌"; else icon="✅"; fi
+          {
+            echo "## ${icon} E2E Tests (preview)"
+            echo ""
+            echo "| | Count |"
+            echo "|---|---|"
+            echo "| ✅ Passed | ${passed} |"
+            echo "| ❌ Failed | ${failed} |"
+            echo "| ⏭️ Skipped | ${skipped} |"
+            echo "| **Total** | **${tests}** |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
-
     steps:
       - uses: actions/checkout@v6
 
@@ -66,14 +63,29 @@ jobs:
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
           E2E_TEST_GROUP_ID: ${{ secrets.E2E_TEST_GROUP_ID }}
 
-      - name: Publish test results
-        uses: dorny/test-reporter@v1
+      - name: Write test summary
         if: always()
-        with:
-          name: E2E Tests (mock)
-          path: frontend/results.xml
-          reporter: java-junit
-          fail-on-error: false
+        working-directory: frontend
+        run: |
+          [ -f results.xml ] || exit 0
+          tests=$(grep -om1 'tests="[0-9]*"' results.xml | grep -o '[0-9]*')
+          failures=$(grep -om1 'failures="[0-9]*"' results.xml | grep -o '[0-9]*')
+          errors=$(grep -om1 'errors="[0-9]*"' results.xml | grep -o '[0-9]*')
+          skipped=$(grep -om1 'skipped="[0-9]*"' results.xml | grep -o '[0-9]*')
+          tests=${tests:-0}; failures=${failures:-0}; errors=${errors:-0}; skipped=${skipped:-0}
+          failed=$((failures + errors))
+          passed=$((tests - failed - skipped))
+          if [ "$failed" -gt 0 ]; then icon="❌"; else icon="✅"; fi
+          {
+            echo "## ${icon} E2E Tests (mock)"
+            echo ""
+            echo "| | Count |"
+            echo "|---|---|"
+            echo "| ✅ Passed | ${passed} |"
+            echo "| ❌ Failed | ${failed} |"
+            echo "| ⏭️ Skipped | ${skipped} |"
+            echo "| **Total** | **${tests}** |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
 
     steps:
       - uses: actions/checkout@v6
@@ -63,6 +65,15 @@ jobs:
           E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
           E2E_TEST_GROUP_ID: ${{ secrets.E2E_TEST_GROUP_ID }}
+
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: E2E Tests (mock)
+          path: frontend/results.xml
+          reporter: java-junit
+          fail-on-error: false
 
       - name: Upload Playwright report
         if: always()

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -14,6 +14,7 @@
 /coverage
 /test-results
 /playwright-report
+/results.xml
 /.auth
 
 # next.js

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -9,7 +9,7 @@ if (fs.existsSync(envFile)) {
 }
 
 export default defineConfig({
-  reporter: [["list"], ["html"]],
+  reporter: [["list"], ["html"], ["junit", { outputFile: "results.xml" }]],
   testDir: "./e2e",
   // preview runs against a shared real Supabase; sequential execution prevents
   // Realtime events from one test closing dialogs opened by another test


### PR DESCRIPTION
## Summary

- `playwright.config.ts` に `junit` reporter を追加（`frontend/results.xml` に出力）
- `e2e.yml` / `e2e-preview.yml` に `dorny/test-reporter@v1` ステップを追加
- 各ワークフローに `checks: write` 権限を付与

## 確認方法

PR 上で E2E ワークフローが実行された後、**Checks タブ**に "E2E Tests (mock)" または "E2E Tests (preview)" が表示され、テスト一覧をブラウザから直接確認できます。

スクリーンショット・トレースが必要な場合は、引き続き artifact（`playwright-report-*`）をダウンロードして確認できます。

Closes #128