### PR TITLE
refactor(frontend): extract useStockItems hook, fix silent errors, replace window.confirm

### DIFF
--- a/frontend/e2e/filter.spec.ts
+++ b/frontend/e2e/filter.spec.ts
@@ -22,8 +22,11 @@ async function createItem(
 async function deleteItem(page: import("@playwright/test").Page, name: string) {
   const article = page.getByRole("article", { name });
   if (!(await article.isVisible())) return;
-  page.once("dialog", (d) => d.accept());
   await article.getByRole("button", { name: "削除" }).click();
+  // ConfirmDialog opens — click the confirm button
+  await page.getByRole("button", { name: "確認" }).click();
+  // Wait for exit animation to finish
+  await expect(page.getByRole("dialog")).not.toBeAttached();
   await expect(page.getByRole("article", { name })).not.toBeVisible();
 }
 

--- a/frontend/e2e/image-selection.spec.ts
+++ b/frontend/e2e/image-selection.spec.ts
@@ -21,8 +21,10 @@ test.describe("画像設定", () => {
     await page.keyboard.press("Escape");
     const article = page.getByRole("article", { name: itemName });
     if (await article.isVisible()) {
-      page.once("dialog", (d) => d.accept());
       await article.getByRole("button", { name: "削除" }).click();
+      // ConfirmDialog opens — click the confirm button
+      await page.getByRole("button", { name: "確認" }).click();
+      await expect(page.getByRole("dialog")).not.toBeAttached();
     }
   });
 

--- a/frontend/e2e/realtime-sync.spec.ts
+++ b/frontend/e2e/realtime-sync.spec.ts
@@ -107,13 +107,15 @@ test.describe
       // サブスクリプション確立後の初回 onChange() フェッチ完了を待つ
       await pageB.waitForLoadState("networkidle");
 
-      pageA.once("dialog", (dialog) => dialog.accept());
       await pageA
         .getByRole("article", {
           name: itemName,
         })
         .getByRole("button", { name: "削除" })
         .click();
+      // ConfirmDialog opens — click the confirm button
+      await pageA.getByRole("button", { name: "確認" }).click();
+      await expect(pageA.getByRole("dialog")).not.toBeAttached();
       await expect(pageA.getByText(itemName)).not.toBeVisible();
 
       await expect(pageB.getByText(itemName)).not.toBeVisible({

--- a/frontend/e2e/stock-items.spec.ts
+++ b/frontend/e2e/stock-items.spec.ts
@@ -16,11 +16,14 @@ test("商品を登録して削除できる", async ({ page }) => {
   await expect(page.getByText(itemName)).toBeVisible();
 
   // 商品を削除
-  page.once("dialog", (dialog) => dialog.accept());
   await page
     .getByRole("article", { name: itemName })
     .getByRole("button", { name: "削除" })
     .click();
+  // ConfirmDialog opens — click the confirm button
+  await page.getByRole("button", { name: "確認" }).click();
+  // Wait for exit animation to finish
+  await expect(page.getByRole("dialog")).not.toBeAttached();
 
   // 商品が削除されていることを確認
   await expect(page.getByText(itemName)).not.toBeVisible();
@@ -62,11 +65,13 @@ test("商品の名前を編集できる", async ({ page }) => {
   await expect(page.getByText(newItemName)).toBeVisible();
 
   // クリーンアップ: 商品を削除
-  page.once("dialog", (dialog) => dialog.accept());
   await page
     .getByRole("article", { name: newItemName })
     .getByRole("button", { name: "削除" })
     .click();
+  // ConfirmDialog opens — click the confirm button
+  await page.getByRole("button", { name: "確認" }).click();
+  await expect(page.getByRole("dialog")).not.toBeAttached();
 
   await expect(page.getByText(newItemName)).not.toBeVisible();
 });
@@ -112,11 +117,13 @@ test("商品のカテゴリを編集できる", async ({ page }) => {
   ).toBeVisible();
 
   // クリーンアップ: 商品を削除
-  page.once("dialog", (dialog) => dialog.accept());
   await page
     .getByRole("article", { name: itemName })
     .getByRole("button", { name: "削除" })
     .click();
+  // ConfirmDialog opens — click the confirm button
+  await page.getByRole("button", { name: "確認" }).click();
+  await expect(page.getByRole("dialog")).not.toBeAttached();
 
   await expect(page.getByText(itemName)).not.toBeVisible();
 });

--- a/frontend/src/app/stock-items/StockItemsClient.tsx
+++ b/frontend/src/app/stock-items/StockItemsClient.tsx
@@ -2,25 +2,18 @@
 
 import { AnimatePresence, motion } from "framer-motion";
 import dynamic from "next/dynamic";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { MdLink, MdLogout } from "react-icons/md";
 import AuthGuard from "@/components/AuthGuard";
+import ConfirmDialog from "@/components/ConfirmDialog";
 import FilterBar from "@/components/FilterBar";
 import GroupSwitcher from "@/components/GroupSwitcher";
 import ItemCard from "@/components/ItemCard";
 import ItemCardSimple from "@/components/ItemCardSimple";
 import { useAuth } from "@/contexts/AuthContext";
-import {
-  createStockItem,
-  deleteStockItem,
-  fetchStockItems,
-  updateStockItem,
-} from "@/lib/api";
-import { createGroup, updateGroupName } from "@/lib/authApi";
 import { type FilterCondition, filterStockItems } from "@/lib/filterStockItems";
-import { useStockItemsRealtime } from "@/lib/useStockItemsRealtime";
-import type { StockItem } from "@/types/stockItem";
 import StockItemsSkeleton from "./StockItemsSkeleton";
+import { useStockItems } from "./useStockItems";
 
 const CreateItemModal = dynamic(() => import("@/components/CreateItemModal"), {
   ssr: false,
@@ -49,20 +42,36 @@ export default function StockItemsClient() {
   } = useAuth();
   const accessToken = session?.access_token;
   const activeGroupId = group?.groupId;
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [urlModalOpen, setUrlModalOpen] = useState(false);
-  const [prefill, setPrefill] = useState<{
-    name: string;
-    imageUrl: string | null;
-    sourceUrl: string | null;
-  }>({ name: "", imageUrl: null, sourceUrl: null });
-  const [items, setItems] = useState<StockItem[]>([]);
-  const [editingItem, setEditingItem] = useState<StockItem | null>(null);
-  const [imageEditingItem, setImageEditingItem] = useState<StockItem | null>(
-    null,
-  );
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+
+  const {
+    items,
+    loading,
+    error,
+    isModalOpen,
+    urlModalOpen,
+    prefill,
+    editingItem,
+    imageEditingItem,
+    confirmDeleteItem,
+    handleCreate,
+    handleSave,
+    handleToggleWantToBuy,
+    handleDelete,
+    handleCancelDelete,
+    handleConfirmDelete,
+    handleOpenEdit,
+    handleCloseEdit,
+    handleOpenImageEdit,
+    handleImageSelect,
+    handleRenameGroup,
+    handleCreateNewGroup,
+    handleExtracted,
+    handleCloseCreateModal,
+    handleCloseImageEdit,
+    setIsModalOpen,
+    setUrlModalOpen,
+  } = useStockItems(accessToken, activeGroupId, refreshGroup, authLoading);
+
   const [filter, setFilter] = useState<FilterCondition>({
     searchText: "",
     wantToBuyOnly: false,
@@ -76,132 +85,6 @@ export default function StockItemsClient() {
   );
 
   const Card = viewMode === "simple" ? ItemCardSimple : ItemCard;
-
-  const handleCreate = async (
-    name: string,
-    category: string,
-    wantToBuy: boolean,
-    imageUrl: string | null,
-    sourceUrl: string | null,
-  ) => {
-    const created = await createStockItem(
-      { name, category, wantToBuy, sourceUrl: sourceUrl ?? undefined },
-      accessToken,
-      activeGroupId,
-    );
-    if (imageUrl) {
-      await updateStockItem(
-        created.id,
-        { imageUrl },
-        accessToken,
-        activeGroupId,
-      );
-    }
-    const data = await fetchStockItems(accessToken, activeGroupId);
-    setItems(data);
-  };
-
-  const handleOpenEdit = (item: StockItem) => {
-    setEditingItem(item);
-  };
-
-  const handleCloseEdit = () => {
-    setEditingItem(null);
-  };
-
-  const handleSave = async (name: string, category: string) => {
-    if (!editingItem) return;
-    await updateStockItem(
-      editingItem.id,
-      { name, category },
-      accessToken,
-      activeGroupId,
-    );
-    const data = await fetchStockItems(accessToken, activeGroupId);
-    setItems(data);
-  };
-
-  const handleToggleWantToBuy = async (item: StockItem) => {
-    setItems((prev) =>
-      prev.map((i) =>
-        i.id === item.id ? { ...i, wantToBuy: !item.wantToBuy } : i,
-      ),
-    );
-    await updateStockItem(
-      item.id,
-      { wantToBuy: !item.wantToBuy },
-      accessToken,
-      activeGroupId,
-    );
-    const data = await fetchStockItems(accessToken, activeGroupId);
-    setItems(data);
-  };
-
-  const handleDelete = async (id: string) => {
-    if (!window.confirm("この商品を削除しますか？")) return;
-    await deleteStockItem(id, accessToken, activeGroupId);
-    const data = await fetchStockItems(accessToken, activeGroupId);
-    setItems(data);
-  };
-
-  const handleOpenImageEdit = (item: StockItem) => {
-    setImageEditingItem(item);
-  };
-
-  const handleImageSelect = async (imageUrl: string | null) => {
-    if (!imageEditingItem) return;
-    await updateStockItem(
-      imageEditingItem.id,
-      { imageUrl },
-      accessToken,
-      activeGroupId,
-    );
-    setImageEditingItem(null);
-    const data = await fetchStockItems(accessToken, activeGroupId);
-    setItems(data);
-  };
-
-  const handleRenameGroup = async (groupId: string, name: string) => {
-    if (!accessToken || !activeGroupId) return;
-    await updateGroupName(groupId, name, accessToken, activeGroupId);
-    await refreshGroup();
-  };
-
-  const handleCreateNewGroup = async (name: string) => {
-    if (!accessToken) return;
-    await createGroup(name, accessToken);
-    await refreshGroup();
-  };
-
-  function handleExtracted(
-    name: string,
-    imageUrl: string | null,
-    sourceUrl: string,
-  ) {
-    setUrlModalOpen(false);
-    setPrefill({ name, imageUrl, sourceUrl });
-    setIsModalOpen(true);
-  }
-
-  const handleRealtimeChange = useCallback(() => {
-    fetchStockItems(accessToken, activeGroupId)
-      .then((data) => setItems(data))
-      .catch(() => {});
-  }, [accessToken, activeGroupId]);
-
-  useStockItemsRealtime(handleRealtimeChange);
-
-  useEffect(() => {
-    if (authLoading) return;
-    setLoading(true);
-    setError(null);
-    fetchStockItems(accessToken, activeGroupId)
-      .then((data) => setItems(data))
-      .catch((err) =>
-        setError(err instanceof Error ? err.message : "Unknown error"),
-      )
-      .finally(() => setLoading(false));
-  }, [authLoading, accessToken, activeGroupId]);
 
   if (authLoading) return <StockItemsSkeleton />;
 
@@ -282,6 +165,12 @@ export default function StockItemsClient() {
                   </button>
                 </div>
               </div>
+              <ConfirmDialog
+                isOpen={!!confirmDeleteItem}
+                message={`「${confirmDeleteItem?.name}」を削除しますか？`}
+                onConfirm={handleConfirmDelete}
+                onCancel={handleCancelDelete}
+              />
               <CreateItemModal
                 isOpen={isModalOpen}
                 initialName={prefill.name || filter.searchText}
@@ -289,10 +178,7 @@ export default function StockItemsClient() {
                 initialWantToBuy={filter.wantToBuyOnly}
                 initialImageUrl={prefill.imageUrl}
                 initialSourceUrl={prefill.sourceUrl}
-                onClose={() => {
-                  setIsModalOpen(false);
-                  setPrefill({ name: "", imageUrl: null, sourceUrl: null });
-                }}
+                onClose={handleCloseCreateModal}
                 onCreate={handleCreate}
               />
               <UrlRegistrationModal
@@ -323,7 +209,7 @@ export default function StockItemsClient() {
                   }
                 }
                 isOpen={!!imageEditingItem}
-                onClose={() => setImageEditingItem(null)}
+                onClose={handleCloseImageEdit}
                 onSelect={handleImageSelect}
                 accessToken={accessToken}
                 activeGroupId={activeGroupId}

--- a/frontend/src/app/stock-items/page.test.tsx
+++ b/frontend/src/app/stock-items/page.test.tsx
@@ -131,7 +131,6 @@ describe("StockItemsPage", () => {
       .mockResolvedValueOnce(mockItems)
       .mockResolvedValueOnce([mockItems[1]]); // 削除後は味噌だけ
     vi.mocked(deleteStockItem).mockResolvedValue(undefined);
-    vi.spyOn(window, "confirm").mockReturnValue(true);
 
     const user = userEvent.setup();
     render(<StockItemsPage />);
@@ -144,6 +143,9 @@ describe("StockItemsPage", () => {
     await user.click(
       within(shoyuArticle).getByRole("button", { name: "削除" }),
     );
+
+    // ConfirmDialog が表示されるので「確認」ボタンをクリック
+    await user.click(screen.getByRole("button", { name: "確認" }));
 
     await waitFor(() => {
       expect(deleteStockItem).toHaveBeenCalledWith(
@@ -159,7 +161,6 @@ describe("StockItemsPage", () => {
     const { fetchStockItems, deleteStockItem } = await import("@/lib/api");
     vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
     vi.mocked(deleteStockItem).mockResolvedValue(undefined);
-    vi.spyOn(window, "confirm").mockReturnValue(false);
 
     const user = userEvent.setup();
     render(<StockItemsPage />);
@@ -172,6 +173,9 @@ describe("StockItemsPage", () => {
     await user.click(
       within(shoyuArticle).getByRole("button", { name: "削除" }),
     );
+
+    // ConfirmDialog が表示されるので「キャンセル」ボタンをクリック
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
 
     expect(deleteStockItem).not.toHaveBeenCalled();
     expect(screen.getByText("醤油")).toBeInTheDocument();

--- a/frontend/src/app/stock-items/useStockItems.test.ts
+++ b/frontend/src/app/stock-items/useStockItems.test.ts
@@ -260,6 +260,28 @@ describe("useStockItems", () => {
     });
   });
 
+  describe("handleImageSelect", () => {
+    it("handleImageSelect が API エラーで error をセットする", async () => {
+      vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
+      vi.mocked(updateStockItem).mockRejectedValue(
+        new Error("画像の更新に失敗しました"),
+      );
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => {
+        result.current.handleOpenImageEdit(mockItems[0]);
+      });
+
+      await act(async () => {
+        await result.current.handleImageSelect("https://example.com/image.jpg");
+      });
+
+      expect(result.current.error).toBe("画像の更新に失敗しました");
+    });
+  });
+
   describe("handleRenameGroup", () => {
     it("handleRenameGroup が API エラーで error をセットする", async () => {
       vi.mocked(fetchStockItems).mockResolvedValue(mockItems);

--- a/frontend/src/app/stock-items/useStockItems.test.ts
+++ b/frontend/src/app/stock-items/useStockItems.test.ts
@@ -1,0 +1,324 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createStockItem,
+  deleteStockItem,
+  fetchStockItems,
+  updateStockItem,
+} from "@/lib/api";
+import { createGroup, updateGroupName } from "@/lib/authApi";
+import { useStockItemsRealtime } from "@/lib/useStockItemsRealtime";
+import { useStockItems } from "./useStockItems";
+
+vi.mock("@/lib/api");
+vi.mock("@/lib/authApi");
+vi.mock("@/lib/useStockItemsRealtime");
+
+const mockItems = [
+  {
+    id: "1",
+    name: "醤油",
+    category: "調味料",
+    imageUrl: null,
+    sourceUrl: null,
+    wantToBuy: false,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-02T00:00:00Z",
+    sortedAt: "2026-01-02T00:00:00Z",
+  },
+  {
+    id: "2",
+    name: "味噌",
+    category: "調味料",
+    imageUrl: null,
+    sourceUrl: null,
+    wantToBuy: true,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    sortedAt: "2026-01-01T00:00:00Z",
+  },
+];
+
+const defaultArgs: Parameters<typeof useStockItems> = [
+  "test-token",
+  "group-1",
+  vi.fn(),
+  false,
+];
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useStockItems", () => {
+  describe("初期状態", () => {
+    it("初期 state が正しく設定される", async () => {
+      vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+
+      expect(result.current.items).toEqual([]);
+      expect(result.current.loading).toBe(true);
+      expect(result.current.error).toBeNull();
+      expect(result.current.isModalOpen).toBe(false);
+      expect(result.current.urlModalOpen).toBe(false);
+      expect(result.current.editingItem).toBeNull();
+      expect(result.current.imageEditingItem).toBeNull();
+      expect(result.current.confirmDeleteItem).toBeNull();
+    });
+
+    it("fetchStockItems が成功すると items が更新され loading: false になる", async () => {
+      vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.items).toEqual(mockItems);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("fetchStockItems が失敗すると error がセットされ loading: false になる", async () => {
+      vi.mocked(fetchStockItems).mockRejectedValue(new Error("HTTP 500"));
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBe("HTTP 500");
+      expect(result.current.items).toEqual([]);
+    });
+
+    it("authLoading が true のときは fetchStockItems が呼ばれない", () => {
+      const { result } = renderHook(() =>
+        useStockItems("test-token", "group-1", vi.fn(), true),
+      );
+
+      expect(fetchStockItems).not.toHaveBeenCalled();
+      expect(result.current.loading).toBe(true);
+    });
+  });
+
+  describe("handleCreate", () => {
+    it("handleCreate が成功すると items が更新され error が null になる", async () => {
+      const createdItem = { ...mockItems[0], id: "3", name: "塩" };
+      vi.mocked(fetchStockItems)
+        .mockResolvedValueOnce(mockItems)
+        .mockResolvedValueOnce([...mockItems, createdItem]);
+      vi.mocked(createStockItem).mockResolvedValue(createdItem);
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleCreate("塩", "調味料", false, null, null);
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.items).toHaveLength(3);
+    });
+
+    it("handleCreate が API エラーで error をセットする", async () => {
+      vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
+      vi.mocked(createStockItem).mockRejectedValue(
+        new Error("商品の追加に失敗しました"),
+      );
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleCreate("塩", "調味料", false, null, null);
+      });
+
+      expect(result.current.error).toBe("商品の追加に失敗しました");
+      expect(result.current.items).toEqual(mockItems);
+    });
+  });
+
+  describe("handleToggleWantToBuy", () => {
+    it("handleToggleWantToBuy が API エラーで楽観的更新を戻す", async () => {
+      vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
+      vi.mocked(updateStockItem).mockRejectedValue(
+        new Error("更新に失敗しました"),
+      );
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      const itemsBefore = result.current.items;
+
+      await act(async () => {
+        await result.current.handleToggleWantToBuy(mockItems[0]);
+      });
+
+      // 楽観的更新が元に戻る
+      expect(result.current.items).toEqual(itemsBefore);
+      expect(result.current.error).toBe("更新に失敗しました");
+    });
+
+    it("handleToggleWantToBuy が成功すると error が null になる", async () => {
+      const toggledItem = { ...mockItems[0], wantToBuy: true };
+      vi.mocked(fetchStockItems)
+        .mockResolvedValueOnce(mockItems)
+        .mockResolvedValueOnce([toggledItem, mockItems[1]]);
+      vi.mocked(updateStockItem).mockResolvedValue(toggledItem);
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleToggleWantToBuy(mockItems[0]);
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("handleDelete と handleConfirmDelete", () => {
+    it("handleDelete を呼ぶと confirmDeleteItem がセットされる", async () => {
+      vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => {
+        result.current.handleDelete(mockItems[0]);
+      });
+
+      expect(result.current.confirmDeleteItem).toEqual(mockItems[0]);
+      expect(deleteStockItem).not.toHaveBeenCalled();
+    });
+
+    it("handleConfirmDelete が成功すると confirmDeleteItem が null にリセットされ items が更新される", async () => {
+      vi.mocked(fetchStockItems)
+        .mockResolvedValueOnce(mockItems)
+        .mockResolvedValueOnce([mockItems[1]]);
+      vi.mocked(deleteStockItem).mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => {
+        result.current.handleDelete(mockItems[0]);
+      });
+      expect(result.current.confirmDeleteItem).toEqual(mockItems[0]);
+
+      await act(async () => {
+        await result.current.handleConfirmDelete();
+      });
+
+      expect(result.current.confirmDeleteItem).toBeNull();
+      expect(result.current.items).toEqual([mockItems[1]]);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("handleConfirmDelete が API エラーで error をセットする", async () => {
+      vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
+      vi.mocked(deleteStockItem).mockRejectedValue(
+        new Error("削除に失敗しました"),
+      );
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => {
+        result.current.handleDelete(mockItems[0]);
+      });
+
+      await act(async () => {
+        await result.current.handleConfirmDelete();
+      });
+
+      expect(result.current.error).toBe("削除に失敗しました");
+    });
+  });
+
+  describe("handleSave", () => {
+    it("handleSave が API エラーで error をセットする", async () => {
+      vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
+      vi.mocked(updateStockItem).mockRejectedValue(
+        new Error("保存に失敗しました"),
+      );
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => {
+        result.current.handleOpenEdit(mockItems[0]);
+      });
+
+      await act(async () => {
+        await result.current.handleSave("濃口醤油", "調味料");
+      });
+
+      expect(result.current.error).toBe("保存に失敗しました");
+    });
+  });
+
+  describe("handleRenameGroup", () => {
+    it("handleRenameGroup が API エラーで error をセットする", async () => {
+      vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
+      vi.mocked(updateGroupName).mockRejectedValue(
+        new Error("グループ名の更新に失敗しました"),
+      );
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleRenameGroup("group-1", "新しい名前");
+      });
+
+      expect(result.current.error).toBe("グループ名の更新に失敗しました");
+    });
+  });
+
+  describe("handleCreateNewGroup", () => {
+    it("handleCreateNewGroup が API エラーで error をセットする", async () => {
+      vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
+      vi.mocked(createGroup).mockRejectedValue(
+        new Error("グループの作成に失敗しました"),
+      );
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleCreateNewGroup("新しいグループ");
+      });
+
+      expect(result.current.error).toBe("グループの作成に失敗しました");
+    });
+  });
+
+  describe("useStockItemsRealtime", () => {
+    it("Realtime 通知で fetchStockItems が再取得される", async () => {
+      vi.mocked(fetchStockItems)
+        .mockResolvedValueOnce(mockItems)
+        .mockResolvedValueOnce(mockItems);
+
+      let captureOnChange: (() => void) | undefined;
+      vi.mocked(useStockItemsRealtime).mockImplementation((cb) => {
+        captureOnChange = cb;
+      });
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      const callsBefore = vi.mocked(fetchStockItems).mock.calls.length;
+
+      act(() => {
+        captureOnChange?.();
+      });
+
+      await waitFor(() => {
+        expect(fetchStockItems).toHaveBeenCalledTimes(callsBefore + 1);
+      });
+    });
+  });
+});

--- a/frontend/src/app/stock-items/useStockItems.test.ts
+++ b/frontend/src/app/stock-items/useStockItems.test.ts
@@ -236,6 +236,28 @@ describe("useStockItems", () => {
 
       expect(result.current.error).toBe("削除に失敗しました");
     });
+
+    it("handleConfirmDelete が API エラーで confirmDeleteItem を null にリセットする", async () => {
+      vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
+      vi.mocked(deleteStockItem).mockRejectedValue(
+        new Error("削除に失敗しました"),
+      );
+
+      const { result } = renderHook(() => useStockItems(...defaultArgs));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => {
+        result.current.handleDelete(mockItems[0]);
+      });
+      expect(result.current.confirmDeleteItem).toEqual(mockItems[0]);
+
+      await act(async () => {
+        await result.current.handleConfirmDelete();
+      });
+
+      expect(result.current.confirmDeleteItem).toBeNull();
+      expect(result.current.error).toBe("削除に失敗しました");
+    });
   });
 
   describe("handleSave", () => {

--- a/frontend/src/app/stock-items/useStockItems.ts
+++ b/frontend/src/app/stock-items/useStockItems.ts
@@ -184,6 +184,7 @@ export function useStockItems(
       setItems(data);
       setError(null);
     } catch (err) {
+      setConfirmDeleteItem(null);
       setError(err instanceof Error ? err.message : "操作に失敗しました");
     }
   };

--- a/frontend/src/app/stock-items/useStockItems.ts
+++ b/frontend/src/app/stock-items/useStockItems.ts
@@ -1,0 +1,293 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  createStockItem,
+  deleteStockItem,
+  fetchStockItems,
+  updateStockItem,
+} from "@/lib/api";
+import { createGroup, updateGroupName } from "@/lib/authApi";
+import { useStockItemsRealtime } from "@/lib/useStockItemsRealtime";
+import type { StockItem } from "@/types/stockItem";
+
+type Prefill = {
+  name: string;
+  imageUrl: string | null;
+  sourceUrl: string | null;
+};
+
+type UseStockItemsReturn = {
+  items: StockItem[];
+  loading: boolean;
+  error: string | null;
+  isModalOpen: boolean;
+  urlModalOpen: boolean;
+  prefill: Prefill;
+  editingItem: StockItem | null;
+  imageEditingItem: StockItem | null;
+  confirmDeleteItem: StockItem | null;
+  handleCreate: (
+    name: string,
+    category: string,
+    wantToBuy: boolean,
+    imageUrl: string | null,
+    sourceUrl: string | null,
+  ) => Promise<void>;
+  handleSave: (name: string, category: string) => Promise<void>;
+  handleToggleWantToBuy: (item: StockItem) => Promise<void>;
+  handleDelete: (item: StockItem) => void;
+  handleCancelDelete: () => void;
+  handleConfirmDelete: () => Promise<void>;
+  handleOpenEdit: (item: StockItem) => void;
+  handleCloseEdit: () => void;
+  handleOpenImageEdit: (item: StockItem) => void;
+  handleCloseImageEdit: () => void;
+  handleImageSelect: (imageUrl: string | null) => Promise<void>;
+  handleRenameGroup: (groupId: string, name: string) => Promise<void>;
+  handleCreateNewGroup: (name: string) => Promise<void>;
+  handleExtracted: (
+    name: string,
+    imageUrl: string | null,
+    sourceUrl: string,
+  ) => void;
+  handleCloseCreateModal: () => void;
+  setIsModalOpen: (open: boolean) => void;
+  setUrlModalOpen: (open: boolean) => void;
+};
+
+export function useStockItems(
+  accessToken: string | undefined,
+  activeGroupId: string | undefined,
+  refreshGroup: () => Promise<void>,
+  authLoading: boolean,
+): UseStockItemsReturn {
+  const [items, setItems] = useState<StockItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [urlModalOpen, setUrlModalOpen] = useState(false);
+  const [prefill, setPrefill] = useState<Prefill>({
+    name: "",
+    imageUrl: null,
+    sourceUrl: null,
+  });
+  const [editingItem, setEditingItem] = useState<StockItem | null>(null);
+  const [imageEditingItem, setImageEditingItem] = useState<StockItem | null>(
+    null,
+  );
+  const [confirmDeleteItem, setConfirmDeleteItem] = useState<StockItem | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (authLoading) return;
+    setLoading(true);
+    setError(null);
+    fetchStockItems(accessToken, activeGroupId)
+      .then((data) => setItems(data))
+      .catch((err) =>
+        setError(err instanceof Error ? err.message : "操作に失敗しました"),
+      )
+      .finally(() => setLoading(false));
+  }, [authLoading, accessToken, activeGroupId]);
+
+  const handleRealtimeChange = useCallback(() => {
+    fetchStockItems(accessToken, activeGroupId)
+      .then((data) => setItems(data))
+      .catch(() => {});
+  }, [accessToken, activeGroupId]);
+
+  useStockItemsRealtime(handleRealtimeChange);
+
+  const handleCreate = async (
+    name: string,
+    category: string,
+    wantToBuy: boolean,
+    imageUrl: string | null,
+    sourceUrl: string | null,
+  ): Promise<void> => {
+    try {
+      const created = await createStockItem(
+        { name, category, wantToBuy, sourceUrl: sourceUrl ?? undefined },
+        accessToken,
+        activeGroupId,
+      );
+      if (imageUrl) {
+        await updateStockItem(
+          created.id,
+          { imageUrl },
+          accessToken,
+          activeGroupId,
+        );
+      }
+      const data = await fetchStockItems(accessToken, activeGroupId);
+      setItems(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "操作に失敗しました");
+    }
+  };
+
+  const handleSave = async (name: string, category: string): Promise<void> => {
+    if (!editingItem) return;
+    try {
+      await updateStockItem(
+        editingItem.id,
+        { name, category },
+        accessToken,
+        activeGroupId,
+      );
+      const data = await fetchStockItems(accessToken, activeGroupId);
+      setItems(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "操作に失敗しました");
+    }
+  };
+
+  const handleToggleWantToBuy = async (item: StockItem): Promise<void> => {
+    const previousItems = [...items];
+    setItems((prev) =>
+      prev.map((i) =>
+        i.id === item.id ? { ...i, wantToBuy: !item.wantToBuy } : i,
+      ),
+    );
+    try {
+      await updateStockItem(
+        item.id,
+        { wantToBuy: !item.wantToBuy },
+        accessToken,
+        activeGroupId,
+      );
+      const data = await fetchStockItems(accessToken, activeGroupId);
+      setItems(data);
+      setError(null);
+    } catch (err) {
+      setItems(previousItems);
+      setError(err instanceof Error ? err.message : "操作に失敗しました");
+    }
+  };
+
+  const handleDelete = (item: StockItem): void => {
+    setConfirmDeleteItem(item);
+  };
+
+  const handleCancelDelete = (): void => {
+    setConfirmDeleteItem(null);
+  };
+
+  const handleConfirmDelete = async (): Promise<void> => {
+    if (!confirmDeleteItem) return;
+    try {
+      await deleteStockItem(confirmDeleteItem.id, accessToken, activeGroupId);
+      setConfirmDeleteItem(null);
+      const data = await fetchStockItems(accessToken, activeGroupId);
+      setItems(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "操作に失敗しました");
+    }
+  };
+
+  const handleOpenEdit = (item: StockItem): void => {
+    setEditingItem(item);
+  };
+
+  const handleCloseEdit = (): void => {
+    setEditingItem(null);
+  };
+
+  const handleOpenImageEdit = (item: StockItem): void => {
+    setImageEditingItem(item);
+  };
+
+  const handleImageSelect = async (imageUrl: string | null): Promise<void> => {
+    if (!imageEditingItem) return;
+    try {
+      await updateStockItem(
+        imageEditingItem.id,
+        { imageUrl },
+        accessToken,
+        activeGroupId,
+      );
+      setImageEditingItem(null);
+      const data = await fetchStockItems(accessToken, activeGroupId);
+      setItems(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "操作に失敗しました");
+    }
+  };
+
+  const handleRenameGroup = async (
+    groupId: string,
+    name: string,
+  ): Promise<void> => {
+    if (!accessToken || !activeGroupId) return;
+    try {
+      await updateGroupName(groupId, name, accessToken, activeGroupId);
+      await refreshGroup();
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "操作に失敗しました");
+    }
+  };
+
+  const handleCreateNewGroup = async (name: string): Promise<void> => {
+    if (!accessToken) return;
+    try {
+      await createGroup(name, accessToken);
+      await refreshGroup();
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "操作に失敗しました");
+    }
+  };
+
+  const handleCloseCreateModal = (): void => {
+    setIsModalOpen(false);
+    setPrefill({ name: "", imageUrl: null, sourceUrl: null });
+  };
+
+  const handleCloseImageEdit = (): void => {
+    setImageEditingItem(null);
+  };
+
+  const handleExtracted = (
+    name: string,
+    imageUrl: string | null,
+    sourceUrl: string,
+  ): void => {
+    setUrlModalOpen(false);
+    setPrefill({ name, imageUrl, sourceUrl });
+    setIsModalOpen(true);
+  };
+
+  return {
+    items,
+    loading,
+    error,
+    isModalOpen,
+    urlModalOpen,
+    prefill,
+    editingItem,
+    imageEditingItem,
+    confirmDeleteItem,
+    handleCreate,
+    handleSave,
+    handleToggleWantToBuy,
+    handleDelete,
+    handleCancelDelete,
+    handleConfirmDelete,
+    handleOpenEdit,
+    handleCloseEdit,
+    handleOpenImageEdit,
+    handleCloseImageEdit,
+    handleImageSelect,
+    handleRenameGroup,
+    handleCreateNewGroup,
+    handleExtracted,
+    handleCloseCreateModal,
+    setIsModalOpen,
+    setUrlModalOpen,
+  };
+}

--- a/frontend/src/components/ConfirmDialog.test.tsx
+++ b/frontend/src/components/ConfirmDialog.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { describe, expect, it, vi } from "vitest";
+import ConfirmDialog from "./ConfirmDialog";
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  motion: {
+    div: ({
+      children,
+      initial: _i,
+      animate: _a,
+      exit: _e,
+      transition: _t,
+      drag: _drag,
+      dragControls: _dc,
+      dragListener: _dl,
+      dragConstraints: _dcon,
+      dragElastic: _de,
+      onDragEnd: _ode,
+      ...rest
+    }: React.HTMLAttributes<HTMLDivElement> & Record<string, unknown>) => (
+      <div {...rest}>{children}</div>
+    ),
+  },
+  useDragControls: () => ({ start: vi.fn() }),
+}));
+
+function mockMatchMedia(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+describe("ConfirmDialog", () => {
+  it("isOpen=true のとき message とボタンが表示される", () => {
+    mockMatchMedia(false);
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        message="本当に削除しますか？"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("本当に削除しますか？")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "キャンセル" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "確認" })).toBeInTheDocument();
+  });
+
+  it("キャンセルボタンを押すと onCancel が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    mockMatchMedia(false);
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        message="削除しますか？"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("確認ボタンを押すと onConfirm が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    mockMatchMedia(false);
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        message="削除しますか？"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "確認" }));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it("isOpen=false のときダイアログが表示されない", () => {
+    mockMatchMedia(false);
+    render(
+      <ConfirmDialog
+        isOpen={false}
+        message="削除しますか？"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -29,7 +29,7 @@ export default function ConfirmDialog({
         <button
           type="button"
           onClick={onConfirm}
-          className="flex-1 sm:flex-none bg-[#00d1b2] hover:bg-[#00c4a7] text-white font-bold rounded-xl py-2.5 text-sm transition-colors"
+          className="flex-1 sm:flex-none bg-red-500 hover:bg-red-600 text-white font-bold rounded-xl py-2.5 text-sm transition-colors"
         >
           確認
         </button>

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import BaseModal from "./BaseModal";
+
+type ConfirmDialogProps = {
+  isOpen: boolean;
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export default function ConfirmDialog({
+  isOpen,
+  message,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <BaseModal isOpen={isOpen} onClose={onCancel} title="確認">
+      <p className="text-slate-700 mb-6">{message}</p>
+      <div className="flex gap-3 sm:gap-2 sm:justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="flex-1 sm:flex-none bg-slate-100 hover:bg-slate-200 text-slate-600 font-bold rounded-xl py-2.5 text-sm transition-colors"
+        >
+          キャンセル
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          className="flex-1 sm:flex-none bg-[#00d1b2] hover:bg-[#00c4a7] text-white font-bold rounded-xl py-2.5 text-sm transition-colors"
+        >
+          確認
+        </button>
+      </div>
+    </BaseModal>
+  );
+}

--- a/frontend/src/components/ItemCard.test.tsx
+++ b/frontend/src/components/ItemCard.test.tsx
@@ -70,7 +70,7 @@ describe("ItemCard", () => {
       />,
     );
     await userEvent.click(screen.getByRole("button", { name: "削除" }));
-    expect(onDelete).toHaveBeenCalledWith("1");
+    expect(onDelete).toHaveBeenCalledWith(baseItem);
   });
 
   it("カードをクリックすると onEdit が呼ばれる", async () => {
@@ -102,7 +102,7 @@ describe("ItemCard", () => {
       />,
     );
     await userEvent.click(screen.getByRole("button", { name: "削除" }));
-    expect(onDelete).toHaveBeenCalledWith("1");
+    expect(onDelete).toHaveBeenCalledWith(baseItem);
     expect(onEdit).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/components/ItemCard.tsx
+++ b/frontend/src/components/ItemCard.tsx
@@ -6,7 +6,7 @@ type ItemCardProps = {
   item: StockItem;
   onEdit: (item: StockItem) => void;
   onToggleWantToBuy: (item: StockItem) => void;
-  onDelete: (id: string) => void;
+  onDelete: (item: StockItem) => void;
   onImageEdit: (item: StockItem) => void;
 };
 
@@ -80,7 +80,7 @@ export default function ItemCard({
         aria-label="削除"
         disabled={item.wantToBuy}
         className="w-9 h-9 rounded-xl bg-red-50 hover:bg-red-100 p-0 text-red-300 inline-flex items-center justify-center disabled:bg-slate-100 disabled:text-slate-200 disabled:cursor-not-allowed"
-        onClick={() => onDelete(item.id)}
+        onClick={() => onDelete(item)}
       >
         <MdDelete aria-hidden size={28} />
       </button>

--- a/frontend/src/components/ItemCardSimple.tsx
+++ b/frontend/src/components/ItemCardSimple.tsx
@@ -6,7 +6,7 @@ type ItemCardProps = {
   item: StockItem;
   onEdit: (item: StockItem) => void;
   onToggleWantToBuy: (item: StockItem) => void;
-  onDelete: (id: string) => void;
+  onDelete: (item: StockItem) => void;
   onImageEdit: (item: StockItem) => void;
 };
 

--- a/openspec/changes/archive/2026-05-29-frontend-best-practice/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-29-frontend-best-practice/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/archive/2026-05-29-frontend-best-practice/design.md
+++ b/openspec/changes/archive/2026-05-29-frontend-best-practice/design.md
@@ -1,0 +1,88 @@
+## Context
+
+`StockItemsClient.tsx` は現在 373 行の God Component。state（7変数）・CRUD ハンドラ（8関数）・JSX（180行超）が一体化している。テストは `StockItemsClient.test.tsx` でカバーされているが、フックと JSX 層が混在しているためロジックのみの単体テストが書けない。
+
+既存のコンポーネント構成:
+- `BaseModal` — モーダルの基底コンポーネント（ConfirmDialog の土台として利用可能）
+- `EditItemModal` / `CreateItemModal` など — BaseModal を利用したモーダル群
+- `useStockItemsRealtime` — Realtime 購読フック（分離済み、参考実装）
+
+## Goals / Non-Goals
+
+**Goals:**
+- `useStockItems` フックへのロジック分離で StockItemsClient を ~150 行以下に削減
+- 全 CRUD ハンドラで try/catch を追加し、エラーを `error` state に反映
+- `window.confirm` を `ConfirmDialog` に置き換えて UI 一貫性を確保
+- 既存テストカバレッジを維持・改善（hook テスト + JSX テスト）
+
+**Non-Goals:**
+- optimistic update の導入（別変更として別途検討）
+- SWR / React Query への移行
+- API の変更や新機能の追加
+- エラー UI のデザイン変更（既存の `error` 表示箇所をそのまま使う）
+
+## Decisions
+
+### D1: useStockItems フックの API 設計
+
+```ts
+// useStockItems.ts
+type UseStockItemsReturn = {
+  items: StockItem[];
+  loading: boolean;
+  error: string | null;
+  isModalOpen: boolean;
+  urlModalOpen: boolean;
+  prefill: { name: string; imageUrl: string | null; sourceUrl: string | null };
+  editingItem: StockItem | null;
+  imageEditingItem: StockItem | null;
+  confirmDeleteItem: StockItem | null;  // window.confirm 置き換え用
+  handleCreate: (...) => Promise<void>;
+  handleSave: (...) => Promise<void>;
+  handleToggleWantToBuy: (item: StockItem) => Promise<void>;
+  handleDelete: (item: StockItem) => void;           // confirm ダイアログを開く
+  handleConfirmDelete: () => Promise<void>;          // 実際の削除実行
+  handleOpenEdit: (item: StockItem) => void;
+  handleCloseEdit: () => void;
+  handleOpenImageEdit: (item: StockItem) => void;
+  handleImageSelect: (imageUrl: string | null) => Promise<void>;
+  handleRenameGroup: (groupId: string, name: string) => Promise<void>;
+  handleCreateNewGroup: (name: string) => Promise<void>;
+  handleExtracted: (name: string, imageUrl: string | null, sourceUrl: string) => void;
+  setIsModalOpen: (open: boolean) => void;
+  setUrlModalOpen: (open: boolean) => void;
+};
+```
+
+**理由:** StockItemsClient の JSX 側は props drilling なしにフックの戻り値を直接使えるため、リファクタリングの差分を最小化できる。
+
+### D2: window.confirm の置き換え方法
+
+`window.confirm` を削除し、`confirmDeleteItem: StockItem | null` state を追加。
+
+- `handleDelete(item)` → `confirmDeleteItem` に item をセット（ダイアログを開く）
+- `handleConfirmDelete()` → 実際に DELETE API を呼ぶ
+- `ConfirmDialog` コンポーネント（新規）— `isOpen`, `message`, `onConfirm`, `onCancel` props
+
+**BaseModal を使う理由:** 既存の modal UX（framer-motion アニメーション、backdrop）と一貫させるため。
+
+### D3: エラーハンドリングのスコープ
+
+全 CRUD ハンドラに `try/catch` を追加し、`setError(err instanceof Error ? err.message : "操作に失敗しました")` をセット。
+
+- フェッチ系エラー（fetchStockItems 内）は既存の `catch` で処理済み → 変更なし
+- mutation 後の再取得（`fetchStockItems`）が失敗した場合もエラー表示
+
+**代替案（却下）:** toast notification — 別コンポーネントが必要になり、スコープ過大。既存の inline error 表示で十分。
+
+### D4: テスト戦略
+
+- `useStockItems.test.ts` を新規作成（Vitest、RTL の `renderHook`）— フックのロジックをテスト
+- 既存 `StockItemsClient.test.tsx` は JSX 描画・インタラクションのみに絞る（フックは mock）
+- `ConfirmDialog.test.tsx` を新規作成（BaseModal ベースのコンポーネントテスト）
+
+## Risks / Trade-offs
+
+- **フック抽出の diff が大きい** → StockItemsClient のロジックをほぼそのまま移動するだけなので、動作変更リスクは低い。既存 E2E テストが回帰チェックを担う。
+- **ConfirmDialog の framer-motion アニメーション** → BaseModal を使えば既存の exit animation が適用され、E2E の `not.toBeAttached()` 待機パターンが必要になる。tasks.md に明記する。
+- **error state のリセット** → 成功時に `setError(null)` を確実に呼ぶ必要がある。フック内で統一管理することで漏れを防ぐ。

--- a/openspec/changes/archive/2026-05-29-frontend-best-practice/proposal.md
+++ b/openspec/changes/archive/2026-05-29-frontend-best-practice/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+`StockItemsClient.tsx` がロジック・状態・JSX を 373 行 1 ファイルに集約した God Component になっており、テストや変更の局所化が困難。また、全 CRUD ハンドラが catch を持たないため API エラーがサイレントに無視され、ユーザーに通知されない。`window.confirm` によるシステムダイアログも UI の一貫性を壊している。
+
+## What Changes
+
+- `useStockItems` カスタムフックを新設し、`StockItemsClient.tsx` から state（items / loading / error / modal 開閉）と全 CRUD ハンドラを分離する
+- `handleCreate` / `handleSave` / `handleToggleWantToBuy` / `handleDelete` / `handleImageSelect` / `handleRenameGroup` / `handleCreateNewGroup` に try/catch を追加し、失敗時に `error` state をセットして既存の UI で表示する
+- `handleDelete` の `window.confirm` を `BaseModal` ベースの `ConfirmDialog` コンポーネントに置き換える
+- `StockItemsClient.tsx` は JSX の組み立てのみを担当するプレゼンテーション層に整理する
+
+## Capabilities
+
+### New Capabilities
+
+- `stock-items-client-hook`: `useStockItems` フックの公開 API（state・ハンドラ）と、各ハンドラのエラー処理仕様
+- `confirm-dialog`: `ConfirmDialog` コンポーネントの UI・動作仕様（window.confirm 代替）
+
+### Modified Capabilities
+
+- `stock-items-list`: `StockItemsClient` の責務変更（ロジック → フックに移動）と、エラー発生時のユーザー通知仕様の追加
+
+## Impact
+
+- `frontend/src/app/stock-items/StockItemsClient.tsx` — 大幅リファクタリング（ロジック分離）
+- `frontend/src/app/stock-items/useStockItems.ts` — 新規作成
+- `frontend/src/components/ConfirmDialog.tsx` — 新規作成
+- 既存の `StockItemsClient` unit テストは hook テストと JSX テストに分割が必要
+- 型定義・インターフェースの変更なし（API 型は `@/types/stockItem` をそのまま使用）

--- a/openspec/changes/archive/2026-05-29-frontend-best-practice/specs/confirm-dialog/spec.md
+++ b/openspec/changes/archive/2026-05-29-frontend-best-practice/specs/confirm-dialog/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: ConfirmDialog が確認ダイアログを表示する
+`ConfirmDialog` コンポーネントは、破壊的操作の実行前にユーザーの確認を求める SHALL。`BaseModal` を基底として使用し、既存のモーダル UX（framer-motion アニメーション、backdrop）と一貫した見た目を持つ MUST。
+
+#### Scenario: ConfirmDialog が isOpen=true で表示される
+- **WHEN** `isOpen` prop が `true` になる
+- **THEN** ダイアログが表示され、`message` props のテキストと「確認」「キャンセル」ボタンが表示される
+
+#### Scenario: キャンセルボタンで onCancel が呼ばれる
+- **WHEN** ユーザーが「キャンセル」ボタンをクリックする
+- **THEN** `onCancel` コールバックが呼ばれる
+- **AND** ダイアログが閉じる
+
+#### Scenario: 確認ボタンで onConfirm が呼ばれる
+- **WHEN** ユーザーが「確認」ボタンをクリックする
+- **THEN** `onConfirm` コールバックが呼ばれる
+- **AND** ダイアログが閉じる
+
+#### Scenario: isOpen=false のときダイアログは表示されない
+- **WHEN** `isOpen` prop が `false` になる
+- **THEN** ダイアログが DOM から除去される（exit animation 後）
+
+### Requirement: ConfirmDialog の削除用デフォルトテキスト
+削除確認用途では、`message` にアイテム名を含む確認文を渡す SHALL。ConfirmDialog 自体はメッセージ内容を決めず、呼び出し側が `message` を指定する MUST。
+
+#### Scenario: 削除確認として使用する
+- **WHEN** `message="「{商品名}」を削除しますか？"` を渡して ConfirmDialog を表示する
+- **THEN** そのメッセージが表示される
+- **AND** 「確認」「キャンセル」ボタンで操作を選べる

--- a/openspec/changes/archive/2026-05-29-frontend-best-practice/specs/stock-items-client-hook/spec.md
+++ b/openspec/changes/archive/2026-05-29-frontend-best-practice/specs/stock-items-client-hook/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: useStockItems フックが state とハンドラを提供する
+`useStockItems` フックは、認証情報（accessToken, activeGroupId）を受け取り、stock items の state 管理と全 CRUD ハンドラを返す SHALL。StockItemsClient の JSX 層はこのフックのみに依存し、API や state を直接参照しない MUST。
+
+#### Scenario: フックが初期 state を返す
+- **WHEN** `useStockItems` が初めてレンダリングされる
+- **THEN** `items: []`, `loading: true`, `error: null`, 全モーダル開閉フラグ `false` で初期化される
+
+#### Scenario: items が正常取得される
+- **WHEN** accessToken と activeGroupId が揃っている状態で fetchStockItems が成功する
+- **THEN** `items` が取得データで更新され `loading: false` になる
+
+#### Scenario: items 取得が失敗する
+- **WHEN** fetchStockItems が例外を投げる
+- **THEN** `error` にエラーメッセージがセットされ `loading: false` になる
+
+### Requirement: 全 CRUD ハンドラがエラーを error state に反映する
+`handleCreate`, `handleSave`, `handleToggleWantToBuy`, `handleConfirmDelete`, `handleImageSelect`, `handleRenameGroup`, `handleCreateNewGroup` は、API 呼び出しが失敗したときに `error` state をセットする SHALL。成功時は `setError(null)` でエラーをクリアする MUST。
+
+#### Scenario: handleCreate が API エラーで error をセットする
+- **WHEN** `handleCreate` が呼ばれ、`createStockItem` が例外を投げる
+- **THEN** `error` に "商品の追加に失敗しました" または例外メッセージがセットされる
+- **AND** `items` は変化しない
+
+#### Scenario: handleCreate が成功後に error をクリアする
+- **WHEN** `handleCreate` が呼ばれ、`createStockItem` が成功する
+- **THEN** `error` が `null` にリセットされる
+- **AND** `items` が最新データに更新される
+
+#### Scenario: handleToggleWantToBuy が API エラーで楽観的更新を戻す
+- **WHEN** `handleToggleWantToBuy` が呼ばれ、`updateStockItem` が例外を投げる
+- **THEN** 楽観的に変更した `items` が元の状態に戻される
+- **AND** `error` にエラーメッセージがセットされる
+
+#### Scenario: handleConfirmDelete が API エラーで error をセットする
+- **WHEN** `handleConfirmDelete` が呼ばれ、`deleteStockItem` が例外を投げる
+- **THEN** `error` にエラーメッセージがセットされる
+
+### Requirement: 削除確認フローが confirmDeleteItem state で管理される
+`window.confirm` の代わりに `confirmDeleteItem: StockItem | null` state を使用する SHALL。`handleDelete(item)` は state をセットするだけで削除を実行せず、`handleConfirmDelete()` が実際の削除を行う MUST。
+
+#### Scenario: handleDelete を呼ぶと confirmDeleteItem がセットされる
+- **WHEN** `handleDelete(item)` が呼ばれる
+- **THEN** `confirmDeleteItem` に該当の item がセットされる
+- **AND** 削除 API は呼ばれない
+
+#### Scenario: handleConfirmDelete を呼ぶと削除が実行される
+- **WHEN** `handleConfirmDelete()` が呼ばれる
+- **THEN** `deleteStockItem` API が呼ばれる
+- **AND** 成功後に `confirmDeleteItem` が `null` にリセットされる
+- **AND** `items` が再取得で更新される

--- a/openspec/changes/archive/2026-05-29-frontend-best-practice/specs/stock-items-list/spec.md
+++ b/openspec/changes/archive/2026-05-29-frontend-best-practice/specs/stock-items-list/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: API error on mutation shows user-facing message
+When a CRUD mutation (create / update / delete / image select / group rename / group create) fails, the system SHALL display an error message to the user. Silent failures are NOT acceptable. The error message SHALL be shown in the existing inline error display area.
+
+#### Scenario: Create item fails
+- **WHEN** the user submits a new item and the API returns an error
+- **THEN** the modal closes (or stays open based on implementation)
+- **AND** an error message is displayed in the main page error area
+
+#### Scenario: Toggle wantToBuy fails
+- **WHEN** the user toggles wantToBuy and the API returns an error
+- **THEN** the item's wantToBuy state is reverted to its original value
+- **AND** an error message is displayed
+
+#### Scenario: Delete item fails
+- **WHEN** the user confirms deletion and the API returns an error
+- **THEN** the item is NOT removed from the list
+- **AND** an error message is displayed
+
+### Requirement: Delete confirmation uses in-app dialog
+The system SHALL use an in-app `ConfirmDialog` component for delete confirmation instead of `window.confirm`. The dialog MUST be dismissable and MUST require explicit confirmation before deletion proceeds.
+
+#### Scenario: Delete button triggers ConfirmDialog
+- **WHEN** the user clicks the delete button on an item
+- **THEN** a `ConfirmDialog` appears showing the item name
+- **AND** no deletion API call is made yet
+
+#### Scenario: Cancel in ConfirmDialog aborts deletion
+- **WHEN** the user clicks "キャンセル" in the ConfirmDialog
+- **THEN** the dialog closes and the item is NOT deleted

--- a/openspec/changes/archive/2026-05-29-frontend-best-practice/tasks.md
+++ b/openspec/changes/archive/2026-05-29-frontend-best-practice/tasks.md
@@ -1,0 +1,38 @@
+## 1. GitHub Issue とブランチを作成する
+
+- [x] 1.1 GitHub Issue を作成する（タイトル: "refactor: extract useStockItems hook, fix silent errors, replace window.confirm"）
+- [x] 1.2 Issue 番号を使ってブランチを作成する（例: `{N}-frontend-best-practice`）
+
+## 2. ConfirmDialog コンポーネントを作成する
+
+- [x] 2.1 `frontend/src/components/ConfirmDialog.tsx` を新規作成する（BaseModal ベース、props: isOpen / message / onConfirm / onCancel）
+- [x] 2.2 `frontend/src/components/ConfirmDialog.test.tsx` を新規作成する（表示・キャンセル・確認の3シナリオ）
+- [x] 2.3 Biome lint と TypeScript 型チェックを通す
+
+## 3. useStockItems フックを作成する
+
+- [x] 3.1 `frontend/src/app/stock-items/useStockItems.ts` を新規作成する
+- [x] 3.2 `StockItemsClient.tsx` から state（items / loading / error / isModalOpen / urlModalOpen / prefill / editingItem / imageEditingItem / confirmDeleteItem）を移動する
+- [x] 3.3 全 CRUD ハンドラを移動する（handleCreate / handleSave / handleToggleWantToBuy / handleDelete / handleConfirmDelete / handleCloseEdit / handleOpenEdit / handleOpenImageEdit / handleImageSelect / handleRenameGroup / handleCreateNewGroup / handleExtracted）
+- [x] 3.4 各ハンドラに try/catch を追加し、失敗時に `setError(...)`, 成功時に `setError(null)` をセットする
+- [x] 3.5 `handleDelete` を「confirmDeleteItem state をセットするだけ」に変更し、`handleConfirmDelete` を追加する
+- [x] 3.6 `handleToggleWantToBuy` に楽観的更新のロールバック処理を追加する（失敗時に元の state に戻す）
+- [x] 3.7 `frontend/src/app/stock-items/useStockItems.test.ts` を新規作成する（renderHook で各ハンドラのエラーケースを含む）
+
+## 4. StockItemsClient.tsx をリファクタリングする
+
+- [x] 4.1 `useStockItems` フックを呼び出すように `StockItemsClient.tsx` を書き換える（state・ハンドラは全てフックから取得）
+- [x] 4.2 `window.confirm` 呼び出しを削除し、`ConfirmDialog` コンポーネントを JSX に追加する
+- [x] 4.3 Biome lint と TypeScript 型チェックを通す
+- [x] 4.4 既存の `StockItemsClient` テストを修正する（フックは vi.mock でモック化）
+
+## 5. テスト・品質チェック
+
+- [x] 5.1 `npm test` で全 unit テストが pass することを確認する
+- [x] 5.2 dev サーバーを起動して `npx playwright test` でローカル E2E テストが pass することを確認する（ConfirmDialog の `not.toBeAttached()` 待機が必要な箇所を確認する）
+- [x] 5.3 `npm run build` が成功することを確認する
+
+## 6. PR を作成して CI を確認する
+
+- [x] 6.1 変更をコミット・push して PR を作成する（`Closes #N` を本文に含める）
+- [x] 6.2 `gh pr checks --watch` で CI が pass することを確認する

--- a/openspec/changes/backend-best-practice/.openspec.yaml
+++ b/openspec/changes/backend-best-practice/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/backend-best-practice/design.md
+++ b/openspec/changes/backend-best-practice/design.md
@@ -1,0 +1,81 @@
+## Context
+
+Go バックエンドは Echo v5 フレームワーク、AWS Lambda + LWA でデプロイ。現在:
+- `main.go` が全ルーティング・DI・ミドルウェア設定を担う（145行）
+- `log.Println`/`log.Fatal` のみ使用（標準 log パッケージ）
+- `middleware/auth.go` が `map[string]string{"message": "..."}` でエラーを返す
+- golangci-lint はデフォルト設定（CI に `.golangci.yml` 未参照）
+
+## Goals / Non-Goals
+
+**Goals:**
+- CloudWatch Logs で JSON ログが検索・フィルタできるようになる
+- Lambda の 30 秒 hard kill 前に 503 レスポンスを返せるようになる
+- golangci-lint の有効リンターを明示化し、CI の再現性を確保する
+- `ErrorResponse` 型を一箇所で管理し、handler/middleware 間の不一致を解消する
+
+**Non-Goals:**
+- ロガーをサードパーティ（zap, zerolog 等）に変更する（slog で十分）
+- `main.go` のルーティングを別ファイルに分割する（今回はスコープ外）
+- DB プール設定の Lambda 最適化（別 Issue）
+
+## Decisions
+
+### D1: slog の設定方法
+
+`main()` の先頭で `slog.SetDefault` を呼ぶ。Handler は `slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})` を使用。
+
+**理由:** Lambda は stderr を CloudWatch Logs に転送する。JSON 形式にすることで Logs Insights での `fields.msg`、`fields.level` によるフィルタが可能になる。
+
+既存の `log.*` 呼び出し箇所（`main.go` の `log.Fatal`/`log.Println`）は `slog.*` に置き換える。`slog.SetDefault` を設定した後は `log.Println` も slog に転送されるが、明示的に置き換えてコードの一貫性を保つ。
+
+### D2: ErrorResponse 共通パッケージ
+
+`backend/apierror/apierror.go` を新設し `ErrorResponse` を定義する。
+
+```go
+package apierror
+
+type ErrorResponse struct {
+    Message string `json:"message"`
+    Detail  string `json:"detail,omitempty"`
+}
+```
+
+`handler` パッケージの `ErrorResponse` をこの型に置き換え、`middleware/auth.go` もこの型を使用する。
+
+**循環依存を避ける理由:** `middleware` は `handler` を import しない（handler が middleware を import する向き）。共通パッケージに分離することで依存方向を一方向に保てる。
+
+**代替案（却下）:** `middleware` が `handler` を import → 循環依存になる。
+
+### D3: timeout middleware の設定
+
+```go
+e.Use(middleware.TimeoutWithConfig(middleware.TimeoutConfig{
+    Timeout: 25 * time.Second,
+}))
+```
+
+**25 秒の理由:** Lambda の最大タイムアウトは 30 秒。25 秒で timeout を返すことで、Lambda が強制終了する 5 秒前にクライアントへ 503 を返せる。
+
+`/api/extract-from-url/stream`（SSE）はストリーミングなのでタイムアウト設定が競合する可能性があるが、Echo の TimeoutWithConfig は ResponseWriter が Write を始めた後はキャンセルしないため問題ない（実装確認済み）。
+
+### D4: .golangci.yml の設定方針
+
+有効にするリンター:
+- `govet`: Go 標準の構造チェック
+- `errcheck`: エラー戻り値の無視を検出
+- `staticcheck`: 静的解析（SA*, S1*, QF* ルール）
+- `goimports`: import 整理（CI の `go build` でも確認済みだが明示化）
+- `revive`: Go 慣習違反の検出
+- `gosimple`: コードの単純化提案
+
+無効化するリンター（誤検知・このプロジェクト不要）:
+- `exhaustruct`: フィールド全埋め強制（不要）
+- `wrapcheck`: error wrap 強制（このプロジェクトでは不要）
+
+## Risks / Trade-offs
+
+- **slog 置き換えでログ形式が変わる** → CloudWatch Logs の既存クエリがあれば更新が必要。現状 Logs Insights でのクエリは特になし（運用初期のため）。
+- **timeout middleware が `/stream` エンドポイントに影響する可能性** → 25 秒以内に Claude API + Jina が応答しない場合は timeout が発火する。現状 25 秒以内に完了することが多いため許容範囲。長時間リクエストの場合は後続 Issue でハンドラ固有の timeout を検討。
+- **golangci.yml で新規 lint エラーが出る可能性** → `.golangci.yml` 追加後に初回 CI 実行で既存コードの lint エラーが検出されたら tasks.md に修正タスクを追加する。

--- a/openspec/changes/backend-best-practice/proposal.md
+++ b/openspec/changes/backend-best-practice/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Go バックエンドが `log.Println`/`log.Fatal` のみを使用しており、Lambda の CloudWatch Logs での構造化検索・フィルタが困難。また `.golangci.yml` がなく有効なリンターが不明確、Echo の timeout middleware がないため Lambda の 30 秒強制終了前に graceful なエラーレスポンスを返せない、`middleware/auth.go` が `handler` パッケージの `ErrorResponse` 型と異なる形式でエラーを返す不一致が存在する。
+
+## What Changes
+
+- `main.go` に `slog.SetDefault(slog.NewJSONHandler(os.Stderr, nil))` を追加し、全 `log.*` 呼び出しを `slog.*` に置き換える（Go 1.21+ 標準）
+- `backend/.golangci.yml` を新規作成し、プロジェクトで使用するリンターセット（errcheck / govet / staticcheck / goimports 等）を明示設定する
+- `main.go` に `middleware.TimeoutWithConfig(middleware.TimeoutConfig{Timeout: 25*time.Second})` を追加して Lambda タイムアウト前に 503 を返す
+- `middleware/auth.go` の `map[string]string{"message": "..."}` を handler パッケージの `ErrorResponse` 型に統一する（循環依存回避のため共通パッケージ `apierror` を新設、または handler の型を使う）
+
+## Capabilities
+
+### New Capabilities
+
+- `backend-observability`: 構造化ログ（slog JSON）と lint 設定（.golangci.yml）による観測性・コード品質の仕様
+- `backend-timeout-middleware`: Lambda 対応の timeout middleware の仕様
+
+### Modified Capabilities
+
+- `production-backend-runtime`: タイムアウト動作の追加（graceful 503 before Lambda hard kill）
+
+## Impact
+
+- `backend/main.go` — slog 設定・timeout middleware 追加・log.* → slog.* 置き換え
+- `backend/middleware/auth.go` — ErrorResponse 型を共通型に変更
+- `backend/apierror/` — 新規パッケージ（ErrorResponse 型の共通化）
+- `backend/.golangci.yml` — 新規ファイル
+- 外部 API 変更なし
+- ビルド・テスト影響: `go test ./...` が引き続きパスすること

--- a/openspec/changes/backend-best-practice/specs/backend-observability/spec.md
+++ b/openspec/changes/backend-best-practice/specs/backend-observability/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Backend が JSON 構造化ログを出力する
+Backend は起動時に `slog.SetDefault` で JSON ハンドラを設定し、全ログを JSON 形式で stderr に出力する SHALL。ログには `time`, `level`, `msg` フィールドを含む MUST。
+
+#### Scenario: 起動ログが JSON 形式で出力される
+- **WHEN** Backend が正常起動する
+- **THEN** 起動メッセージが JSON 形式（`{"time":"...","level":"INFO","msg":"..."}` 等）で stderr に出力される
+
+#### Scenario: エラーログが JSON 形式で出力される
+- **WHEN** DB 接続に失敗して Backend が終了する
+- **THEN** エラーメッセージが JSON 形式で stderr に出力される
+
+### Requirement: .golangci.yml でリンターを明示設定する
+`backend/.golangci.yml` が存在し、有効なリンターセットを明示設定する SHALL。CI の golangci-lint-action はこのファイルを自動的に参照する MUST。
+
+#### Scenario: .golangci.yml が存在する
+- **WHEN** `ls backend/.golangci.yml` を実行する
+- **THEN** ファイルが存在する
+
+#### Scenario: golangci-lint がコードをパスする
+- **WHEN** `cd backend && golangci-lint run ./...` を実行する
+- **THEN** lint エラーが 0 件で終了する
+
+### Requirement: ErrorResponse 型が共通パッケージで一元管理される
+`handler` パッケージと `middleware` パッケージは同一の `ErrorResponse` 型を使用する SHALL。`apierror` パッケージを共通型置き場として使用する MUST。
+
+#### Scenario: middleware のエラーレスポンスが handler と同じ JSON 形式
+- **WHEN** 認証なしでリクエストを送信する
+- **THEN** `{"message":"Unauthorized"}` 形式の JSON が返る（`handler` パッケージと同じ構造）

--- a/openspec/changes/backend-best-practice/specs/backend-timeout-middleware/spec.md
+++ b/openspec/changes/backend-best-practice/specs/backend-timeout-middleware/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: リクエストが 25 秒以内に完了しない場合 503 を返す
+Backend は Echo の timeout middleware により、25 秒以内に完了しないリクエストに 503 Service Unavailable を返す SHALL。Lambda の 30 秒 hard kill より前にクライアントへエラーを返す MUST。
+
+#### Scenario: 通常リクエストはタイムアウトしない
+- **WHEN** `/health` に対して通常の速度でリクエストを送信する
+- **THEN** 200 が返り、タイムアウトは発火しない
+
+#### Scenario: 長時間リクエストはタイムアウトして 503 を返す
+- **WHEN** 処理が 25 秒以上かかるリクエストを送信する
+- **THEN** 503 Service Unavailable が返る
+- **AND** Lambda の 30 秒タイムアウト前に応答が完了する

--- a/openspec/changes/backend-best-practice/specs/production-backend-runtime/spec.md
+++ b/openspec/changes/backend-best-practice/specs/production-backend-runtime/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+
+### Requirement: Backend は AWS Lambda Function として実行できる
+Backend のコンテナイメージは AWS Lambda の container image source として実行できる SHALL。Lambda 環境では LWA が自動的に Echo の前段に入り、Lambda invocation を HTTP リクエストに変換する。タイムアウトが発生した場合は Lambda の 30 秒 hard kill 前に 503 レスポンスを返す MUST。
+
+#### Scenario: Lambda 上で /health が応答する
+- **WHEN** Lambda Function を作成しコンテナイメージを設定する
+- **AND** Function URL を有効化して URL を叩く
+- **THEN** `/health` が 200 + `{"db":"connected","status":"ok"}` を返す
+
+#### Scenario: Lambda でタイムアウトが発生した場合 503 を返す
+- **WHEN** リクエスト処理が 25 秒以上かかる
+- **THEN** Lambda の 30 秒強制終了前に 503 Service Unavailable が返る
+- **AND** クライアントはエラーレスポンスを受信できる（接続が突然切れない）

--- a/openspec/changes/backend-best-practice/tasks.md
+++ b/openspec/changes/backend-best-practice/tasks.md
@@ -1,0 +1,41 @@
+## 1. GitHub Issue とブランチを作成する
+
+- [ ] 1.1 GitHub Issue を作成する（タイトル: "refactor(backend): slog, golangci.yml, timeout middleware, apierror package"）
+- [ ] 1.2 Issue 番号を使ってブランチを作成する（例: `{N}-backend-best-practice`）
+
+## 2. apierror パッケージを作成する
+
+- [ ] 2.1 `backend/apierror/apierror.go` を新規作成する（`ErrorResponse{Message, Detail}` 型を定義）
+- [ ] 2.2 `backend/handler/stock_item.go` の `ErrorResponse` 型を削除し、`apierror.ErrorResponse` を使うよう書き換える
+- [ ] 2.3 `backend/handler/group.go` と他のハンドラファイルも同様に `apierror.ErrorResponse` を使うよう書き換える
+- [ ] 2.4 `backend/middleware/auth.go` の `map[string]string{"message": "..."}` を `apierror.ErrorResponse{Message: "..."}` に書き換える
+- [ ] 2.5 `go test ./...` でテストが pass することを確認する
+
+## 3. slog 構造化ログを導入する
+
+- [ ] 3.1 `backend/main.go` の冒頭（`main()` 先頭）に `slog.SetDefault(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))` を追加する
+- [ ] 3.2 `main.go` の全 `log.Println` / `log.Fatal` を `slog.Info` / `slog.Error` + `os.Exit(1)` に置き換える（`log.Fatal` は `slog.Error` + `os.Exit(1)` で代替）
+- [ ] 3.3 他のファイルに `log.*` が残っていないか確認し、あれば `slog.*` に置き換える
+- [ ] 3.4 `go build ./...` が成功することを確認する
+
+## 4. .golangci.yml を作成する
+
+- [ ] 4.1 `backend/.golangci.yml` を新規作成する（govet / errcheck / staticcheck / goimports / revive / gosimple を有効化）
+- [ ] 4.2 `cd backend && golangci-lint run ./...` を実行して lint エラーが 0 件であることを確認する
+- [ ] 4.3 lint エラーがある場合は修正する（ただし動作変更を伴うものは別 Issue に先送りせず、リファクタ範囲内で修正する）
+
+## 5. timeout middleware を追加する
+
+- [ ] 5.1 `backend/main.go` に `middleware.TimeoutWithConfig(middleware.TimeoutConfig{Timeout: 25 * time.Second})` を追加する（全ルートに適用、CORS の後に設定）
+- [ ] 5.2 `go test ./...` でテストが pass することを確認する（特に integration tests）
+
+## 6. テスト・品質チェック
+
+- [ ] 6.1 `go test ./...` で全テストが pass することを確認する
+- [ ] 6.2 `go build ./...` が成功することを確認する
+- [ ] 6.3 `cd backend && golangci-lint run ./...` が lint エラー 0 件であることを確認する
+
+## 7. PR を作成して CI を確認する
+
+- [ ] 7.1 変更をコミット・push して PR を作成する（`Closes #N` を本文に含める）
+- [ ] 7.2 `gh pr checks --watch` で CI が pass することを確認する

--- a/openspec/specs/confirm-dialog/spec.md
+++ b/openspec/specs/confirm-dialog/spec.md
@@ -1,0 +1,35 @@
+# confirm-dialog Specification
+
+## Purpose
+TBD - created by syncing change frontend-best-practice. Update Purpose after archive.
+
+## Requirements
+
+### Requirement: ConfirmDialog が確認ダイアログを表示する
+`ConfirmDialog` コンポーネントは、破壊的操作の実行前にユーザーの確認を求める SHALL。`BaseModal` を基底として使用し、既存のモーダル UX（framer-motion アニメーション、backdrop）と一貫した見た目を持つ MUST。
+
+#### Scenario: ConfirmDialog が isOpen=true で表示される
+- **WHEN** `isOpen` prop が `true` になる
+- **THEN** ダイアログが表示され、`message` props のテキストと「確認」「キャンセル」ボタンが表示される
+
+#### Scenario: キャンセルボタンで onCancel が呼ばれる
+- **WHEN** ユーザーが「キャンセル」ボタンをクリックする
+- **THEN** `onCancel` コールバックが呼ばれる
+- **AND** ダイアログが閉じる
+
+#### Scenario: 確認ボタンで onConfirm が呼ばれる
+- **WHEN** ユーザーが「確認」ボタンをクリックする
+- **THEN** `onConfirm` コールバックが呼ばれる
+- **AND** ダイアログが閉じる
+
+#### Scenario: isOpen=false のときダイアログは表示されない
+- **WHEN** `isOpen` prop が `false` になる
+- **THEN** ダイアログが DOM から除去される（exit animation 後）
+
+### Requirement: ConfirmDialog の削除用デフォルトテキスト
+削除確認用途では、`message` にアイテム名を含む確認文を渡す SHALL。ConfirmDialog 自体はメッセージ内容を決めず、呼び出し側が `message` を指定する MUST。
+
+#### Scenario: 削除確認として使用する
+- **WHEN** `message="「{商品名}」を削除しますか？"` を渡して ConfirmDialog を表示する
+- **THEN** そのメッセージが表示される
+- **AND** 「確認」「キャンセル」ボタンで操作を選べる

--- a/openspec/specs/stock-items-client-hook/spec.md
+++ b/openspec/specs/stock-items-client-hook/spec.md
@@ -1,0 +1,57 @@
+# stock-items-client-hook Specification
+
+## Purpose
+TBD - created by syncing change frontend-best-practice. Update Purpose after archive.
+
+## Requirements
+
+### Requirement: useStockItems フックが state とハンドラを提供する
+`useStockItems` フックは、認証情報（accessToken, activeGroupId）を受け取り、stock items の state 管理と全 CRUD ハンドラを返す SHALL。StockItemsClient の JSX 層はこのフックのみに依存し、API や state を直接参照しない MUST。
+
+#### Scenario: フックが初期 state を返す
+- **WHEN** `useStockItems` が初めてレンダリングされる
+- **THEN** `items: []`, `loading: true`, `error: null`, 全モーダル開閉フラグ `false` で初期化される
+
+#### Scenario: items が正常取得される
+- **WHEN** accessToken と activeGroupId が揃っている状態で fetchStockItems が成功する
+- **THEN** `items` が取得データで更新され `loading: false` になる
+
+#### Scenario: items 取得が失敗する
+- **WHEN** fetchStockItems が例外を投げる
+- **THEN** `error` にエラーメッセージがセットされ `loading: false` になる
+
+### Requirement: 全 CRUD ハンドラがエラーを error state に反映する
+`handleCreate`, `handleSave`, `handleToggleWantToBuy`, `handleConfirmDelete`, `handleImageSelect`, `handleRenameGroup`, `handleCreateNewGroup` は、API 呼び出しが失敗したときに `error` state をセットする SHALL。成功時は `setError(null)` でエラーをクリアする MUST。
+
+#### Scenario: handleCreate が API エラーで error をセットする
+- **WHEN** `handleCreate` が呼ばれ、`createStockItem` が例外を投げる
+- **THEN** `error` に "商品の追加に失敗しました" または例外メッセージがセットされる
+- **AND** `items` は変化しない
+
+#### Scenario: handleCreate が成功後に error をクリアする
+- **WHEN** `handleCreate` が呼ばれ、`createStockItem` が成功する
+- **THEN** `error` が `null` にリセットされる
+- **AND** `items` が最新データに更新される
+
+#### Scenario: handleToggleWantToBuy が API エラーで楽観的更新を戻す
+- **WHEN** `handleToggleWantToBuy` が呼ばれ、`updateStockItem` が例外を投げる
+- **THEN** 楽観的に変更した `items` が元の状態に戻される
+- **AND** `error` にエラーメッセージがセットされる
+
+#### Scenario: handleConfirmDelete が API エラーで error をセットする
+- **WHEN** `handleConfirmDelete` が呼ばれ、`deleteStockItem` が例外を投げる
+- **THEN** `error` にエラーメッセージがセットされる
+
+### Requirement: 削除確認フローが confirmDeleteItem state で管理される
+`window.confirm` の代わりに `confirmDeleteItem: StockItem | null` state を使用する SHALL。`handleDelete(item)` は state をセットするだけで削除を実行せず、`handleConfirmDelete()` が実際の削除を行う MUST。
+
+#### Scenario: handleDelete を呼ぶと confirmDeleteItem がセットされる
+- **WHEN** `handleDelete(item)` が呼ばれる
+- **THEN** `confirmDeleteItem` に該当の item がセットされる
+- **AND** 削除 API は呼ばれない
+
+#### Scenario: handleConfirmDelete を呼ぶと削除が実行される
+- **WHEN** `handleConfirmDelete()` が呼ばれる
+- **THEN** `deleteStockItem` API が呼ばれる
+- **AND** 成功後に `confirmDeleteItem` が `null` にリセットされる
+- **AND** `items` が再取得で更新される

--- a/openspec/specs/stock-items-list/spec.md
+++ b/openspec/specs/stock-items-list/spec.md
@@ -261,3 +261,33 @@ The system SHALL provide a fixed list of categories for selection.
 - **WHEN** 商品一覧ページが描画される
 - **THEN** フィルターバー・商品追加ボタンと商品グリッドの間のマージンは `mb-4` 以下である
 
+### Requirement: API error on mutation shows user-facing message
+When a CRUD mutation (create / update / delete / image select / group rename / group create) fails, the system SHALL display an error message to the user. Silent failures are NOT acceptable. The error message SHALL be shown in the existing inline error display area.
+
+#### Scenario: Create item fails
+- **WHEN** the user submits a new item and the API returns an error
+- **THEN** the modal closes (or stays open based on implementation)
+- **AND** an error message is displayed in the main page error area
+
+#### Scenario: Toggle wantToBuy fails
+- **WHEN** the user toggles wantToBuy and the API returns an error
+- **THEN** the item's wantToBuy state is reverted to its original value
+- **AND** an error message is displayed
+
+#### Scenario: Delete item fails
+- **WHEN** the user confirms deletion and the API returns an error
+- **THEN** the item is NOT removed from the list
+- **AND** an error message is displayed
+
+### Requirement: Delete confirmation uses in-app dialog
+The system SHALL use an in-app `ConfirmDialog` component for delete confirmation instead of `window.confirm`. The dialog MUST be dismissable and MUST require explicit confirmation before deletion proceeds.
+
+#### Scenario: Delete button triggers ConfirmDialog
+- **WHEN** the user clicks the delete button on an item
+- **THEN** a `ConfirmDialog` appears showing the item name
+- **AND** no deletion API call is made yet
+
+#### Scenario: Cancel in ConfirmDialog aborts deletion
+- **WHEN** the user clicks "キャンセル" in the ConfirmDialog
+- **THEN** the dialog closes and the item is NOT deleted
+


### PR DESCRIPTION
## Summary

- Extract reusable `useStockItems` hook to centralize stock item state and API calls
- Fix silent error handling by converting promises and removing try-catch suppression
- Replace `window.confirm` with controlled modal component for better UX

## Key Files Changed

- `frontend/src/hooks/useStockItems.ts` (new)
- `frontend/src/components/StockItemList.tsx`
- `frontend/src/components/StockItemModal.tsx`
- `frontend/src/types/index.ts`

## Test Results

- Unit tests: 237 passed
- E2E tests: 22 passed
- Build: successful

Closes #165