### PR TITLE
Center mobile bottom sheet in viewport

### DIFF
--- a/frontend/e2e/filter.spec.ts
+++ b/frontend/e2e/filter.spec.ts
@@ -126,6 +126,8 @@ test.describe("フィルタリング", () => {
 
     // Cleanup: turn off filter, reset wantToBuy, then delete
     await page.getByRole("button", { name: "買いたいものだけ" }).click();
+    await expect(page.getByRole("article", { name: item1.name })).toBeVisible();
+    await expect(page.getByRole("article", { name: item2.name })).toBeVisible();
     await setWantToBuy(page, item1.name, false);
     await deleteItem(page, item1.name);
     await deleteItem(page, item2.name);

--- a/frontend/src/components/BaseModal.tsx
+++ b/frontend/src/components/BaseModal.tsx
@@ -81,7 +81,7 @@ export default function BaseModal({
           />
 
           {/* Dialog / Sheet */}
-          <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center sm:p-4 pointer-events-none">
+          <div className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none">
             {isDesktop ? (
               <motion.div
                 role="dialog"
@@ -101,7 +101,7 @@ export default function BaseModal({
               <motion.div
                 role="dialog"
                 aria-modal="true"
-                className="pointer-events-auto w-full bg-white rounded-t-2xl shadow-xl"
+                className="pointer-events-auto w-full max-w-md bg-white rounded-2xl shadow-xl"
                 drag="y"
                 dragControls={dragControls}
                 dragListener={false}


### PR DESCRIPTION
## Summary

- モバイルのボトムシートが下半分に留まって操作しづらい問題を修正
- スライドアップ後に画面中央で止まるよう変更

## Changes

- `BaseModal.tsx`: `items-end sm:items-center` → `items-center`（常に垂直中央）
- `BaseModal.tsx`: `sm:p-4` → `p-4`（全サイズで左右余白）
- Mobile `motion.div`: `rounded-t-2xl` → `rounded-2xl`（全周角丸）、`max-w-md` 追加

## Preserved

- スライドアップアニメーション（`y: "100%"` → `0`）
- ドラッグハンドルによるスワイプ閉じ
- Esc キー・スクリムクリックによる閉じる動作

Closes #146