### PR TITLE
Remove 招待 text from header invite link

### DIFF
--- a/frontend/src/app/stock-items/StockItemsClient.tsx
+++ b/frontend/src/app/stock-items/StockItemsClient.tsx
@@ -210,7 +210,6 @@ export default function StockItemsClient() {
                   className="flex items-center gap-1.5 h-8 px-2.5 rounded-lg bg-black/20 hover:bg-black/30 transition-colors text-sm text-white no-underline"
                 >
                   <MdLink aria-hidden size={16} />
-                  招待
                 </a>
               )}
               <button


### PR DESCRIPTION
## Summary
- ヘッダーの招待リンクから「招待」の文字を削除し、アイコンのみの表示にする

Closes #134