### PR TITLE
test: テスト名の言語統一・グルーピング整理

### DIFF
--- a/backend/handler/group_test.go
+++ b/backend/handler/group_test.go
@@ -58,221 +58,231 @@ func setupGroupRouter(h *GroupHandler) *echo.Echo {
 	return e
 }
 
-func TestCreateGroup_Success(t *testing.T) {
-	userID := uuid.New()
-	groupID := uuid.New()
-	mock := &mockGroupRepo{
-		createGroupFn: func(_ context.Context, name string, _ uuid.UUID) (*repository.Group, error) {
-			return &repository.Group{ID: groupID, Name: name}, nil
-		},
-	}
-	h := NewGroupHandler(mock)
-	e := setupGroupRouter(h)
+func TestCreateGroup(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		userID := uuid.New()
+		groupID := uuid.New()
+		mock := &mockGroupRepo{
+			createGroupFn: func(_ context.Context, name string, _ uuid.UUID) (*repository.Group, error) {
+				return &repository.Group{ID: groupID, Name: name}, nil
+			},
+		}
+		h := NewGroupHandler(mock)
+		e := setupGroupRouter(h)
 
-	body := `{"name":"我が家"}`
-	req := httptest.NewRequest(http.MethodPost, "/api/groups", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: userID})
-	require.NoError(t, h.CreateGroup(c))
+		body := `{"name":"我が家"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/groups", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: userID})
+		require.NoError(t, h.CreateGroup(c))
 
-	assert.Equal(t, http.StatusCreated, rec.Code)
-	var resp repository.Group
-	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
-	assert.Equal(t, groupID, resp.ID)
-	assert.Equal(t, "我が家", resp.Name)
+		assert.Equal(t, http.StatusCreated, rec.Code)
+		var resp repository.Group
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		assert.Equal(t, groupID, resp.ID)
+		assert.Equal(t, "我が家", resp.Name)
+	})
+
+	t.Run("already_member_still_succeeds", func(t *testing.T) {
+		userID := uuid.New()
+		groupID := uuid.New()
+		mock := &mockGroupRepo{
+			createGroupFn: func(_ context.Context, name string, _ uuid.UUID) (*repository.Group, error) {
+				return &repository.Group{ID: groupID, Name: name}, nil
+			},
+		}
+		h := NewGroupHandler(mock)
+		e := setupGroupRouter(h)
+
+		body := `{"name":"新しい家"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/groups", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: userID})
+		require.NoError(t, h.CreateGroup(c))
+
+		assert.Equal(t, http.StatusCreated, rec.Code)
+	})
 }
 
-func TestCreateGroup_AlreadyMember_StillSucceeds(t *testing.T) {
-	userID := uuid.New()
-	groupID := uuid.New()
-	mock := &mockGroupRepo{
-		createGroupFn: func(_ context.Context, name string, _ uuid.UUID) (*repository.Group, error) {
-			return &repository.Group{ID: groupID, Name: name}, nil
-		},
-	}
-	h := NewGroupHandler(mock)
-	e := setupGroupRouter(h)
+func TestGetMyGroups(t *testing.T) {
+	t.Run("returns_all", func(t *testing.T) {
+		userID := uuid.New()
+		groupID1 := uuid.New()
+		groupID2 := uuid.New()
+		mock := &mockGroupRepo{
+			findMembershipsFn: func(_ context.Context, _ uuid.UUID) ([]repository.GroupMembership, error) {
+				return []repository.GroupMembership{
+					{GroupID: groupID1, Name: "我が家", Role: "owner"},
+					{GroupID: groupID2, Name: "実家", Role: "member"},
+				}, nil
+			},
+		}
+		h := NewGroupHandler(mock)
+		e := setupGroupRouter(h)
 
-	body := `{"name":"新しい家"}`
-	req := httptest.NewRequest(http.MethodPost, "/api/groups", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: userID})
-	require.NoError(t, h.CreateGroup(c))
+		req := httptest.NewRequest(http.MethodGet, "/api/groups/me", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: userID})
+		require.NoError(t, h.GetMyGroups(c))
 
-	assert.Equal(t, http.StatusCreated, rec.Code)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var resp []repository.GroupMembership
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		require.Len(t, resp, 2)
+		assert.Equal(t, groupID1, resp[0].GroupID)
+		assert.Equal(t, groupID2, resp[1].GroupID)
+	})
 }
 
-func TestGetMyGroups_ReturnsAll(t *testing.T) {
-	userID := uuid.New()
-	groupID1 := uuid.New()
-	groupID2 := uuid.New()
-	mock := &mockGroupRepo{
-		findMembershipsFn: func(_ context.Context, _ uuid.UUID) ([]repository.GroupMembership, error) {
-			return []repository.GroupMembership{
-				{GroupID: groupID1, Name: "我が家", Role: "owner"},
-				{GroupID: groupID2, Name: "実家", Role: "member"},
-			}, nil
-		},
-	}
-	h := NewGroupHandler(mock)
-	e := setupGroupRouter(h)
+func TestUpdateGroup(t *testing.T) {
+	t.Run("owner_success", func(t *testing.T) {
+		groupID := uuid.New()
+		mock := &mockGroupRepo{
+			updateGroupNameFn: func(_ context.Context, gID uuid.UUID, name string) (*repository.Group, error) {
+				return &repository.Group{ID: gID, Name: name}, nil
+			},
+		}
+		h := NewGroupHandler(mock)
+		e := setupGroupRouter(h)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/groups/me", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: userID})
-	require.NoError(t, h.GetMyGroups(c))
+		body := `{"name":"新しい名前"}`
+		req := httptest.NewRequest(http.MethodPatch, "/api/groups/"+groupID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPathValues(echo.PathValues{{Name: "id", Value: groupID.String()}})
+		middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: uuid.New(), GroupID: groupID, Role: "owner"})
+		require.NoError(t, h.UpdateGroup(c))
 
-	assert.Equal(t, http.StatusOK, rec.Code)
-	var resp []repository.GroupMembership
-	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
-	require.Len(t, resp, 2)
-	assert.Equal(t, groupID1, resp[0].GroupID)
-	assert.Equal(t, groupID2, resp[1].GroupID)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var resp repository.Group
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		assert.Equal(t, "新しい名前", resp.Name)
+	})
+
+	t.Run("member_forbidden", func(t *testing.T) {
+		groupID := uuid.New()
+		mock := &mockGroupRepo{}
+		h := NewGroupHandler(mock)
+		e := setupGroupRouter(h)
+
+		body := `{"name":"名前"}`
+		req := httptest.NewRequest(http.MethodPatch, "/api/groups/"+groupID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPathValues(echo.PathValues{{Name: "id", Value: groupID.String()}})
+		middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: uuid.New(), GroupID: groupID, Role: "member"})
+		require.NoError(t, h.UpdateGroup(c))
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("wrong_group_forbidden", func(t *testing.T) {
+		groupID := uuid.New()
+		otherGroupID := uuid.New()
+		mock := &mockGroupRepo{}
+		h := NewGroupHandler(mock)
+		e := setupGroupRouter(h)
+
+		body := `{"name":"名前"}`
+		req := httptest.NewRequest(http.MethodPatch, "/api/groups/"+otherGroupID.String(), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPathValues(echo.PathValues{{Name: "id", Value: otherGroupID.String()}})
+		middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: uuid.New(), GroupID: groupID, Role: "owner"})
+		require.NoError(t, h.UpdateGroup(c))
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
 }
 
-func TestUpdateGroup_Owner_Success(t *testing.T) {
-	groupID := uuid.New()
-	mock := &mockGroupRepo{
-		updateGroupNameFn: func(_ context.Context, gID uuid.UUID, name string) (*repository.Group, error) {
-			return &repository.Group{ID: gID, Name: name}, nil
-		},
-	}
-	h := NewGroupHandler(mock)
-	e := setupGroupRouter(h)
+func TestCreateInvitation(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		userID := uuid.New()
+		groupID := uuid.New()
+		token := uuid.New()
+		mock := &mockGroupRepo{
+			createInvitationFn: func(_ context.Context, gID, cBy uuid.UUID, _ time.Duration) (*repository.Invitation, error) {
+				return &repository.Invitation{
+					Token:     token,
+					GroupID:   gID,
+					CreatedBy: cBy,
+					ExpiresAt: time.Now().Add(7 * 24 * time.Hour),
+				}, nil
+			},
+		}
+		h := NewGroupHandler(mock)
+		e := setupGroupRouter(h)
 
-	body := `{"name":"新しい名前"}`
-	req := httptest.NewRequest(http.MethodPatch, "/api/groups/"+groupID.String(), strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.SetPathValues(echo.PathValues{{Name: "id", Value: groupID.String()}})
-	middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: uuid.New(), GroupID: groupID, Role: "owner"})
-	require.NoError(t, h.UpdateGroup(c))
+		req := httptest.NewRequest(http.MethodPost, "/api/invitations", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: userID, GroupID: groupID, Role: "owner"})
+		require.NoError(t, h.CreateInvitation(c))
 
-	assert.Equal(t, http.StatusOK, rec.Code)
-	var resp repository.Group
-	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
-	assert.Equal(t, "新しい名前", resp.Name)
+		assert.Equal(t, http.StatusCreated, rec.Code)
+		var resp repository.Invitation
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		assert.Equal(t, token, resp.Token)
+	})
 }
 
-func TestUpdateGroup_Member_Forbidden(t *testing.T) {
-	groupID := uuid.New()
-	mock := &mockGroupRepo{}
-	h := NewGroupHandler(mock)
-	e := setupGroupRouter(h)
+func TestAcceptInvitation(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		userID := uuid.New()
+		token := uuid.New()
+		groupID := uuid.New()
+		mock := &mockGroupRepo{
+			acceptInvitationFn: func(_ context.Context, tok, uid uuid.UUID) error {
+				assert.Equal(t, token, tok)
+				assert.Equal(t, userID, uid)
+				return nil
+			},
+			findMembershipsFn: func(_ context.Context, _ uuid.UUID) ([]repository.GroupMembership, error) {
+				return []repository.GroupMembership{{GroupID: groupID, Name: "家", Role: "member"}}, nil
+			},
+		}
+		h := NewGroupHandler(mock)
+		e := setupGroupRouter(h)
 
-	body := `{"name":"名前"}`
-	req := httptest.NewRequest(http.MethodPatch, "/api/groups/"+groupID.String(), strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.SetPathValues(echo.PathValues{{Name: "id", Value: groupID.String()}})
-	middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: uuid.New(), GroupID: groupID, Role: "member"})
-	require.NoError(t, h.UpdateGroup(c))
+		req := httptest.NewRequest(http.MethodPost, "/api/invitations/"+token.String()+"/accept", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPathValues(echo.PathValues{{Name: "token", Value: token.String()}})
+		middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: userID})
+		require.NoError(t, h.AcceptInvitation(c))
 
-	assert.Equal(t, http.StatusForbidden, rec.Code)
-}
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var resp []repository.GroupMembership
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		require.Len(t, resp, 1)
+	})
 
-func TestUpdateGroup_WrongGroup_Forbidden(t *testing.T) {
-	groupID := uuid.New()
-	otherGroupID := uuid.New()
-	mock := &mockGroupRepo{}
-	h := NewGroupHandler(mock)
-	e := setupGroupRouter(h)
+	t.Run("expired", func(t *testing.T) {
+		userID := uuid.New()
+		token := uuid.New()
+		mock := &mockGroupRepo{
+			acceptInvitationFn: func(_ context.Context, _, _ uuid.UUID) error {
+				return repository.ErrInvitationExpired
+			},
+		}
+		h := NewGroupHandler(mock)
+		e := setupGroupRouter(h)
 
-	body := `{"name":"名前"}`
-	req := httptest.NewRequest(http.MethodPatch, "/api/groups/"+otherGroupID.String(), strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.SetPathValues(echo.PathValues{{Name: "id", Value: otherGroupID.String()}})
-	middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: uuid.New(), GroupID: groupID, Role: "owner"})
-	require.NoError(t, h.UpdateGroup(c))
+		req := httptest.NewRequest(http.MethodPost, "/api/invitations/"+token.String()+"/accept", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPathValues(echo.PathValues{{Name: "token", Value: token.String()}})
+		middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: userID})
+		require.NoError(t, h.AcceptInvitation(c))
 
-	assert.Equal(t, http.StatusForbidden, rec.Code)
-}
-
-func TestCreateInvitation_Success(t *testing.T) {
-	userID := uuid.New()
-	groupID := uuid.New()
-	token := uuid.New()
-	mock := &mockGroupRepo{
-		createInvitationFn: func(_ context.Context, gID, cBy uuid.UUID, _ time.Duration) (*repository.Invitation, error) {
-			return &repository.Invitation{
-				Token:     token,
-				GroupID:   gID,
-				CreatedBy: cBy,
-				ExpiresAt: time.Now().Add(7 * 24 * time.Hour),
-			}, nil
-		},
-	}
-	h := NewGroupHandler(mock)
-	e := setupGroupRouter(h)
-
-	req := httptest.NewRequest(http.MethodPost, "/api/invitations", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: userID, GroupID: groupID, Role: "owner"})
-	require.NoError(t, h.CreateInvitation(c))
-
-	assert.Equal(t, http.StatusCreated, rec.Code)
-	var resp repository.Invitation
-	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
-	assert.Equal(t, token, resp.Token)
-}
-
-func TestAcceptInvitation_Success(t *testing.T) {
-	userID := uuid.New()
-	token := uuid.New()
-	groupID := uuid.New()
-	mock := &mockGroupRepo{
-		acceptInvitationFn: func(_ context.Context, tok, uid uuid.UUID) error {
-			assert.Equal(t, token, tok)
-			assert.Equal(t, userID, uid)
-			return nil
-		},
-		findMembershipsFn: func(_ context.Context, _ uuid.UUID) ([]repository.GroupMembership, error) {
-			return []repository.GroupMembership{{GroupID: groupID, Name: "家", Role: "member"}}, nil
-		},
-	}
-	h := NewGroupHandler(mock)
-	e := setupGroupRouter(h)
-
-	req := httptest.NewRequest(http.MethodPost, "/api/invitations/"+token.String()+"/accept", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.SetPathValues(echo.PathValues{{Name: "token", Value: token.String()}})
-	middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: userID})
-	require.NoError(t, h.AcceptInvitation(c))
-
-	assert.Equal(t, http.StatusOK, rec.Code)
-	var resp []repository.GroupMembership
-	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
-	require.Len(t, resp, 1)
-}
-
-func TestAcceptInvitation_Expired(t *testing.T) {
-	userID := uuid.New()
-	token := uuid.New()
-	mock := &mockGroupRepo{
-		acceptInvitationFn: func(_ context.Context, _, _ uuid.UUID) error {
-			return repository.ErrInvitationExpired
-		},
-	}
-	h := NewGroupHandler(mock)
-	e := setupGroupRouter(h)
-
-	req := httptest.NewRequest(http.MethodPost, "/api/invitations/"+token.String()+"/accept", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.SetPathValues(echo.PathValues{{Name: "token", Value: token.String()}})
-	middleware.SetAuthInfo(c, &middleware.AuthInfo{UserID: userID})
-	require.NoError(t, h.AcceptInvitation(c))
-
-	assert.Equal(t, http.StatusGone, rec.Code)
+		assert.Equal(t, http.StatusGone, rec.Code)
+	})
 }

--- a/backend/handler/image_search_test.go
+++ b/backend/handler/image_search_test.go
@@ -30,85 +30,6 @@ func setupImageSearchRouter(h *ImageSearchHandler) *echo.Echo {
 	return e
 }
 
-func TestImageSearch_Success(t *testing.T) {
-	h := NewImageSearchHandler(&stubImageClient{
-		results: []imagesearch.Result{
-			{ImageURL: "https://x/a.jpg", ThumbnailURL: "https://x/a-t.jpg", Title: "A"},
-		},
-	})
-	e := setupImageSearchRouter(h)
-
-	req := httptest.NewRequest(http.MethodGet, "/api/image-search?q=apple", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	require.Equal(t, http.StatusOK, rec.Code)
-	var body ImageSearchResponse
-	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
-	require.Len(t, body.Items, 1)
-	assert.Equal(t, "https://x/a.jpg", body.Items[0].ImageURL)
-}
-
-func TestImageSearch_MissingQuery(t *testing.T) {
-	h := NewImageSearchHandler(&stubImageClient{})
-	e := setupImageSearchRouter(h)
-
-	req := httptest.NewRequest(http.MethodGet, "/api/image-search", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-}
-
-func TestImageSearch_QuotaExceeded(t *testing.T) {
-	h := NewImageSearchHandler(&stubImageClient{err: imagesearch.ErrQuotaExceeded})
-	e := setupImageSearchRouter(h)
-
-	req := httptest.NewRequest(http.MethodGet, "/api/image-search?q=x", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusTooManyRequests, rec.Code)
-}
-
-func TestImageSearch_UpstreamFailure(t *testing.T) {
-	h := NewImageSearchHandler(&stubImageClient{err: errors.New("boom")})
-	e := setupImageSearchRouter(h)
-
-	req := httptest.NewRequest(http.MethodGet, "/api/image-search?q=x", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusBadGateway, rec.Code)
-}
-
-func TestImageSearch_NilClient_ReturnsServiceUnavailable(t *testing.T) {
-	h := NewImageSearchHandler(nil)
-	e := setupImageSearchRouter(h)
-
-	req := httptest.NewRequest(http.MethodGet, "/api/image-search?q=x", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
-	assert.True(t, strings.Contains(rec.Body.String(), "not configured"))
-}
-
-func TestImageSearch_NumParamRespected(t *testing.T) {
-	called := false
-	stub := &stubNumCapture{}
-	h := NewImageSearchHandler(stub)
-	e := setupImageSearchRouter(h)
-
-	req := httptest.NewRequest(http.MethodGet, "/api/image-search?q=x&num=3", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	called = stub.calledWithNum != 0
-	assert.True(t, called)
-	assert.Equal(t, 3, stub.calledWithNum)
-}
-
 type stubNumCapture struct {
 	calledWithNum int
 }
@@ -116,4 +37,85 @@ type stubNumCapture struct {
 func (s *stubNumCapture) Search(_ context.Context, _ string, num int) ([]imagesearch.Result, error) {
 	s.calledWithNum = num
 	return []imagesearch.Result{}, nil
+}
+
+func TestImageSearch(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		h := NewImageSearchHandler(&stubImageClient{
+			results: []imagesearch.Result{
+				{ImageURL: "https://x/a.jpg", ThumbnailURL: "https://x/a-t.jpg", Title: "A"},
+			},
+		})
+		e := setupImageSearchRouter(h)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/image-search?q=apple", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		var body ImageSearchResponse
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+		require.Len(t, body.Items, 1)
+		assert.Equal(t, "https://x/a.jpg", body.Items[0].ImageURL)
+	})
+
+	t.Run("missing_query", func(t *testing.T) {
+		h := NewImageSearchHandler(&stubImageClient{})
+		e := setupImageSearchRouter(h)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/image-search", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("quota_exceeded", func(t *testing.T) {
+		h := NewImageSearchHandler(&stubImageClient{err: imagesearch.ErrQuotaExceeded})
+		e := setupImageSearchRouter(h)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/image-search?q=x", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+	})
+
+	t.Run("upstream_failure", func(t *testing.T) {
+		h := NewImageSearchHandler(&stubImageClient{err: errors.New("boom")})
+		e := setupImageSearchRouter(h)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/image-search?q=x", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadGateway, rec.Code)
+	})
+
+	t.Run("nil_client_returns_service_unavailable", func(t *testing.T) {
+		h := NewImageSearchHandler(nil)
+		e := setupImageSearchRouter(h)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/image-search?q=x", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		assert.True(t, strings.Contains(rec.Body.String(), "not configured"))
+	})
+
+	t.Run("num_param_respected", func(t *testing.T) {
+		called := false
+		stub := &stubNumCapture{}
+		h := NewImageSearchHandler(stub)
+		e := setupImageSearchRouter(h)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/image-search?q=x&num=3", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		called = stub.calledWithNum != 0
+		assert.True(t, called)
+		assert.Equal(t, 3, stub.calledWithNum)
+	})
 }

--- a/backend/handler/stock_item_test.go
+++ b/backend/handler/stock_item_test.go
@@ -62,486 +62,494 @@ func setupRouterWithAuth(h *StockItemHandler, authInfo *middleware.AuthInfo) *ec
 	return e
 }
 
-func TestList_Success(t *testing.T) {
-	now := time.Now()
-	testGroupID := uuid.New()
-	items := []repository.StockItem{
-		{ID: uuid.New(), Name: "醤油", Category: "調味料", WantToBuy: false, GroupID: testGroupID, CreatedAt: now, UpdatedAt: now},
-		{ID: uuid.New(), Name: "味噌", Category: "調味料", WantToBuy: true, GroupID: testGroupID, CreatedAt: now, UpdatedAt: now},
-	}
-	mock := &mockStockItemRepo{
-		listFn: func(_ context.Context, groupID uuid.UUID) ([]repository.StockItem, error) {
-			assert.Equal(t, testGroupID, groupID)
-			return items, nil
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+func TestList(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		now := time.Now()
+		testGroupID := uuid.New()
+		items := []repository.StockItem{
+			{ID: uuid.New(), Name: "醤油", Category: "調味料", WantToBuy: false, GroupID: testGroupID, CreatedAt: now, UpdatedAt: now},
+			{ID: uuid.New(), Name: "味噌", Category: "調味料", WantToBuy: true, GroupID: testGroupID, CreatedAt: now, UpdatedAt: now},
+		}
+		mock := &mockStockItemRepo{
+			listFn: func(_ context.Context, groupID uuid.UUID) ([]repository.StockItem, error) {
+				assert.Equal(t, testGroupID, groupID)
+				return items, nil
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/stock-items", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
+		req := httptest.NewRequest(http.MethodGet, "/api/stock-items", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
 
-	assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, http.StatusOK, rec.Code)
 
-	var body []repository.StockItem
-	err := json.NewDecoder(rec.Body).Decode(&body)
-	require.NoError(t, err)
-	assert.Len(t, body, 2)
-	assert.Equal(t, "醤油", body[0].Name)
+		var body []repository.StockItem
+		err := json.NewDecoder(rec.Body).Decode(&body)
+		require.NoError(t, err)
+		assert.Len(t, body, 2)
+		assert.Equal(t, "醤油", body[0].Name)
+	})
+
+	t.Run("empty_list", func(t *testing.T) {
+		testGroupID := uuid.New()
+		mock := &mockStockItemRepo{
+			listFn: func(_ context.Context, _ uuid.UUID) ([]repository.StockItem, error) {
+				return []repository.StockItem{}, nil
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+
+		req := httptest.NewRequest(http.MethodGet, "/api/stock-items", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var body []repository.StockItem
+		err := json.NewDecoder(rec.Body).Decode(&body)
+		require.NoError(t, err)
+		assert.Len(t, body, 0)
+	})
+
+	t.Run("repo_error", func(t *testing.T) {
+		testGroupID := uuid.New()
+		mock := &mockStockItemRepo{
+			listFn: func(_ context.Context, _ uuid.UUID) ([]repository.StockItem, error) {
+				return nil, errors.New("repository error")
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+
+		req := httptest.NewRequest(http.MethodGet, "/api/stock-items", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	})
 }
 
-func TestList_Success_Empty(t *testing.T) {
-	testGroupID := uuid.New()
-	mock := &mockStockItemRepo{
-		listFn: func(_ context.Context, _ uuid.UUID) ([]repository.StockItem, error) {
-			return []repository.StockItem{}, nil
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+func TestCreate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		now := time.Now()
+		testGroupID := uuid.New()
+		expected := &repository.StockItem{
+			ID:        uuid.New(),
+			Name:      "醤油",
+			Category:  "調味料",
+			WantToBuy: false,
+			GroupID:   testGroupID,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		mock := &mockStockItemRepo{
+			createFn: func(_ context.Context, groupID uuid.UUID, name, category string, _ *bool, _ *string) (*repository.StockItem, error) {
+				assert.Equal(t, testGroupID, groupID)
+				assert.Equal(t, "醤油", name)
+				assert.Equal(t, "調味料", category)
+				return expected, nil
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/stock-items", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
+		reqBody := strings.NewReader(`{"name": "醤油", "category": "調味料"}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/stock-items", reqBody)
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
 
-	assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, http.StatusCreated, rec.Code)
 
-	var body []repository.StockItem
-	err := json.NewDecoder(rec.Body).Decode(&body)
-	require.NoError(t, err)
-	assert.Len(t, body, 0)
+		var body repository.StockItem
+		err := json.NewDecoder(rec.Body).Decode(&body)
+		require.NoError(t, err)
+		assert.Equal(t, expected.ID, body.ID)
+		assert.Equal(t, expected.Name, body.Name)
+		assert.Equal(t, expected.Category, body.Category)
+		assert.Equal(t, expected.WantToBuy, body.WantToBuy)
+	})
+
+	t.Run("with_want_to_buy_true", func(t *testing.T) {
+		now := time.Now()
+		testGroupID := uuid.New()
+		expected := &repository.StockItem{
+			ID:        uuid.New(),
+			Name:      "醤油",
+			Category:  "調味料",
+			WantToBuy: true,
+			GroupID:   testGroupID,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		mock := &mockStockItemRepo{
+			createFn: func(_ context.Context, _ uuid.UUID, _, _ string, wantToBuy *bool, _ *string) (*repository.StockItem, error) {
+				require.NotNil(t, wantToBuy)
+				assert.True(t, *wantToBuy)
+				return expected, nil
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+
+		reqBody := strings.NewReader(`{"name": "醤油", "category": "調味料", "wantToBuy": true}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/stock-items", reqBody)
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusCreated, rec.Code)
+
+		var body repository.StockItem
+		err := json.NewDecoder(rec.Body).Decode(&body)
+		require.NoError(t, err)
+		assert.True(t, body.WantToBuy)
+	})
+
+	t.Run("empty_name", func(t *testing.T) {
+		testGroupID := uuid.New()
+		mock := &mockStockItemRepo{
+			createFn: func(_ context.Context, _ uuid.UUID, _, _ string, _ *bool, _ *string) (*repository.StockItem, error) {
+				return nil, nil
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+
+		reqBody := strings.NewReader(`{"name": "", "category": "調味料"}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/stock-items", reqBody)
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("empty_category", func(t *testing.T) {
+		testGroupID := uuid.New()
+		mock := &mockStockItemRepo{
+			createFn: func(_ context.Context, _ uuid.UUID, _, _ string, _ *bool, _ *string) (*repository.StockItem, error) {
+				return nil, nil
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+
+		reqBody := strings.NewReader(`{"name": "醤油", "category": ""}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/stock-items", reqBody)
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("duplicate_name", func(t *testing.T) {
+		testGroupID := uuid.New()
+		mock := &mockStockItemRepo{
+			createFn: func(_ context.Context, _ uuid.UUID, _, _ string, _ *bool, _ *string) (*repository.StockItem, error) {
+				return nil, &pgconn.PgError{Code: "23505"}
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+
+		reqBody := strings.NewReader(`{"name": "醤油", "category": "調味料"}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/stock-items", reqBody)
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusConflict, rec.Code)
+	})
 }
 
-func TestList_RepoError(t *testing.T) {
-	testGroupID := uuid.New()
-	mock := &mockStockItemRepo{
-		listFn: func(_ context.Context, _ uuid.UUID) ([]repository.StockItem, error) {
-			return nil, errors.New("repository error")
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+func TestUpdate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		now := time.Now()
+		testGroupID := uuid.New()
+		expected := &repository.StockItem{
+			ID:        uuid.New(),
+			Name:      "こいくち醤油",
+			Category:  "飲み物",
+			WantToBuy: true,
+			GroupID:   testGroupID,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		mock := &mockStockItemRepo{
+			updateFn: func(_ context.Context, id uuid.UUID, groupID uuid.UUID, params repository.UpdateParams) (*repository.StockItem, error) {
+				assert.Equal(t, expected.ID, id)
+				assert.Equal(t, testGroupID, groupID)
+				assert.Equal(t, "こいくち醤油", *params.Name)
+				assert.Equal(t, "飲み物", *params.Category)
+				assert.Equal(t, true, *params.WantToBuy)
+				return expected, nil
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/stock-items", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
+		reqBody := strings.NewReader(`{"name": "こいくち醤油", "category": "飲み物", "wantToBuy": true}`)
+		req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/"+expected.ID.String(), reqBody)
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
 
-	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var body repository.StockItem
+		err := json.NewDecoder(rec.Body).Decode(&body)
+		require.NoError(t, err)
+		assert.Equal(t, expected.ID, body.ID)
+		assert.Equal(t, expected.Name, body.Name)
+		assert.Equal(t, expected.Category, body.Category)
+		assert.Equal(t, expected.WantToBuy, body.WantToBuy)
+	})
+
+	t.Run("image_url_set_value", func(t *testing.T) {
+		now := time.Now()
+		id := uuid.New()
+		testGroupID := uuid.New()
+		var captured repository.UpdateParams
+		mock := &mockStockItemRepo{
+			updateFn: func(_ context.Context, gotID uuid.UUID, _ uuid.UUID, params repository.UpdateParams) (*repository.StockItem, error) {
+				captured = params
+				url := "https://example.com/a.jpg"
+				return &repository.StockItem{ID: gotID, Name: "醤油", Category: "調味料", GroupID: testGroupID, ImageURL: &url, CreatedAt: now, UpdatedAt: now}, nil
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+
+		reqBody := strings.NewReader(`{"imageUrl": "https://example.com/a.jpg"}`)
+		req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/"+id.String(), reqBody)
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NotNil(t, captured.ImageURL)
+		require.NotNil(t, captured.ImageURL.Value)
+		assert.Equal(t, "https://example.com/a.jpg", *captured.ImageURL.Value)
+	})
+
+	t.Run("image_url_explicit_null", func(t *testing.T) {
+		now := time.Now()
+		id := uuid.New()
+		testGroupID := uuid.New()
+		var captured repository.UpdateParams
+		mock := &mockStockItemRepo{
+			updateFn: func(_ context.Context, gotID uuid.UUID, _ uuid.UUID, params repository.UpdateParams) (*repository.StockItem, error) {
+				captured = params
+				return &repository.StockItem{ID: gotID, Name: "醤油", Category: "調味料", GroupID: testGroupID, ImageURL: nil, CreatedAt: now, UpdatedAt: now}, nil
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+
+		reqBody := strings.NewReader(`{"imageUrl": null}`)
+		req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/"+id.String(), reqBody)
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NotNil(t, captured.ImageURL, "ImageURL patch wrapper should be non-nil when null is explicit")
+		assert.Nil(t, captured.ImageURL.Value, "Value should be nil to indicate NULL")
+	})
+
+	t.Run("image_url_unspecified", func(t *testing.T) {
+		now := time.Now()
+		id := uuid.New()
+		testGroupID := uuid.New()
+		var captured repository.UpdateParams
+		mock := &mockStockItemRepo{
+			updateFn: func(_ context.Context, gotID uuid.UUID, _ uuid.UUID, params repository.UpdateParams) (*repository.StockItem, error) {
+				captured = params
+				return &repository.StockItem{ID: gotID, Name: "x", Category: "★", GroupID: testGroupID, CreatedAt: now, UpdatedAt: now}, nil
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+
+		reqBody := strings.NewReader(`{"name": "x"}`)
+		req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/"+id.String(), reqBody)
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Nil(t, captured.ImageURL, "ImageURL patch wrapper should be nil when field is absent")
+	})
+
+	t.Run("image_url_invalid_type", func(t *testing.T) {
+		testGroupID := uuid.New()
+		mock := &mockStockItemRepo{
+			updateFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ repository.UpdateParams) (*repository.StockItem, error) {
+				t.Fatal("repo.Update should not be called on invalid imageUrl")
+				return nil, nil
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+
+		reqBody := strings.NewReader(`{"imageUrl": 123}`)
+		req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/"+uuid.New().String(), reqBody)
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("invalid_id", func(t *testing.T) {
+		testGroupID := uuid.New()
+		mock := &mockStockItemRepo{
+			updateFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ repository.UpdateParams) (*repository.StockItem, error) {
+				return nil, nil
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+
+		reqBody := strings.NewReader(`{"name": "こいくち醤油", "category": "飲み物", "wantToBuy": true}`)
+		req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/invalid-uuid", reqBody)
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("not_found", func(t *testing.T) {
+		testGroupID := uuid.New()
+		mock := &mockStockItemRepo{
+			updateFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ repository.UpdateParams) (*repository.StockItem, error) {
+				return nil, pgx.ErrNoRows
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+
+		reqBody := strings.NewReader(`{"name": "こいくち醤油", "category": "飲み物", "wantToBuy": true}`)
+		req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/"+uuid.New().String(), reqBody)
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("duplicate_name", func(t *testing.T) {
+		testGroupID := uuid.New()
+		mock := &mockStockItemRepo{
+			updateFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ repository.UpdateParams) (*repository.StockItem, error) {
+				return nil, &pgconn.PgError{Code: "23505"}
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+
+		reqBody := strings.NewReader(`{"name": "こいくち醤油", "category": "飲み物", "wantToBuy": true}`)
+		req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/"+uuid.New().String(), reqBody)
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusConflict, rec.Code)
+	})
 }
 
-func TestCreate_Success(t *testing.T) {
-	now := time.Now()
-	testGroupID := uuid.New()
-	expected := &repository.StockItem{
-		ID:        uuid.New(),
-		Name:      "醤油",
-		Category:  "調味料",
-		WantToBuy: false,
-		GroupID:   testGroupID,
-		CreatedAt: now,
-		UpdatedAt: now,
-	}
-	mock := &mockStockItemRepo{
-		createFn: func(_ context.Context, groupID uuid.UUID, name, category string, _ *bool, _ *string) (*repository.StockItem, error) {
-			assert.Equal(t, testGroupID, groupID)
-			assert.Equal(t, "醤油", name)
-			assert.Equal(t, "調味料", category)
-			return expected, nil
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+func TestDelete(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		testGroupID := uuid.New()
+		mock := &mockStockItemRepo{
+			getFn: func(_ context.Context, id uuid.UUID, groupID uuid.UUID) (*repository.StockItem, error) {
+				assert.Equal(t, testGroupID, groupID)
+				return &repository.StockItem{
+					ID:        id,
+					Name:      "醤油",
+					Category:  "調味料",
+					WantToBuy: false,
+					GroupID:   testGroupID,
+				}, nil
+			},
+			deleteFn: func(_ context.Context, _ uuid.UUID, groupID uuid.UUID) error {
+				assert.Equal(t, testGroupID, groupID)
+				return nil
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
 
-	reqBody := strings.NewReader(`{"name": "醤油", "category": "調味料"}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/stock-items", reqBody)
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
+		id := uuid.New()
+		req := httptest.NewRequest(http.MethodDelete, "/api/stock-items/"+id.String(), nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
 
-	assert.Equal(t, http.StatusCreated, rec.Code)
+		assert.Equal(t, http.StatusNoContent, rec.Code)
+	})
 
-	var body repository.StockItem
-	err := json.NewDecoder(rec.Body).Decode(&body)
-	require.NoError(t, err)
-	assert.Equal(t, expected.ID, body.ID)
-	assert.Equal(t, expected.Name, body.Name)
-	assert.Equal(t, expected.Category, body.Category)
-	assert.Equal(t, expected.WantToBuy, body.WantToBuy)
-}
+	t.Run("invalid_id", func(t *testing.T) {
+		testGroupID := uuid.New()
+		mock := &mockStockItemRepo{
+			deleteFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
+				return nil
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
 
-func TestCreate_WithWantToBuyTrue(t *testing.T) {
-	now := time.Now()
-	testGroupID := uuid.New()
-	expected := &repository.StockItem{
-		ID:        uuid.New(),
-		Name:      "醤油",
-		Category:  "調味料",
-		WantToBuy: true,
-		GroupID:   testGroupID,
-		CreatedAt: now,
-		UpdatedAt: now,
-	}
-	mock := &mockStockItemRepo{
-		createFn: func(_ context.Context, _ uuid.UUID, _, _ string, wantToBuy *bool, _ *string) (*repository.StockItem, error) {
-			require.NotNil(t, wantToBuy)
-			assert.True(t, *wantToBuy)
-			return expected, nil
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+		req := httptest.NewRequest(http.MethodDelete, "/api/stock-items/invalid-uuid", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
 
-	reqBody := strings.NewReader(`{"name": "醤油", "category": "調味料", "wantToBuy": true}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/stock-items", reqBody)
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
 
-	assert.Equal(t, http.StatusCreated, rec.Code)
+	t.Run("not_found", func(t *testing.T) {
+		testGroupID := uuid.New()
+		mock := &mockStockItemRepo{
+			getFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID) (*repository.StockItem, error) {
+				return nil, pgx.ErrNoRows
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
 
-	var body repository.StockItem
-	err := json.NewDecoder(rec.Body).Decode(&body)
-	require.NoError(t, err)
-	assert.True(t, body.WantToBuy)
-}
+		id := uuid.New()
+		req := httptest.NewRequest(http.MethodDelete, "/api/stock-items/"+id.String(), nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
 
-func TestCreate_EmptyName(t *testing.T) {
-	testGroupID := uuid.New()
-	mock := &mockStockItemRepo{
-		createFn: func(_ context.Context, _ uuid.UUID, _, _ string, _ *bool, _ *string) (*repository.StockItem, error) {
-			return nil, nil
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
 
-	reqBody := strings.NewReader(`{"name": "", "category": "調味料"}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/stock-items", reqBody)
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
+	t.Run("want_to_buy_true", func(t *testing.T) {
+		testGroupID := uuid.New()
+		mock := &mockStockItemRepo{
+			getFn: func(_ context.Context, id uuid.UUID, _ uuid.UUID) (*repository.StockItem, error) {
+				return &repository.StockItem{
+					ID:        id,
+					Name:      "醤油",
+					Category:  "調味料",
+					WantToBuy: true,
+					GroupID:   testGroupID,
+				}, nil
+			},
+		}
+		h := NewStockItemHandler(mock)
+		e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
 
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-}
+		id := uuid.New()
+		req := httptest.NewRequest(http.MethodDelete, "/api/stock-items/"+id.String(), nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
 
-func TestCreate_EmptyCategory(t *testing.T) {
-	testGroupID := uuid.New()
-	mock := &mockStockItemRepo{
-		createFn: func(_ context.Context, _ uuid.UUID, _, _ string, _ *bool, _ *string) (*repository.StockItem, error) {
-			return nil, nil
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
-
-	reqBody := strings.NewReader(`{"name": "醤油", "category": ""}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/stock-items", reqBody)
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-}
-
-func TestCreate_DuplicateName(t *testing.T) {
-	testGroupID := uuid.New()
-	mock := &mockStockItemRepo{
-		createFn: func(_ context.Context, _ uuid.UUID, _, _ string, _ *bool, _ *string) (*repository.StockItem, error) {
-			return nil, &pgconn.PgError{Code: "23505"}
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
-
-	reqBody := strings.NewReader(`{"name": "醤油", "category": "調味料"}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/stock-items", reqBody)
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusConflict, rec.Code)
-}
-
-func TestUpdate_Success(t *testing.T) {
-	now := time.Now()
-	testGroupID := uuid.New()
-	expected := &repository.StockItem{
-		ID:        uuid.New(),
-		Name:      "こいくち醤油",
-		Category:  "飲み物",
-		WantToBuy: true,
-		GroupID:   testGroupID,
-		CreatedAt: now,
-		UpdatedAt: now,
-	}
-	mock := &mockStockItemRepo{
-		updateFn: func(_ context.Context, id uuid.UUID, groupID uuid.UUID, params repository.UpdateParams) (*repository.StockItem, error) {
-			assert.Equal(t, expected.ID, id)
-			assert.Equal(t, testGroupID, groupID)
-			assert.Equal(t, "こいくち醤油", *params.Name)
-			assert.Equal(t, "飲み物", *params.Category)
-			assert.Equal(t, true, *params.WantToBuy)
-			return expected, nil
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
-
-	reqBody := strings.NewReader(`{"name": "こいくち醤油", "category": "飲み物", "wantToBuy": true}`)
-	req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/"+expected.ID.String(), reqBody)
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusOK, rec.Code)
-
-	var body repository.StockItem
-	err := json.NewDecoder(rec.Body).Decode(&body)
-	require.NoError(t, err)
-	assert.Equal(t, expected.ID, body.ID)
-	assert.Equal(t, expected.Name, body.Name)
-	assert.Equal(t, expected.Category, body.Category)
-	assert.Equal(t, expected.WantToBuy, body.WantToBuy)
-}
-
-func TestUpdate_ImageURL_SetValue(t *testing.T) {
-	now := time.Now()
-	id := uuid.New()
-	testGroupID := uuid.New()
-	var captured repository.UpdateParams
-	mock := &mockStockItemRepo{
-		updateFn: func(_ context.Context, gotID uuid.UUID, _ uuid.UUID, params repository.UpdateParams) (*repository.StockItem, error) {
-			captured = params
-			url := "https://example.com/a.jpg"
-			return &repository.StockItem{ID: gotID, Name: "醤油", Category: "調味料", GroupID: testGroupID, ImageURL: &url, CreatedAt: now, UpdatedAt: now}, nil
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
-
-	reqBody := strings.NewReader(`{"imageUrl": "https://example.com/a.jpg"}`)
-	req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/"+id.String(), reqBody)
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusOK, rec.Code)
-	require.NotNil(t, captured.ImageURL)
-	require.NotNil(t, captured.ImageURL.Value)
-	assert.Equal(t, "https://example.com/a.jpg", *captured.ImageURL.Value)
-}
-
-func TestUpdate_ImageURL_ExplicitNull(t *testing.T) {
-	now := time.Now()
-	id := uuid.New()
-	testGroupID := uuid.New()
-	var captured repository.UpdateParams
-	mock := &mockStockItemRepo{
-		updateFn: func(_ context.Context, gotID uuid.UUID, _ uuid.UUID, params repository.UpdateParams) (*repository.StockItem, error) {
-			captured = params
-			return &repository.StockItem{ID: gotID, Name: "醤油", Category: "調味料", GroupID: testGroupID, ImageURL: nil, CreatedAt: now, UpdatedAt: now}, nil
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
-
-	reqBody := strings.NewReader(`{"imageUrl": null}`)
-	req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/"+id.String(), reqBody)
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusOK, rec.Code)
-	require.NotNil(t, captured.ImageURL, "ImageURL patch wrapper should be non-nil when null is explicit")
-	assert.Nil(t, captured.ImageURL.Value, "Value should be nil to indicate NULL")
-}
-
-func TestUpdate_ImageURL_Unspecified(t *testing.T) {
-	now := time.Now()
-	id := uuid.New()
-	testGroupID := uuid.New()
-	var captured repository.UpdateParams
-	mock := &mockStockItemRepo{
-		updateFn: func(_ context.Context, gotID uuid.UUID, _ uuid.UUID, params repository.UpdateParams) (*repository.StockItem, error) {
-			captured = params
-			return &repository.StockItem{ID: gotID, Name: "x", Category: "★", GroupID: testGroupID, CreatedAt: now, UpdatedAt: now}, nil
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
-
-	reqBody := strings.NewReader(`{"name": "x"}`)
-	req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/"+id.String(), reqBody)
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Nil(t, captured.ImageURL, "ImageURL patch wrapper should be nil when field is absent")
-}
-
-func TestUpdate_ImageURL_InvalidType(t *testing.T) {
-	testGroupID := uuid.New()
-	mock := &mockStockItemRepo{
-		updateFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ repository.UpdateParams) (*repository.StockItem, error) {
-			t.Fatal("repo.Update should not be called on invalid imageUrl")
-			return nil, nil
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
-
-	reqBody := strings.NewReader(`{"imageUrl": 123}`)
-	req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/"+uuid.New().String(), reqBody)
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-}
-
-func TestUpdate_InvalidID(t *testing.T) {
-	testGroupID := uuid.New()
-	mock := &mockStockItemRepo{
-		updateFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ repository.UpdateParams) (*repository.StockItem, error) {
-			return nil, nil
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
-
-	reqBody := strings.NewReader(`{"name": "こいくち醤油", "category": "飲み物", "wantToBuy": true}`)
-	req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/invalid-uuid", reqBody)
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-}
-
-func TestUpdate_NotFound(t *testing.T) {
-	testGroupID := uuid.New()
-	mock := &mockStockItemRepo{
-		updateFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ repository.UpdateParams) (*repository.StockItem, error) {
-			return nil, pgx.ErrNoRows
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
-
-	reqBody := strings.NewReader(`{"name": "こいくち醤油", "category": "飲み物", "wantToBuy": true}`)
-	req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/"+uuid.New().String(), reqBody)
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusNotFound, rec.Code)
-}
-
-func TestUpdate_DuplicateName(t *testing.T) {
-	testGroupID := uuid.New()
-	mock := &mockStockItemRepo{
-		updateFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ repository.UpdateParams) (*repository.StockItem, error) {
-			return nil, &pgconn.PgError{Code: "23505"}
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
-
-	reqBody := strings.NewReader(`{"name": "こいくち醤油", "category": "飲み物", "wantToBuy": true}`)
-	req := httptest.NewRequest(http.MethodPatch, "/api/stock-items/"+uuid.New().String(), reqBody)
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusConflict, rec.Code)
-}
-
-func TestDelete_Success(t *testing.T) {
-	testGroupID := uuid.New()
-	mock := &mockStockItemRepo{
-		getFn: func(_ context.Context, id uuid.UUID, groupID uuid.UUID) (*repository.StockItem, error) {
-			assert.Equal(t, testGroupID, groupID)
-			return &repository.StockItem{
-				ID:        id,
-				Name:      "醤油",
-				Category:  "調味料",
-				WantToBuy: false,
-				GroupID:   testGroupID,
-			}, nil
-		},
-		deleteFn: func(_ context.Context, _ uuid.UUID, groupID uuid.UUID) error {
-			assert.Equal(t, testGroupID, groupID)
-			return nil
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
-
-	id := uuid.New()
-	req := httptest.NewRequest(http.MethodDelete, "/api/stock-items/"+id.String(), nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusNoContent, rec.Code)
-}
-
-func TestDelete_InvalidID(t *testing.T) {
-	testGroupID := uuid.New()
-	mock := &mockStockItemRepo{
-		deleteFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
-			return nil
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
-
-	req := httptest.NewRequest(http.MethodDelete, "/api/stock-items/invalid-uuid", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-}
-
-func TestDelete_NotFound(t *testing.T) {
-	testGroupID := uuid.New()
-	mock := &mockStockItemRepo{
-		getFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID) (*repository.StockItem, error) {
-			return nil, pgx.ErrNoRows
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
-
-	id := uuid.New()
-	req := httptest.NewRequest(http.MethodDelete, "/api/stock-items/"+id.String(), nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusNotFound, rec.Code)
-}
-
-func TestDelete_WantToBuyTrue(t *testing.T) {
-	testGroupID := uuid.New()
-	mock := &mockStockItemRepo{
-		getFn: func(_ context.Context, id uuid.UUID, _ uuid.UUID) (*repository.StockItem, error) {
-			return &repository.StockItem{
-				ID:        id,
-				Name:      "醤油",
-				Category:  "調味料",
-				WantToBuy: true,
-				GroupID:   testGroupID,
-			}, nil
-		},
-	}
-	h := NewStockItemHandler(mock)
-	e := setupRouterWithAuth(h, &middleware.AuthInfo{UserID: uuid.New(), GroupID: testGroupID, Role: "owner"})
-
-	id := uuid.New()
-	req := httptest.NewRequest(http.MethodDelete, "/api/stock-items/"+id.String(), nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusConflict, rec.Code)
+		assert.Equal(t, http.StatusConflict, rec.Code)
+	})
 }

--- a/backend/handler/url_extract_stream_test.go
+++ b/backend/handler/url_extract_stream_test.go
@@ -66,126 +66,128 @@ func parseSSEEvents(body string) []map[string]string {
 	return events
 }
 
-func TestExtractStream_NormalPath_ProgressThenDone(t *testing.T) {
-	mock := &mockProgressExtractor{
-		steps: []struct{ step, message string }{
-			{"fetching", "ページを取得中..."},
-			{"extracting", "商品情報を解析中..."},
-		},
-		result: urlextract.Result{Name: "テスト商品", ImageURL: "https://example.com/img.jpg"},
-	}
-	h := &URLExtractStreamHandler{extractor: mock}
-	e := setupStreamRouter(h)
-
-	rec := postExtractStream(e, `{"url":"https://example.com/product"}`)
-
-	require.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
-
-	events := parseSSEEvents(rec.Body.String())
-	require.GreaterOrEqual(t, len(events), 3, "expect at least 2 progress + 1 done")
-
-	assert.Equal(t, "progress", events[0]["event"])
-	assert.Contains(t, events[0]["data"], `"step":"fetching"`)
-
-	assert.Equal(t, "progress", events[1]["event"])
-	assert.Contains(t, events[1]["data"], `"step":"extracting"`)
-
-	last := events[len(events)-1]
-	assert.Equal(t, "done", last["event"])
-	assert.Contains(t, last["data"], `"name":"テスト商品"`)
-	assert.Contains(t, last["data"], `"imageUrl":"https://example.com/img.jpg"`)
-}
-
-func TestExtractStream_ErrorPath_ErrorEventNoDone(t *testing.T) {
-	mock := &mockProgressExtractor{
-		steps: []struct{ step, message string }{
-			{"fetching", "ページを取得中..."},
-		},
-		err: fmt.Errorf("connection refused: %w", urlextract.ErrFetchFailed),
-	}
-	h := &URLExtractStreamHandler{extractor: mock}
-	e := setupStreamRouter(h)
-
-	rec := postExtractStream(e, `{"url":"https://example.com/product"}`)
-
-	require.Equal(t, http.StatusOK, rec.Code)
-	events := parseSSEEvents(rec.Body.String())
-
-	eventNames := make([]string, len(events))
-	for i, ev := range events {
-		eventNames[i] = ev["event"]
-	}
-	assert.Contains(t, eventNames, "error")
-	assert.NotContains(t, eventNames, "done")
-
-	var errEvent map[string]string
-	for _, ev := range events {
-		if ev["event"] == "error" {
-			errEvent = ev
-			break
+func TestExtractStream(t *testing.T) {
+	t.Run("normal_path_progress_then_done", func(t *testing.T) {
+		mock := &mockProgressExtractor{
+			steps: []struct{ step, message string }{
+				{"fetching", "ページを取得中..."},
+				{"extracting", "商品情報を解析中..."},
+			},
+			result: urlextract.Result{Name: "テスト商品", ImageURL: "https://example.com/img.jpg"},
 		}
-	}
-	require.NotNil(t, errEvent)
-	assert.Contains(t, errEvent["data"], `"kind":"fetchFailed"`)
-}
+		h := &URLExtractStreamHandler{extractor: mock}
+		e := setupStreamRouter(h)
 
-func TestExtractStream_WithCandidates_DoneIncludesCandidates(t *testing.T) {
-	mock := &mockProgressExtractor{
-		result: urlextract.Result{
-			Name:           "長い商品名テストサンプル二十五文字以上",
-			ImageURL:       "",
-			NameCandidates: []string{"候補1", "候補2", "候補3"},
-		},
-	}
-	h := &URLExtractStreamHandler{extractor: mock}
-	e := setupStreamRouter(h)
+		rec := postExtractStream(e, `{"url":"https://example.com/product"}`)
 
-	rec := postExtractStream(e, `{"url":"https://example.com/product"}`)
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
 
-	require.Equal(t, http.StatusOK, rec.Code)
-	events := parseSSEEvents(rec.Body.String())
+		events := parseSSEEvents(rec.Body.String())
+		require.GreaterOrEqual(t, len(events), 3, "expect at least 2 progress + 1 done")
 
-	var doneEvent map[string]string
-	for _, ev := range events {
-		if ev["event"] == "done" {
-			doneEvent = ev
-			break
+		assert.Equal(t, "progress", events[0]["event"])
+		assert.Contains(t, events[0]["data"], `"step":"fetching"`)
+
+		assert.Equal(t, "progress", events[1]["event"])
+		assert.Contains(t, events[1]["data"], `"step":"extracting"`)
+
+		last := events[len(events)-1]
+		assert.Equal(t, "done", last["event"])
+		assert.Contains(t, last["data"], `"name":"テスト商品"`)
+		assert.Contains(t, last["data"], `"imageUrl":"https://example.com/img.jpg"`)
+	})
+
+	t.Run("error_path_error_event_no_done", func(t *testing.T) {
+		mock := &mockProgressExtractor{
+			steps: []struct{ step, message string }{
+				{"fetching", "ページを取得中..."},
+			},
+			err: fmt.Errorf("connection refused: %w", urlextract.ErrFetchFailed),
 		}
-	}
-	require.NotNil(t, doneEvent, "done event must be present")
-	assert.Contains(t, doneEvent["data"], `"nameCandidates"`)
-	assert.Contains(t, doneEvent["data"], "候補1")
-}
+		h := &URLExtractStreamHandler{extractor: mock}
+		e := setupStreamRouter(h)
 
-func TestExtractStream_WithoutCandidates_DoneOmitsCandidates(t *testing.T) {
-	mock := &mockProgressExtractor{
-		result: urlextract.Result{Name: "牛乳", ImageURL: ""},
-	}
-	h := &URLExtractStreamHandler{extractor: mock}
-	e := setupStreamRouter(h)
+		rec := postExtractStream(e, `{"url":"https://example.com/product"}`)
 
-	rec := postExtractStream(e, `{"url":"https://example.com/product"}`)
+		require.Equal(t, http.StatusOK, rec.Code)
+		events := parseSSEEvents(rec.Body.String())
 
-	require.Equal(t, http.StatusOK, rec.Code)
-	events := parseSSEEvents(rec.Body.String())
-
-	var doneEvent map[string]string
-	for _, ev := range events {
-		if ev["event"] == "done" {
-			doneEvent = ev
-			break
+		eventNames := make([]string, len(events))
+		for i, ev := range events {
+			eventNames[i] = ev["event"]
 		}
-	}
-	require.NotNil(t, doneEvent, "done event must be present")
-	assert.NotContains(t, doneEvent["data"], `"nameCandidates"`)
-}
+		assert.Contains(t, eventNames, "error")
+		assert.NotContains(t, eventNames, "done")
 
-func TestExtractStream_EmptyURL_Returns400(t *testing.T) {
-	h := &URLExtractStreamHandler{extractor: &mockProgressExtractor{}}
-	e := setupStreamRouter(h)
+		var errEvent map[string]string
+		for _, ev := range events {
+			if ev["event"] == "error" {
+				errEvent = ev
+				break
+			}
+		}
+		require.NotNil(t, errEvent)
+		assert.Contains(t, errEvent["data"], `"kind":"fetchFailed"`)
+	})
 
-	rec := postExtractStream(e, `{"url":""}`)
+	t.Run("with_candidates_done_includes_candidates", func(t *testing.T) {
+		mock := &mockProgressExtractor{
+			result: urlextract.Result{
+				Name:           "長い商品名テストサンプル二十五文字以上",
+				ImageURL:       "",
+				NameCandidates: []string{"候補1", "候補2", "候補3"},
+			},
+		}
+		h := &URLExtractStreamHandler{extractor: mock}
+		e := setupStreamRouter(h)
 
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+		rec := postExtractStream(e, `{"url":"https://example.com/product"}`)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		events := parseSSEEvents(rec.Body.String())
+
+		var doneEvent map[string]string
+		for _, ev := range events {
+			if ev["event"] == "done" {
+				doneEvent = ev
+				break
+			}
+		}
+		require.NotNil(t, doneEvent, "done event must be present")
+		assert.Contains(t, doneEvent["data"], `"nameCandidates"`)
+		assert.Contains(t, doneEvent["data"], "候補1")
+	})
+
+	t.Run("without_candidates_done_omits_candidates", func(t *testing.T) {
+		mock := &mockProgressExtractor{
+			result: urlextract.Result{Name: "牛乳", ImageURL: ""},
+		}
+		h := &URLExtractStreamHandler{extractor: mock}
+		e := setupStreamRouter(h)
+
+		rec := postExtractStream(e, `{"url":"https://example.com/product"}`)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		events := parseSSEEvents(rec.Body.String())
+
+		var doneEvent map[string]string
+		for _, ev := range events {
+			if ev["event"] == "done" {
+				doneEvent = ev
+				break
+			}
+		}
+		require.NotNil(t, doneEvent, "done event must be present")
+		assert.NotContains(t, doneEvent["data"], `"nameCandidates"`)
+	})
+
+	t.Run("empty_url_returns_400", func(t *testing.T) {
+		h := &URLExtractStreamHandler{extractor: &mockProgressExtractor{}}
+		e := setupStreamRouter(h)
+
+		rec := postExtractStream(e, `{"url":""}`)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
 }

--- a/backend/handler/url_extract_test.go
+++ b/backend/handler/url_extract_test.go
@@ -37,103 +37,105 @@ func postExtractFromURL(e *echo.Echo, body string) *httptest.ResponseRecorder {
 	return rec
 }
 
-func TestUrlExtract_200_withImage(t *testing.T) {
-	imageURL := "https://example.com/img.jpg"
-	h := NewURLExtractHandler(&mockExtractor{
-		result: urlextract.Result{Name: "牛乳", ImageURL: imageURL},
+func TestUrlExtract(t *testing.T) {
+	t.Run("200_with_image", func(t *testing.T) {
+		imageURL := "https://example.com/img.jpg"
+		h := NewURLExtractHandler(&mockExtractor{
+			result: urlextract.Result{Name: "牛乳", ImageURL: imageURL},
+		})
+		e := setupURLExtractRouter(h)
+
+		rec := postExtractFromURL(e, `{"url":"https://example.com/product"}`)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		var resp ExtractFromURLResponse
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		assert.Equal(t, "牛乳", resp.Name)
+		require.NotNil(t, resp.ImageURL)
+		assert.Equal(t, imageURL, *resp.ImageURL)
 	})
-	e := setupURLExtractRouter(h)
 
-	rec := postExtractFromURL(e, `{"url":"https://example.com/product"}`)
+	t.Run("200_no_image", func(t *testing.T) {
+		h := NewURLExtractHandler(&mockExtractor{
+			result: urlextract.Result{Name: "牛乳", ImageURL: ""},
+		})
+		e := setupURLExtractRouter(h)
 
-	require.Equal(t, http.StatusOK, rec.Code)
-	var resp ExtractFromURLResponse
-	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
-	assert.Equal(t, "牛乳", resp.Name)
-	require.NotNil(t, resp.ImageURL)
-	assert.Equal(t, imageURL, *resp.ImageURL)
-}
+		rec := postExtractFromURL(e, `{"url":"https://example.com/product"}`)
 
-func TestUrlExtract_200_noImage(t *testing.T) {
-	h := NewURLExtractHandler(&mockExtractor{
-		result: urlextract.Result{Name: "牛乳", ImageURL: ""},
+		require.Equal(t, http.StatusOK, rec.Code)
+		var resp ExtractFromURLResponse
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		assert.Equal(t, "牛乳", resp.Name)
+		assert.Nil(t, resp.ImageURL)
 	})
-	e := setupURLExtractRouter(h)
 
-	rec := postExtractFromURL(e, `{"url":"https://example.com/product"}`)
+	t.Run("200_with_candidates", func(t *testing.T) {
+		h := NewURLExtractHandler(&mockExtractor{
+			result: urlextract.Result{
+				Name:           "長い商品名テストサンプル二十五文字以上",
+				ImageURL:       "https://example.com/img.jpg",
+				NameCandidates: []string{"候補A", "候補B"},
+			},
+		})
+		e := setupURLExtractRouter(h)
 
-	require.Equal(t, http.StatusOK, rec.Code)
-	var resp ExtractFromURLResponse
-	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
-	assert.Equal(t, "牛乳", resp.Name)
-	assert.Nil(t, resp.ImageURL)
-}
+		rec := postExtractFromURL(e, `{"url":"https://example.com/product"}`)
 
-func TestUrlExtract_200_withCandidates(t *testing.T) {
-	h := NewURLExtractHandler(&mockExtractor{
-		result: urlextract.Result{
-			Name:           "長い商品名テストサンプル二十五文字以上",
-			ImageURL:       "https://example.com/img.jpg",
-			NameCandidates: []string{"候補A", "候補B"},
-		},
+		require.Equal(t, http.StatusOK, rec.Code)
+		var resp ExtractFromURLResponse
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		assert.Equal(t, []string{"候補A", "候補B"}, resp.NameCandidates)
 	})
-	e := setupURLExtractRouter(h)
 
-	rec := postExtractFromURL(e, `{"url":"https://example.com/product"}`)
+	t.Run("200_no_candidates", func(t *testing.T) {
+		h := NewURLExtractHandler(&mockExtractor{
+			result: urlextract.Result{Name: "牛乳", ImageURL: ""},
+		})
+		e := setupURLExtractRouter(h)
 
-	require.Equal(t, http.StatusOK, rec.Code)
-	var resp ExtractFromURLResponse
-	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
-	assert.Equal(t, []string{"候補A", "候補B"}, resp.NameCandidates)
-}
+		rec := postExtractFromURL(e, `{"url":"https://example.com/product"}`)
 
-func TestUrlExtract_200_noCandidates(t *testing.T) {
-	h := NewURLExtractHandler(&mockExtractor{
-		result: urlextract.Result{Name: "牛乳", ImageURL: ""},
+		require.Equal(t, http.StatusOK, rec.Code)
+		var raw map[string]any
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&raw))
+		_, present := raw["nameCandidates"]
+		assert.False(t, present, "nameCandidates key must be absent from JSON when there are no candidates")
 	})
-	e := setupURLExtractRouter(h)
 
-	rec := postExtractFromURL(e, `{"url":"https://example.com/product"}`)
+	t.Run("400_empty_body", func(t *testing.T) {
+		h := NewURLExtractHandler(&mockExtractor{})
+		e := setupURLExtractRouter(h)
 
-	require.Equal(t, http.StatusOK, rec.Code)
-	var raw map[string]any
-	require.NoError(t, json.NewDecoder(rec.Body).Decode(&raw))
-	_, present := raw["nameCandidates"]
-	assert.False(t, present, "nameCandidates key must be absent from JSON when there are no candidates")
-}
+		rec := postExtractFromURL(e, ``)
 
-func TestUrlExtract_400_emptyBody(t *testing.T) {
-	h := NewURLExtractHandler(&mockExtractor{})
-	e := setupURLExtractRouter(h)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
 
-	rec := postExtractFromURL(e, ``)
+	t.Run("400_empty_url", func(t *testing.T) {
+		h := NewURLExtractHandler(&mockExtractor{})
+		e := setupURLExtractRouter(h)
 
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-}
+		rec := postExtractFromURL(e, `{"url":""}`)
 
-func TestUrlExtract_400_emptyURL(t *testing.T) {
-	h := NewURLExtractHandler(&mockExtractor{})
-	e := setupURLExtractRouter(h)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
 
-	rec := postExtractFromURL(e, `{"url":""}`)
+	t.Run("422_extraction_failed", func(t *testing.T) {
+		h := NewURLExtractHandler(&mockExtractor{err: urlextract.ErrExtractionFailed})
+		e := setupURLExtractRouter(h)
 
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-}
+		rec := postExtractFromURL(e, `{"url":"https://example.com/product"}`)
 
-func TestUrlExtract_422_extractionFailed(t *testing.T) {
-	h := NewURLExtractHandler(&mockExtractor{err: urlextract.ErrExtractionFailed})
-	e := setupURLExtractRouter(h)
+		assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	})
 
-	rec := postExtractFromURL(e, `{"url":"https://example.com/product"}`)
+	t.Run("502_fetch_failed", func(t *testing.T) {
+		h := NewURLExtractHandler(&mockExtractor{err: urlextract.ErrFetchFailed})
+		e := setupURLExtractRouter(h)
 
-	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
-}
+		rec := postExtractFromURL(e, `{"url":"https://example.com/product"}`)
 
-func TestUrlExtract_502_fetchFailed(t *testing.T) {
-	h := NewURLExtractHandler(&mockExtractor{err: urlextract.ErrFetchFailed})
-	e := setupURLExtractRouter(h)
-
-	rec := postExtractFromURL(e, `{"url":"https://example.com/product"}`)
-
-	assert.Equal(t, http.StatusBadGateway, rec.Code)
+		assert.Equal(t, http.StatusBadGateway, rec.Code)
+	})
 }

--- a/backend/imagesearch/client_test.go
+++ b/backend/imagesearch/client_test.go
@@ -10,108 +10,110 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGoogleClient_Search_Success(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		q := r.URL.Query()
-		assert.Equal(t, "test-query", q.Get("q"))
-		assert.Equal(t, "image", q.Get("searchType"))
-		assert.Equal(t, "k", q.Get("key"))
-		assert.Equal(t, "id", q.Get("cx"))
-		assert.Equal(t, "5", q.Get("num"))
+func TestGoogleClient_Search(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			q := r.URL.Query()
+			assert.Equal(t, "test-query", q.Get("q"))
+			assert.Equal(t, "image", q.Get("searchType"))
+			assert.Equal(t, "k", q.Get("key"))
+			assert.Equal(t, "id", q.Get("cx"))
+			assert.Equal(t, "5", q.Get("num"))
 
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{
-			"items": [
-				{"link": "https://x.com/a.jpg", "title": "Apple", "image": {"thumbnailLink": "https://x.com/a-thumb.jpg"}},
-				{"link": "https://x.com/b.jpg", "title": "Banana", "image": {"thumbnailLink": "https://x.com/b-thumb.jpg"}}
-			]
-		}`))
-	}))
-	defer server.Close()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"items": [
+					{"link": "https://x.com/a.jpg", "title": "Apple", "image": {"thumbnailLink": "https://x.com/a-thumb.jpg"}},
+					{"link": "https://x.com/b.jpg", "title": "Banana", "image": {"thumbnailLink": "https://x.com/b-thumb.jpg"}}
+				]
+			}`))
+		}))
+		defer server.Close()
 
-	c := &GoogleClient{HTTPClient: server.Client(), APIKey: "k", CSEID: "id", BaseURL: server.URL}
-	results, err := c.Search(context.Background(), "test-query", 5)
-	require.NoError(t, err)
-	require.Len(t, results, 2)
-	assert.Equal(t, "https://x.com/a.jpg", results[0].ImageURL)
-	assert.Equal(t, "https://x.com/a-thumb.jpg", results[0].ThumbnailURL)
-	assert.Equal(t, "Apple", results[0].Title)
-}
+		c := &GoogleClient{HTTPClient: server.Client(), APIKey: "k", CSEID: "id", BaseURL: server.URL}
+		results, err := c.Search(context.Background(), "test-query", 5)
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+		assert.Equal(t, "https://x.com/a.jpg", results[0].ImageURL)
+		assert.Equal(t, "https://x.com/a-thumb.jpg", results[0].ThumbnailURL)
+		assert.Equal(t, "Apple", results[0].Title)
+	})
 
-func TestGoogleClient_Search_EmptyItems(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{}`))
-	}))
-	defer server.Close()
+	t.Run("empty_items", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer server.Close()
 
-	c := &GoogleClient{HTTPClient: server.Client(), APIKey: "k", CSEID: "id", BaseURL: server.URL}
-	results, err := c.Search(context.Background(), "q", 10)
-	require.NoError(t, err)
-	assert.Len(t, results, 0)
-}
+		c := &GoogleClient{HTTPClient: server.Client(), APIKey: "k", CSEID: "id", BaseURL: server.URL}
+		results, err := c.Search(context.Background(), "q", 10)
+		require.NoError(t, err)
+		assert.Len(t, results, 0)
+	})
 
-func TestGoogleClient_Search_NumDefaultedWhenZero(t *testing.T) {
-	var capturedNum string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedNum = r.URL.Query().Get("num")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"items": []}`))
-	}))
-	defer server.Close()
+	t.Run("num_defaulted_when_zero", func(t *testing.T) {
+		var capturedNum string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedNum = r.URL.Query().Get("num")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"items": []}`))
+		}))
+		defer server.Close()
 
-	c := &GoogleClient{HTTPClient: server.Client(), APIKey: "k", CSEID: "id", BaseURL: server.URL}
-	_, err := c.Search(context.Background(), "q", 0)
-	require.NoError(t, err)
-	assert.Equal(t, "10", capturedNum)
-}
+		c := &GoogleClient{HTTPClient: server.Client(), APIKey: "k", CSEID: "id", BaseURL: server.URL}
+		_, err := c.Search(context.Background(), "q", 0)
+		require.NoError(t, err)
+		assert.Equal(t, "10", capturedNum)
+	})
 
-func TestGoogleClient_Search_NumClampedAboveTen(t *testing.T) {
-	var capturedNum string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedNum = r.URL.Query().Get("num")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"items": []}`))
-	}))
-	defer server.Close()
+	t.Run("num_clamped_above_ten", func(t *testing.T) {
+		var capturedNum string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedNum = r.URL.Query().Get("num")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"items": []}`))
+		}))
+		defer server.Close()
 
-	c := &GoogleClient{HTTPClient: server.Client(), APIKey: "k", CSEID: "id", BaseURL: server.URL}
-	_, err := c.Search(context.Background(), "q", 99)
-	require.NoError(t, err)
-	assert.Equal(t, "10", capturedNum)
-}
+		c := &GoogleClient{HTTPClient: server.Client(), APIKey: "k", CSEID: "id", BaseURL: server.URL}
+		_, err := c.Search(context.Background(), "q", 99)
+		require.NoError(t, err)
+		assert.Equal(t, "10", capturedNum)
+	})
 
-func TestGoogleClient_Search_QuotaExceeded(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusTooManyRequests)
-		_, _ = w.Write([]byte(`{"error": {"code": 429, "message": "quota exceeded"}}`))
-	}))
-	defer server.Close()
+	t.Run("quota_exceeded", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error": {"code": 429, "message": "quota exceeded"}}`))
+		}))
+		defer server.Close()
 
-	c := &GoogleClient{HTTPClient: server.Client(), APIKey: "k", CSEID: "id", BaseURL: server.URL}
-	_, err := c.Search(context.Background(), "q", 5)
-	assert.ErrorIs(t, err, ErrQuotaExceeded)
-}
+		c := &GoogleClient{HTTPClient: server.Client(), APIKey: "k", CSEID: "id", BaseURL: server.URL}
+		_, err := c.Search(context.Background(), "q", 5)
+		assert.ErrorIs(t, err, ErrQuotaExceeded)
+	})
 
-func TestGoogleClient_Search_UpstreamFailure_5xx(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer server.Close()
+	t.Run("upstream_failure_5xx", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
 
-	c := &GoogleClient{HTTPClient: server.Client(), APIKey: "k", CSEID: "id", BaseURL: server.URL}
-	_, err := c.Search(context.Background(), "q", 5)
-	assert.ErrorIs(t, err, ErrUpstreamFailure)
-}
+		c := &GoogleClient{HTTPClient: server.Client(), APIKey: "k", CSEID: "id", BaseURL: server.URL}
+		_, err := c.Search(context.Background(), "q", 5)
+		assert.ErrorIs(t, err, ErrUpstreamFailure)
+	})
 
-func TestGoogleClient_Search_InvalidJSON(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`not json`))
-	}))
-	defer server.Close()
+	t.Run("invalid_json", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`not json`))
+		}))
+		defer server.Close()
 
-	c := &GoogleClient{HTTPClient: server.Client(), APIKey: "k", CSEID: "id", BaseURL: server.URL}
-	_, err := c.Search(context.Background(), "q", 5)
-	assert.ErrorIs(t, err, ErrUpstreamFailure)
+		c := &GoogleClient{HTTPClient: server.Client(), APIKey: "k", CSEID: "id", BaseURL: server.URL}
+		_, err := c.Search(context.Background(), "q", 5)
+		assert.ErrorIs(t, err, ErrUpstreamFailure)
+	})
 }

--- a/backend/learning/websocket/handler_test.go
+++ b/backend/learning/websocket/handler_test.go
@@ -15,61 +15,63 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHandler_RegistersOnConnect(t *testing.T) {
-	hub := NewHub()
-	e := echo.New()
-	e.GET("/ws", Handler(hub))
-	srv := httptest.NewServer(e)
-	defer srv.Close()
-	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+func TestHandler(t *testing.T) {
+	t.Run("registers_on_connect", func(t *testing.T) {
+		hub := NewHub()
+		e := echo.New()
+		e.GET("/ws", Handler(hub))
+		srv := httptest.NewServer(e)
+		defer srv.Close()
+		wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
 
-	ctx := context.Background()
-	conn, _, err := cws.Dial(ctx, wsURL, nil)
-	require.NoError(t, err)
-	defer conn.Close(cws.StatusNormalClosure, "")
+		ctx := context.Background()
+		conn, _, err := cws.Dial(ctx, wsURL, nil)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close(cws.StatusNormalClosure, "") }()
 
-	assert.Eventually(t, func() bool {
-		return hub.Len() == 1
-	}, time.Second, 10*time.Millisecond)
-}
+		assert.Eventually(t, func() bool {
+			return hub.Len() == 1
+		}, time.Second, 10*time.Millisecond)
+	})
 
-func TestHandler_UnregistersOnDisconnect(t *testing.T) {
-	hub := NewHub()
-	e := echo.New()
-	e.GET("/ws", Handler(hub))
-	srv := httptest.NewServer(e)
-	defer srv.Close()
-	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+	t.Run("unregisters_on_disconnect", func(t *testing.T) {
+		hub := NewHub()
+		e := echo.New()
+		e.GET("/ws", Handler(hub))
+		srv := httptest.NewServer(e)
+		defer srv.Close()
+		wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
 
-	ctx := context.Background()
-	conn, _, err := cws.Dial(ctx, wsURL, nil)
-	require.NoError(t, err)
-	conn.Close(cws.StatusNormalClosure, "")
+		ctx := context.Background()
+		conn, _, err := cws.Dial(ctx, wsURL, nil)
+		require.NoError(t, err)
+		_ = conn.Close(cws.StatusNormalClosure, "")
 
-	assert.Eventually(t, func() bool {
-		return hub.Len() == 0
-	}, time.Second, 10*time.Millisecond)
-}
+		assert.Eventually(t, func() bool {
+			return hub.Len() == 0
+		}, time.Second, 10*time.Millisecond)
+	})
 
-func TestHandler_BroadcastReachesClient(t *testing.T) {
-	hub := NewHub()
-	e := echo.New()
-	e.GET("/ws", Handler(hub))
-	srv := httptest.NewServer(e)
-	defer srv.Close()
-	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+	t.Run("broadcast_reaches_client", func(t *testing.T) {
+		hub := NewHub()
+		e := echo.New()
+		e.GET("/ws", Handler(hub))
+		srv := httptest.NewServer(e)
+		defer srv.Close()
+		wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
 
-	ctx := context.Background()
-	conn, _, err := cws.Dial(ctx, wsURL, nil)
-	require.NoError(t, err)
-	defer conn.Close(cws.StatusNormalClosure, "")
+		ctx := context.Background()
+		conn, _, err := cws.Dial(ctx, wsURL, nil)
+		require.NoError(t, err)
+		defer func() { _ = conn.Close(cws.StatusNormalClosure, "") }()
 
-	assert.Eventually(t, func() bool {
-		return hub.Len() == 1
-	}, time.Second, 10*time.Millisecond)
+		assert.Eventually(t, func() bool {
+			return hub.Len() == 1
+		}, time.Second, 10*time.Millisecond)
 
-	hub.Broadcast([]byte(`{"type":"x"}`))
-	_, msg, err := conn.Read(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, `{"type":"x"}`, string(msg))
+		hub.Broadcast([]byte(`{"type":"x"}`))
+		_, msg, err := conn.Read(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, `{"type":"x"}`, string(msg))
+	})
 }

--- a/backend/learning/websocket/hub_test.go
+++ b/backend/learning/websocket/hub_test.go
@@ -7,98 +7,100 @@ import (
 	"testing"
 )
 
-func TestHub_NewHub_Empty(t *testing.T) {
-	if got := NewHub().Len(); got != 0 {
-		t.Errorf("NewHub().Len() = %d, want 0", got)
-	}
-}
-
-func TestHub_Register_AddsClient(t *testing.T) {
-	hub := NewHub()
-	c := &Client{Send: make(chan []byte, 1)}
-	hub.Register(c)
-	if got := hub.Len(); got != 1 {
-		t.Errorf("After Register, hub.Len() = %d, want 1", got)
-	}
-}
-
-func TestHub_Unregister_RemovesClient(t *testing.T) {
-	hub := NewHub()
-	c := &Client{Send: make(chan []byte, 1)}
-	hub.Register(c)
-	hub.Unregister(c)
-	if got := hub.Len(); got != 0 {
-		t.Errorf("After Unregister, hub.Len() = %d, want 0", got)
-	}
-}
-
-func TestHub_Broadcast_SingleClient(t *testing.T) {
-	hub := NewHub()
-	c := &Client{Send: make(chan []byte, 1)}
-	hub.Register(c)
-	hub.Broadcast([]byte("hello"))
-	select {
-	case msg := <-c.Send:
-		if string(msg) != "hello" {
-			t.Errorf("Received message = %q, want %q", msg, "hello")
+func TestHub(t *testing.T) {
+	t.Run("new_hub_empty", func(t *testing.T) {
+		if got := NewHub().Len(); got != 0 {
+			t.Errorf("NewHub().Len() = %d, want 0", got)
 		}
-	default:
-		t.Error("Expected to receive a message, but channel was empty")
-	}
-}
+	})
 
-func TestHub_Broadcast_MultipleClients(t *testing.T) {
-	hub := NewHub()
-	c1 := &Client{Send: make(chan []byte, 1)}
-	c2 := &Client{Send: make(chan []byte, 1)}
-	hub.Register(c1)
-	hub.Register(c2)
+	t.Run("register_adds_client", func(t *testing.T) {
+		hub := NewHub()
+		c := &Client{Send: make(chan []byte, 1)}
+		hub.Register(c)
+		if got := hub.Len(); got != 1 {
+			t.Errorf("After Register, hub.Len() = %d, want 1", got)
+		}
+	})
 
-	hub.Broadcast([]byte("hello"))
+	t.Run("unregister_removes_client", func(t *testing.T) {
+		hub := NewHub()
+		c := &Client{Send: make(chan []byte, 1)}
+		hub.Register(c)
+		hub.Unregister(c)
+		if got := hub.Len(); got != 0 {
+			t.Errorf("After Unregister, hub.Len() = %d, want 0", got)
+		}
+	})
 
-	for i, c := range []*Client{c1, c2} {
+	t.Run("broadcast_single_client", func(t *testing.T) {
+		hub := NewHub()
+		c := &Client{Send: make(chan []byte, 1)}
+		hub.Register(c)
+		hub.Broadcast([]byte("hello"))
 		select {
 		case msg := <-c.Send:
 			if string(msg) != "hello" {
-				t.Errorf("Client %d: Received message = %q, want %q", i+1, msg, "hello")
+				t.Errorf("Received message = %q, want %q", msg, "hello")
 			}
 		default:
-			t.Errorf("Client %d: Expected to receive a message, but channel was empty", i+1)
+			t.Error("Expected to receive a message, but channel was empty")
 		}
-	}
-}
+	})
 
-func TestHub_Broadcast_FullChannel_DropsClient(t *testing.T) {
-	hub := NewHub()
-	c := &Client{Send: make(chan []byte, 0)} // buffer size 0
-	hub.Register(c)
-	hub.Broadcast([]byte("hello"))
-	if got := hub.Len(); got != 0 {
-		t.Errorf("After broadcast to full channel, hub.Len() = %d, want 0", got)
-	}
-}
+	t.Run("broadcast_multiple_clients", func(t *testing.T) {
+		hub := NewHub()
+		c1 := &Client{Send: make(chan []byte, 1)}
+		c2 := &Client{Send: make(chan []byte, 1)}
+		hub.Register(c1)
+		hub.Register(c2)
 
-func TestHub_ConcurrentRegisterUnregister(t *testing.T) {
-	hub := NewHub()
-	c := &Client{Send: make(chan []byte, 1)}
+		hub.Broadcast([]byte("hello"))
 
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 1000; i++ {
-			hub.Register(c)
-			hub.Unregister(c)
+		for i, c := range []*Client{c1, c2} {
+			select {
+			case msg := <-c.Send:
+				if string(msg) != "hello" {
+					t.Errorf("Client %d: Received message = %q, want %q", i+1, msg, "hello")
+				}
+			default:
+				t.Errorf("Client %d: Expected to receive a message, but channel was empty", i+1)
+			}
 		}
-	}()
+	})
 
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 1000; i++ {
-			hub.Broadcast([]byte("hello"))
+	t.Run("broadcast_full_channel_drops_client", func(t *testing.T) {
+		hub := NewHub()
+		c := &Client{Send: make(chan []byte)} // buffer size 0
+		hub.Register(c)
+		hub.Broadcast([]byte("hello"))
+		if got := hub.Len(); got != 0 {
+			t.Errorf("After broadcast to full channel, hub.Len() = %d, want 0", got)
 		}
-	}()
+	})
 
-	wg.Wait()
+	t.Run("concurrent_register_unregister", func(t *testing.T) {
+		hub := NewHub()
+		c := &Client{Send: make(chan []byte, 1)}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				hub.Register(c)
+				hub.Unregister(c)
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				hub.Broadcast([]byte("hello"))
+			}
+		}()
+
+		wg.Wait()
+	})
 }

--- a/backend/middleware/auth_test.go
+++ b/backend/middleware/auth_test.go
@@ -70,139 +70,141 @@ func setupMiddlewareTest(cfg middleware.JWTAuthConfig) (*echo.Echo, *httptest.Re
 	return e, rec
 }
 
-func TestJWTAuth_NoHeader(t *testing.T) {
-	e, rec := setupMiddlewareTest(middleware.JWTAuthConfig{
-		KeyFunc: testKeyFunc, GroupRepo: &mockGroupRepo{}, RequireGroup: true,
+func TestJWTAuth(t *testing.T) {
+	t.Run("no_header", func(t *testing.T) {
+		e, rec := setupMiddlewareTest(middleware.JWTAuthConfig{
+			KeyFunc: testKeyFunc, GroupRepo: &mockGroupRepo{}, RequireGroup: true,
+		})
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	})
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	e.ServeHTTP(rec, req)
-	assert.Equal(t, http.StatusUnauthorized, rec.Code)
-}
 
-func TestJWTAuth_InvalidToken(t *testing.T) {
-	e, rec := setupMiddlewareTest(middleware.JWTAuthConfig{
-		KeyFunc: testKeyFunc, GroupRepo: &mockGroupRepo{}, RequireGroup: false,
+	t.Run("invalid_token", func(t *testing.T) {
+		e, rec := setupMiddlewareTest(middleware.JWTAuthConfig{
+			KeyFunc: testKeyFunc, GroupRepo: &mockGroupRepo{}, RequireGroup: false,
+		})
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Authorization", "Bearer not-a-jwt")
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	})
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set("Authorization", "Bearer not-a-jwt")
-	e.ServeHTTP(rec, req)
-	assert.Equal(t, http.StatusUnauthorized, rec.Code)
-}
 
-func TestJWTAuth_ExpiredToken(t *testing.T) {
-	userID := uuid.New()
-	token := makeToken(t, userID.String(), time.Now().Add(-time.Hour))
-	e, rec := setupMiddlewareTest(middleware.JWTAuthConfig{
-		KeyFunc: testKeyFunc, GroupRepo: &mockGroupRepo{}, RequireGroup: false,
+	t.Run("expired_token", func(t *testing.T) {
+		userID := uuid.New()
+		token := makeToken(t, userID.String(), time.Now().Add(-time.Hour))
+		e, rec := setupMiddlewareTest(middleware.JWTAuthConfig{
+			KeyFunc: testKeyFunc, GroupRepo: &mockGroupRepo{}, RequireGroup: false,
+		})
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	})
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	e.ServeHTTP(rec, req)
-	assert.Equal(t, http.StatusUnauthorized, rec.Code)
-}
 
-func TestJWTAuth_ValidToken_NoGroupRequired(t *testing.T) {
-	userID := uuid.New()
-	token := makeToken(t, userID.String(), time.Now().Add(time.Hour))
+	t.Run("valid_token_no_group_required", func(t *testing.T) {
+		userID := uuid.New()
+		token := makeToken(t, userID.String(), time.Now().Add(time.Hour))
 
-	var capturedInfo *middleware.AuthInfo
-	e := echo.New()
-	e.Use(middleware.NewJWTAuth(middleware.JWTAuthConfig{
-		KeyFunc: testKeyFunc, GroupRepo: &mockGroupRepo{}, RequireGroup: false,
-	}))
-	e.GET("/test", func(c *echo.Context) error {
-		info, ok := middleware.GetAuthInfo(c)
-		require.True(t, ok)
-		capturedInfo = info
-		return c.String(http.StatusOK, "ok")
+		var capturedInfo *middleware.AuthInfo
+		e := echo.New()
+		e.Use(middleware.NewJWTAuth(middleware.JWTAuthConfig{
+			KeyFunc: testKeyFunc, GroupRepo: &mockGroupRepo{}, RequireGroup: false,
+		}))
+		e.GET("/test", func(c *echo.Context) error {
+			info, ok := middleware.GetAuthInfo(c)
+			require.True(t, ok)
+			capturedInfo = info
+			return c.String(http.StatusOK, "ok")
+		})
+		rec := httptest.NewRecorder()
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NotNil(t, capturedInfo)
+		assert.Equal(t, userID, capturedInfo.UserID)
+		assert.Equal(t, uuid.Nil, capturedInfo.GroupID)
 	})
-	rec := httptest.NewRecorder()
 
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusOK, rec.Code)
-	require.NotNil(t, capturedInfo)
-	assert.Equal(t, userID, capturedInfo.UserID)
-	assert.Equal(t, uuid.Nil, capturedInfo.GroupID)
-}
-
-func TestJWTAuth_RequireGroup_MissingHeader(t *testing.T) {
-	userID := uuid.New()
-	token := makeToken(t, userID.String(), time.Now().Add(time.Hour))
-	e, rec := setupMiddlewareTest(middleware.JWTAuthConfig{
-		KeyFunc: testKeyFunc, GroupRepo: &mockGroupRepo{}, RequireGroup: true,
+	t.Run("require_group_missing_header", func(t *testing.T) {
+		userID := uuid.New()
+		token := makeToken(t, userID.String(), time.Now().Add(time.Hour))
+		e, rec := setupMiddlewareTest(middleware.JWTAuthConfig{
+			KeyFunc: testKeyFunc, GroupRepo: &mockGroupRepo{}, RequireGroup: true,
+		})
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
 	})
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	e.ServeHTTP(rec, req)
-	assert.Equal(t, http.StatusForbidden, rec.Code)
-}
 
-func TestJWTAuth_RequireGroup_InvalidGroupID(t *testing.T) {
-	userID := uuid.New()
-	token := makeToken(t, userID.String(), time.Now().Add(time.Hour))
-	e, rec := setupMiddlewareTest(middleware.JWTAuthConfig{
-		KeyFunc: testKeyFunc, GroupRepo: &mockGroupRepo{}, RequireGroup: true,
+	t.Run("require_group_invalid_group_id", func(t *testing.T) {
+		userID := uuid.New()
+		token := makeToken(t, userID.String(), time.Now().Add(time.Hour))
+		e, rec := setupMiddlewareTest(middleware.JWTAuthConfig{
+			KeyFunc: testKeyFunc, GroupRepo: &mockGroupRepo{}, RequireGroup: true,
+		})
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("X-Active-Group-ID", "not-a-uuid")
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
 	})
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("X-Active-Group-ID", "not-a-uuid")
-	e.ServeHTTP(rec, req)
-	assert.Equal(t, http.StatusForbidden, rec.Code)
-}
 
-func TestJWTAuth_RequireGroup_NotMember(t *testing.T) {
-	userID := uuid.New()
-	token := makeToken(t, userID.String(), time.Now().Add(time.Hour))
-	mock := &mockGroupRepo{
-		findMembershipsFn: func(_ context.Context, _ uuid.UUID) ([]repository.GroupMembership, error) {
-			return []repository.GroupMembership{}, nil
-		},
-	}
-	e, rec := setupMiddlewareTest(middleware.JWTAuthConfig{
-		KeyFunc: testKeyFunc, GroupRepo: mock, RequireGroup: true,
+	t.Run("require_group_not_member", func(t *testing.T) {
+		userID := uuid.New()
+		token := makeToken(t, userID.String(), time.Now().Add(time.Hour))
+		mock := &mockGroupRepo{
+			findMembershipsFn: func(_ context.Context, _ uuid.UUID) ([]repository.GroupMembership, error) {
+				return []repository.GroupMembership{}, nil
+			},
+		}
+		e, rec := setupMiddlewareTest(middleware.JWTAuthConfig{
+			KeyFunc: testKeyFunc, GroupRepo: mock, RequireGroup: true,
+		})
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("X-Active-Group-ID", uuid.New().String())
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
 	})
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("X-Active-Group-ID", uuid.New().String())
-	e.ServeHTTP(rec, req)
-	assert.Equal(t, http.StatusForbidden, rec.Code)
-}
 
-func TestJWTAuth_RequireGroup_ValidMember(t *testing.T) {
-	userID := uuid.New()
-	groupID := uuid.New()
-	token := makeToken(t, userID.String(), time.Now().Add(time.Hour))
-	mock := &mockGroupRepo{
-		findMembershipsFn: func(_ context.Context, uid uuid.UUID) ([]repository.GroupMembership, error) {
-			assert.Equal(t, userID, uid)
-			return []repository.GroupMembership{{GroupID: groupID, Name: "家", Role: "owner"}}, nil
-		},
-	}
+	t.Run("require_group_valid_member", func(t *testing.T) {
+		userID := uuid.New()
+		groupID := uuid.New()
+		token := makeToken(t, userID.String(), time.Now().Add(time.Hour))
+		mock := &mockGroupRepo{
+			findMembershipsFn: func(_ context.Context, uid uuid.UUID) ([]repository.GroupMembership, error) {
+				assert.Equal(t, userID, uid)
+				return []repository.GroupMembership{{GroupID: groupID, Name: "家", Role: "owner"}}, nil
+			},
+		}
 
-	var capturedInfo *middleware.AuthInfo
-	e := echo.New()
-	e.Use(middleware.NewJWTAuth(middleware.JWTAuthConfig{
-		KeyFunc: testKeyFunc, GroupRepo: mock, RequireGroup: true,
-	}))
-	e.GET("/test", func(c *echo.Context) error {
-		info, ok := middleware.GetAuthInfo(c)
-		require.True(t, ok)
-		capturedInfo = info
-		return c.String(http.StatusOK, "ok")
+		var capturedInfo *middleware.AuthInfo
+		e := echo.New()
+		e.Use(middleware.NewJWTAuth(middleware.JWTAuthConfig{
+			KeyFunc: testKeyFunc, GroupRepo: mock, RequireGroup: true,
+		}))
+		e.GET("/test", func(c *echo.Context) error {
+			info, ok := middleware.GetAuthInfo(c)
+			require.True(t, ok)
+			capturedInfo = info
+			return c.String(http.StatusOK, "ok")
+		})
+		rec := httptest.NewRecorder()
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("X-Active-Group-ID", groupID.String())
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NotNil(t, capturedInfo)
+		assert.Equal(t, userID, capturedInfo.UserID)
+		assert.Equal(t, groupID, capturedInfo.GroupID)
+		assert.Equal(t, "owner", capturedInfo.Role)
 	})
-	rec := httptest.NewRecorder()
-
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("X-Active-Group-ID", groupID.String())
-	e.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusOK, rec.Code)
-	require.NotNil(t, capturedInfo)
-	assert.Equal(t, userID, capturedInfo.UserID)
-	assert.Equal(t, groupID, capturedInfo.GroupID)
-	assert.Equal(t, "owner", capturedInfo.Role)
 }

--- a/backend/middleware/auth_test.go
+++ b/backend/middleware/auth_test.go
@@ -18,7 +18,7 @@ import (
 
 var testSecret = []byte("test-secret-key")
 
-func testKeyFunc(token *jwt.Token) (interface{}, error) {
+func testKeyFunc(token *jwt.Token) (any, error) {
 	if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 		return nil, jwt.ErrSignatureInvalid
 	}

--- a/backend/repository/group_test.go
+++ b/backend/repository/group_test.go
@@ -18,130 +18,142 @@ func setupGroupTestDB(t *testing.T) *PgGroupRepository {
 	return NewPgGroupRepository(testPool)
 }
 
-func TestCreateGroup_Success(t *testing.T) {
-	repo := setupGroupTestDB(t)
-	ownerID := uuid.New()
+func TestCreateGroup(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		repo := setupGroupTestDB(t)
+		ownerID := uuid.New()
 
-	group, err := repo.CreateGroup(context.Background(), "我が家", ownerID)
-	require.NoError(t, err)
-	assert.NotEqual(t, uuid.Nil, group.ID)
-	assert.Equal(t, "我が家", group.Name)
+		group, err := repo.CreateGroup(context.Background(), "我が家", ownerID)
+		require.NoError(t, err)
+		assert.NotEqual(t, uuid.Nil, group.ID)
+		assert.Equal(t, "我が家", group.Name)
 
-	memberships, err := repo.FindMembershipsByUserID(context.Background(), ownerID)
-	require.NoError(t, err)
-	require.Len(t, memberships, 1)
-	assert.Equal(t, group.ID, memberships[0].GroupID)
-	assert.Equal(t, "owner", memberships[0].Role)
+		memberships, err := repo.FindMembershipsByUserID(context.Background(), ownerID)
+		require.NoError(t, err)
+		require.Len(t, memberships, 1)
+		assert.Equal(t, group.ID, memberships[0].GroupID)
+		assert.Equal(t, "owner", memberships[0].Role)
+	})
 }
 
-func TestFindMembershipsByUserID_NotMember(t *testing.T) {
-	repo := setupGroupTestDB(t)
+func TestFindMembershipsByUserID(t *testing.T) {
+	t.Run("not_member", func(t *testing.T) {
+		repo := setupGroupTestDB(t)
 
-	memberships, err := repo.FindMembershipsByUserID(context.Background(), uuid.New())
-	require.NoError(t, err)
-	assert.Empty(t, memberships)
+		memberships, err := repo.FindMembershipsByUserID(context.Background(), uuid.New())
+		require.NoError(t, err)
+		assert.Empty(t, memberships)
+	})
+
+	t.Run("multiple_groups", func(t *testing.T) {
+		repo := setupGroupTestDB(t)
+		userID := uuid.New()
+
+		group1, err := repo.CreateGroup(context.Background(), "我が家", userID)
+		require.NoError(t, err)
+		group2, err := repo.CreateGroup(context.Background(), "実家", uuid.New())
+		require.NoError(t, err)
+		inv, err := repo.CreateInvitation(context.Background(), group2.ID, uuid.New(), 7*24*time.Hour)
+		require.NoError(t, err)
+		require.NoError(t, repo.AcceptInvitation(context.Background(), inv.Token, userID))
+
+		memberships, err := repo.FindMembershipsByUserID(context.Background(), userID)
+		require.NoError(t, err)
+		require.Len(t, memberships, 2)
+
+		ids := []uuid.UUID{memberships[0].GroupID, memberships[1].GroupID}
+		assert.Contains(t, ids, group1.ID)
+		assert.Contains(t, ids, group2.ID)
+	})
 }
 
-func TestFindMembershipsByUserID_MultipleGroups(t *testing.T) {
-	repo := setupGroupTestDB(t)
-	userID := uuid.New()
+func TestUpdateGroupName(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		repo := setupGroupTestDB(t)
+		ownerID := uuid.New()
+		group, err := repo.CreateGroup(context.Background(), "旧名前", ownerID)
+		require.NoError(t, err)
 
-	group1, err := repo.CreateGroup(context.Background(), "我が家", userID)
-	require.NoError(t, err)
-	group2, err := repo.CreateGroup(context.Background(), "実家", uuid.New())
-	require.NoError(t, err)
-	inv, err := repo.CreateInvitation(context.Background(), group2.ID, uuid.New(), 7*24*time.Hour)
-	require.NoError(t, err)
-	require.NoError(t, repo.AcceptInvitation(context.Background(), inv.Token, userID))
+		updated, err := repo.UpdateGroupName(context.Background(), group.ID, "新しい名前")
+		require.NoError(t, err)
+		assert.Equal(t, group.ID, updated.ID)
+		assert.Equal(t, "新しい名前", updated.Name)
+	})
 
-	memberships, err := repo.FindMembershipsByUserID(context.Background(), userID)
-	require.NoError(t, err)
-	require.Len(t, memberships, 2)
+	t.Run("not_found", func(t *testing.T) {
+		repo := setupGroupTestDB(t)
 
-	ids := []uuid.UUID{memberships[0].GroupID, memberships[1].GroupID}
-	assert.Contains(t, ids, group1.ID)
-	assert.Contains(t, ids, group2.ID)
+		_, err := repo.UpdateGroupName(context.Background(), uuid.New(), "名前")
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
 }
 
-func TestUpdateGroupName_Success(t *testing.T) {
-	repo := setupGroupTestDB(t)
-	ownerID := uuid.New()
-	group, err := repo.CreateGroup(context.Background(), "旧名前", ownerID)
-	require.NoError(t, err)
+func TestCreateInvitation(t *testing.T) {
+	t.Run("and_find", func(t *testing.T) {
+		repo := setupGroupTestDB(t)
+		ownerID := uuid.New()
+		group, _ := repo.CreateGroup(context.Background(), "テスト家族", ownerID)
 
-	updated, err := repo.UpdateGroupName(context.Background(), group.ID, "新しい名前")
-	require.NoError(t, err)
-	assert.Equal(t, group.ID, updated.ID)
-	assert.Equal(t, "新しい名前", updated.Name)
+		inv, err := repo.CreateInvitation(context.Background(), group.ID, ownerID, 7*24*time.Hour)
+		require.NoError(t, err)
+		assert.NotEqual(t, uuid.Nil, inv.Token)
+		assert.True(t, inv.ExpiresAt.After(time.Now()))
+		assert.Equal(t, 0, inv.UseCount)
+
+		found, err := repo.FindInvitation(context.Background(), inv.Token)
+		require.NoError(t, err)
+		assert.Equal(t, inv.Token, found.Token)
+	})
 }
 
-func TestUpdateGroupName_NotFound(t *testing.T) {
-	repo := setupGroupTestDB(t)
+func TestFindInvitation(t *testing.T) {
+	t.Run("not_found", func(t *testing.T) {
+		repo := setupGroupTestDB(t)
 
-	_, err := repo.UpdateGroupName(context.Background(), uuid.New(), "名前")
-	assert.ErrorIs(t, err, ErrNotFound)
+		_, err := repo.FindInvitation(context.Background(), uuid.New())
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
 }
 
-func TestCreateInvitation_AndFind(t *testing.T) {
-	repo := setupGroupTestDB(t)
-	ownerID := uuid.New()
-	group, _ := repo.CreateGroup(context.Background(), "テスト家族", ownerID)
+func TestAcceptInvitation(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		repo := setupGroupTestDB(t)
+		ownerID := uuid.New()
+		group, _ := repo.CreateGroup(context.Background(), "テスト家族", ownerID)
+		inv, _ := repo.CreateInvitation(context.Background(), group.ID, ownerID, 7*24*time.Hour)
 
-	inv, err := repo.CreateInvitation(context.Background(), group.ID, ownerID, 7*24*time.Hour)
-	require.NoError(t, err)
-	assert.NotEqual(t, uuid.Nil, inv.Token)
-	assert.True(t, inv.ExpiresAt.After(time.Now()))
-	assert.Equal(t, 0, inv.UseCount)
+		newMemberID := uuid.New()
+		err := repo.AcceptInvitation(context.Background(), inv.Token, newMemberID)
+		require.NoError(t, err)
 
-	found, err := repo.FindInvitation(context.Background(), inv.Token)
-	require.NoError(t, err)
-	assert.Equal(t, inv.Token, found.Token)
-}
+		memberships, err := repo.FindMembershipsByUserID(context.Background(), newMemberID)
+		require.NoError(t, err)
+		require.Len(t, memberships, 1)
+		assert.Equal(t, group.ID, memberships[0].GroupID)
+		assert.Equal(t, "member", memberships[0].Role)
 
-func TestFindInvitation_NotFound(t *testing.T) {
-	repo := setupGroupTestDB(t)
+		updated, _ := repo.FindInvitation(context.Background(), inv.Token)
+		assert.Equal(t, 1, updated.UseCount)
+	})
 
-	_, err := repo.FindInvitation(context.Background(), uuid.New())
-	assert.ErrorIs(t, err, ErrNotFound)
-}
+	t.Run("idempotent", func(t *testing.T) {
+		repo := setupGroupTestDB(t)
+		ownerID := uuid.New()
+		group, _ := repo.CreateGroup(context.Background(), "テスト家族", ownerID)
+		inv, _ := repo.CreateInvitation(context.Background(), group.ID, ownerID, 7*24*time.Hour)
+		memberID := uuid.New()
 
-func TestAcceptInvitation_Success(t *testing.T) {
-	repo := setupGroupTestDB(t)
-	ownerID := uuid.New()
-	group, _ := repo.CreateGroup(context.Background(), "テスト家族", ownerID)
-	inv, _ := repo.CreateInvitation(context.Background(), group.ID, ownerID, 7*24*time.Hour)
+		require.NoError(t, repo.AcceptInvitation(context.Background(), inv.Token, memberID))
+		require.NoError(t, repo.AcceptInvitation(context.Background(), inv.Token, memberID))
+	})
 
-	newMemberID := uuid.New()
-	err := repo.AcceptInvitation(context.Background(), inv.Token, newMemberID)
-	require.NoError(t, err)
+	t.Run("expired", func(t *testing.T) {
+		repo := setupGroupTestDB(t)
+		ownerID := uuid.New()
+		group, _ := repo.CreateGroup(context.Background(), "テスト家族", ownerID)
+		inv, _ := repo.CreateInvitation(context.Background(), group.ID, ownerID, -time.Hour)
 
-	memberships, err := repo.FindMembershipsByUserID(context.Background(), newMemberID)
-	require.NoError(t, err)
-	require.Len(t, memberships, 1)
-	assert.Equal(t, group.ID, memberships[0].GroupID)
-	assert.Equal(t, "member", memberships[0].Role)
-
-	updated, _ := repo.FindInvitation(context.Background(), inv.Token)
-	assert.Equal(t, 1, updated.UseCount)
-}
-
-func TestAcceptInvitation_Idempotent(t *testing.T) {
-	repo := setupGroupTestDB(t)
-	ownerID := uuid.New()
-	group, _ := repo.CreateGroup(context.Background(), "テスト家族", ownerID)
-	inv, _ := repo.CreateInvitation(context.Background(), group.ID, ownerID, 7*24*time.Hour)
-	memberID := uuid.New()
-
-	require.NoError(t, repo.AcceptInvitation(context.Background(), inv.Token, memberID))
-	require.NoError(t, repo.AcceptInvitation(context.Background(), inv.Token, memberID))
-}
-
-func TestAcceptInvitation_Expired(t *testing.T) {
-	repo := setupGroupTestDB(t)
-	ownerID := uuid.New()
-	group, _ := repo.CreateGroup(context.Background(), "テスト家族", ownerID)
-	inv, _ := repo.CreateInvitation(context.Background(), group.ID, ownerID, -time.Hour)
-
-	err := repo.AcceptInvitation(context.Background(), inv.Token, uuid.New())
-	assert.ErrorIs(t, err, ErrInvitationExpired)
+		err := repo.AcceptInvitation(context.Background(), inv.Token, uuid.New())
+		assert.ErrorIs(t, err, ErrInvitationExpired)
+	})
 }

--- a/backend/urlextract/claude_extractor_test.go
+++ b/backend/urlextract/claude_extractor_test.go
@@ -11,108 +11,116 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewClaudeExtractor_NilWhenKeyUnset(t *testing.T) {
-	t.Setenv("ANTHROPIC_API_KEY", "")
-	got := NewClaudeExtractor()
-	assert.Nil(t, got)
+func TestNewClaudeExtractor(t *testing.T) {
+	t.Run("nil_when_key_unset", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "")
+		got := NewClaudeExtractor()
+		assert.Nil(t, got)
+	})
+
+	t.Run("not_nil_when_key_set", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "test-key-value")
+		got := NewClaudeExtractor()
+		assert.NotNil(t, got)
+	})
 }
 
-func TestNewClaudeExtractor_NotNilWhenKeySet(t *testing.T) {
-	t.Setenv("ANTHROPIC_API_KEY", "test-key-value")
-	got := NewClaudeExtractor()
-	assert.NotNil(t, got)
-}
+func TestTruncateText(t *testing.T) {
+	t.Run("short_string_unchanged", func(t *testing.T) {
+		input := "hello world"
+		got := truncateText(input, maxHTMLTextLen)
+		assert.Equal(t, input, got)
+	})
 
-func TestTruncateText_ShortStringUnchanged(t *testing.T) {
-	input := "hello world"
-	got := truncateText(input, maxHTMLTextLen)
-	assert.Equal(t, input, got)
-}
+	t.Run("truncates_to_exact_runes", func(t *testing.T) {
+		// Build a string longer than maxHTMLTextLen using multi-byte runes (Japanese)
+		r := 'あ' // 3-byte UTF-8 rune
+		longStr := ""
+		for range maxHTMLTextLen + 100 {
+			longStr += string(r)
+		}
+		require.Greater(t, utf8.RuneCountInString(longStr), maxHTMLTextLen)
 
-func TestTruncateText_TruncatesToExactRunes(t *testing.T) {
-	// Build a string longer than maxHTMLTextLen using multi-byte runes (Japanese)
-	r := 'あ' // 3-byte UTF-8 rune
-	longStr := ""
-	for i := 0; i < maxHTMLTextLen+100; i++ {
-		longStr += string(r)
-	}
-	require.Greater(t, utf8.RuneCountInString(longStr), maxHTMLTextLen)
+		got := truncateText(longStr, maxHTMLTextLen)
+		assert.Equal(t, maxHTMLTextLen, utf8.RuneCountInString(got))
+	})
 
-	got := truncateText(longStr, maxHTMLTextLen)
-	assert.Equal(t, maxHTMLTextLen, utf8.RuneCountInString(got))
-}
-
-func TestTruncateText_ExactLengthUnchanged(t *testing.T) {
-	r := 'あ'
-	exactStr := ""
-	for i := 0; i < maxHTMLTextLen; i++ {
-		exactStr += string(r)
-	}
-	got := truncateText(exactStr, maxHTMLTextLen)
-	assert.Equal(t, maxHTMLTextLen, utf8.RuneCountInString(got))
-	assert.Equal(t, exactStr, got)
+	t.Run("exact_length_unchanged", func(t *testing.T) {
+		r := 'あ'
+		exactStr := ""
+		for range maxHTMLTextLen {
+			exactStr += string(r)
+		}
+		got := truncateText(exactStr, maxHTMLTextLen)
+		assert.Equal(t, maxHTMLTextLen, utf8.RuneCountInString(got))
+		assert.Equal(t, exactStr, got)
+	})
 }
 
 // TestClaudeResponseParsing tests the JSON parsing logic that ClaudeExtractor.Extract() applies
 // to the Claude API response. We validate that the expected struct unmarshalling works correctly.
-func TestClaudeResponseParsing_NameAndImage(t *testing.T) {
-	responseText := `{"name": "テスト商品", "imageUrl": "https://example.com/img.jpg"}`
-	var extracted struct {
-		Name     string `json:"name"`
-		ImageURL string `json:"imageUrl"`
-	}
-	err := json.Unmarshal([]byte(responseText), &extracted)
-	require.NoError(t, err)
-	assert.Equal(t, "テスト商品", extracted.Name)
-	assert.Equal(t, "https://example.com/img.jpg", extracted.ImageURL)
+func TestClaudeResponseParsing(t *testing.T) {
+	t.Run("name_and_image", func(t *testing.T) {
+		responseText := `{"name": "テスト商品", "imageUrl": "https://example.com/img.jpg"}`
+		var extracted struct {
+			Name     string `json:"name"`
+			ImageURL string `json:"imageUrl"`
+		}
+		err := json.Unmarshal([]byte(responseText), &extracted)
+		require.NoError(t, err)
+		assert.Equal(t, "テスト商品", extracted.Name)
+		assert.Equal(t, "https://example.com/img.jpg", extracted.ImageURL)
+	})
+
+	t.Run("empty_fields", func(t *testing.T) {
+		responseText := `{"name": "", "imageUrl": ""}`
+		var extracted struct {
+			Name     string `json:"name"`
+			ImageURL string `json:"imageUrl"`
+		}
+		err := json.Unmarshal([]byte(responseText), &extracted)
+		require.NoError(t, err)
+		assert.Equal(t, "", extracted.Name)
+		assert.Equal(t, "", extracted.ImageURL)
+	})
+
+	t.Run("malformed_json", func(t *testing.T) {
+		responseText := `not valid json`
+		var extracted struct {
+			Name     string `json:"name"`
+			ImageURL string `json:"imageUrl"`
+		}
+		err := json.Unmarshal([]byte(responseText), &extracted)
+		// Unmarshal should fail; ClaudeExtractor treats this as no result (returns empty Result)
+		assert.Error(t, err)
+	})
 }
 
-func TestClaudeResponseParsing_EmptyFields(t *testing.T) {
-	responseText := `{"name": "", "imageUrl": ""}`
-	var extracted struct {
-		Name     string `json:"name"`
-		ImageURL string `json:"imageUrl"`
-	}
-	err := json.Unmarshal([]byte(responseText), &extracted)
-	require.NoError(t, err)
-	assert.Equal(t, "", extracted.Name)
-	assert.Equal(t, "", extracted.ImageURL)
-}
+func TestGenerateCandidates(t *testing.T) {
+	// TestGenerateCandidates verifies that GenerateCandidates returns the candidates
+	// produced by generateFn when it succeeds.
+	t.Run("happy_path", func(t *testing.T) {
+		want := []string{"候補1", "候補2", "候補3"}
+		e := &ClaudeExtractor{
+			generateFn: func(_ context.Context, _ string) ([]string, error) {
+				return want, nil
+			},
+		}
+		got, err := e.GenerateCandidates(context.Background(), "これは25文字以上の長い商品タイトルです")
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
 
-func TestClaudeResponseParsing_MalformedJSON(t *testing.T) {
-	responseText := `not valid json`
-	var extracted struct {
-		Name     string `json:"name"`
-		ImageURL string `json:"imageUrl"`
-	}
-	err := json.Unmarshal([]byte(responseText), &extracted)
-	// Unmarshal should fail; ClaudeExtractor treats this as no result (returns empty Result)
-	assert.Error(t, err)
-}
-
-// TestGenerateCandidates_HappyPath verifies that GenerateCandidates returns the candidates
-// produced by generateFn when it succeeds.
-func TestGenerateCandidates_HappyPath(t *testing.T) {
-	want := []string{"候補1", "候補2", "候補3"}
-	e := &ClaudeExtractor{
-		generateFn: func(_ context.Context, _ string) ([]string, error) {
-			return want, nil
-		},
-	}
-	got, err := e.GenerateCandidates(context.Background(), "これは25文字以上の長い商品タイトルです")
-	require.NoError(t, err)
-	assert.Equal(t, want, got)
-}
-
-// TestGenerateCandidates_ErrorReturnsEmptySlice verifies that when generateFn returns an error,
-// GenerateCandidates swallows it and returns an empty (non-nil) slice with nil error.
-func TestGenerateCandidates_ErrorReturnsEmptySlice(t *testing.T) {
-	e := &ClaudeExtractor{
-		generateFn: func(_ context.Context, _ string) ([]string, error) {
-			return nil, errors.New("claude API down")
-		},
-	}
-	got, err := e.GenerateCandidates(context.Background(), "長い商品名テスト")
-	require.NoError(t, err)
-	assert.Equal(t, []string{}, got)
+	// error_returns_empty_slice verifies that when generateFn returns an error,
+	// GenerateCandidates swallows it and returns an empty (non-nil) slice with nil error.
+	t.Run("error_returns_empty_slice", func(t *testing.T) {
+		e := &ClaudeExtractor{
+			generateFn: func(_ context.Context, _ string) ([]string, error) {
+				return nil, errors.New("claude API down")
+			},
+		}
+		got, err := e.GenerateCandidates(context.Background(), "長い商品名テスト")
+		require.NoError(t, err)
+		assert.Equal(t, []string{}, got)
+	})
 }

--- a/backend/urlextract/extractor_test.go
+++ b/backend/urlextract/extractor_test.go
@@ -22,185 +22,287 @@ func newTestExtractor(ts *httptest.Server, jina *JinaFetcher, claude *ClaudeExtr
 	)
 }
 
-func TestDefaultExtractor_MetaTagsPresent(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = fmt.Fprintln(w, `<html><head>
-			<meta property="og:title" content="テスト商品">
-			<meta property="og:image" content="https://example.com/img.jpg">
-		</head></html>`)
-	}))
-	defer ts.Close()
+func TestDefaultExtractor(t *testing.T) {
+	t.Run("meta_tags_present", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = fmt.Fprintln(w, `<html><head>
+				<meta property="og:title" content="テスト商品">
+				<meta property="og:image" content="https://example.com/img.jpg">
+			</head></html>`)
+		}))
+		defer ts.Close()
 
-	e := newTestExtractor(ts, nil, nil)
-	got, err := e.Extract(context.Background(), ts.URL)
-	require.NoError(t, err)
-	assert.Equal(t, "テスト商品", got.Name)
-	assert.Equal(t, "https://example.com/img.jpg", got.ImageURL)
-}
+		e := newTestExtractor(ts, nil, nil)
+		got, err := e.Extract(context.Background(), ts.URL)
+		require.NoError(t, err)
+		assert.Equal(t, "テスト商品", got.Name)
+		assert.Equal(t, "https://example.com/img.jpg", got.ImageURL)
+	})
 
-// TestDefaultExtractor_EmptyMetaAndNoClaude_FallsBackToJina verifies that when the direct
-// fetch succeeds but meta extraction yields nothing and Claude is nil, the extractor falls
-// back to Jina. With nil jinaFetcher, ErrFetchFailed is returned.
-func TestDefaultExtractor_EmptyMetaAndNoClaude_FallsBackToJina(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = fmt.Fprintln(w, `<html><head><title>no og tags here</title></head></html>`)
-	}))
-	defer ts.Close()
+	// empty_meta_and_no_claude_falls_back_to_jina verifies that when the direct
+	// fetch succeeds but meta extraction yields nothing and Claude is nil, the extractor falls
+	// back to Jina. With nil jinaFetcher, ErrFetchFailed is returned.
+	t.Run("empty_meta_and_no_claude_falls_back_to_jina", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = fmt.Fprintln(w, `<html><head><title>no og tags here</title></head></html>`)
+		}))
+		defer ts.Close()
 
-	e := newTestExtractor(ts, nil, nil) // nil jina → ErrFetchFailed from extractViaJina
-	_, err := e.Extract(context.Background(), ts.URL)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrFetchFailed))
-}
+		e := newTestExtractor(ts, nil, nil) // nil jina → ErrFetchFailed from extractViaJina
+		_, err := e.Extract(context.Background(), ts.URL)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrFetchFailed))
+	})
 
-// TestDefaultExtractor_FetchFails_ServerError verifies that a non-200 direct fetch
-// triggers the Jina fallback. With nil jinaFetcher, it should return ErrFetchFailed.
-func TestDefaultExtractor_FetchFails_ServerError(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-	}))
-	defer ts.Close()
+	// fetch_fails_server_error verifies that a non-200 direct fetch
+	// triggers the Jina fallback. With nil jinaFetcher, it should return ErrFetchFailed.
+	t.Run("fetch_fails_server_error", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		}))
+		defer ts.Close()
 
-	e := newTestExtractor(ts, nil, nil) // nil jina → fetch failure propagates as ErrFetchFailed
-	_, err := e.Extract(context.Background(), ts.URL)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrFetchFailed))
-}
+		e := newTestExtractor(ts, nil, nil) // nil jina → fetch failure propagates as ErrFetchFailed
+		_, err := e.Extract(context.Background(), ts.URL)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrFetchFailed))
+	})
 
-// TestDefaultExtractor_FetchFails_ServerClosed verifies that a connection failure
-// triggers the Jina fallback. With nil jinaFetcher, it should return ErrFetchFailed.
-func TestDefaultExtractor_FetchFails_ServerClosed(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = fmt.Fprintln(w, `<html></html>`)
-	}))
-	serverURL := ts.URL
-	ts.Close() // close before the request is made
+	// fetch_fails_server_closed verifies that a connection failure
+	// triggers the Jina fallback. With nil jinaFetcher, it should return ErrFetchFailed.
+	t.Run("fetch_fails_server_closed", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = fmt.Fprintln(w, `<html></html>`)
+		}))
+		serverURL := ts.URL
+		ts.Close() // close before the request is made
 
-	e := newTestExtractor(ts, nil, nil) // nil jina → fetch failure propagates as ErrFetchFailed
-	_, err := e.Extract(context.Background(), serverURL)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrFetchFailed))
-}
+		e := newTestExtractor(ts, nil, nil) // nil jina → fetch failure propagates as ErrFetchFailed
+		_, err := e.Extract(context.Background(), serverURL)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrFetchFailed))
+	})
 
-// TestDefaultExtractor_EmptyMetaWithClaudeNil_FallsBackToJina verifies that when Claude is
-// nil and meta extraction yields nothing, the extractor falls back to Jina. With nil
-// jinaFetcher, ErrFetchFailed is returned (not a nil-pointer panic or other error).
-func TestDefaultExtractor_EmptyMetaWithClaudeNil_FallsBackToJina(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = fmt.Fprintln(w, `<html><body>Some page without product info</body></html>`)
-	}))
-	defer ts.Close()
+	// empty_meta_with_claude_nil_falls_back_to_jina verifies that when Claude is
+	// nil and meta extraction yields nothing, the extractor falls back to Jina. With nil
+	// jinaFetcher, ErrFetchFailed is returned (not a nil-pointer panic or other error).
+	t.Run("empty_meta_with_claude_nil_falls_back_to_jina", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = fmt.Fprintln(w, `<html><body>Some page without product info</body></html>`)
+		}))
+		defer ts.Close()
 
-	e := NewDefaultExtractorWithDeps(
-		&Fetcher{HTTPClient: ts.Client()},
-		nil,
-		nil,
-	)
-	_, err := e.Extract(context.Background(), ts.URL)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrFetchFailed))
-}
+		e := NewDefaultExtractorWithDeps(
+			&Fetcher{HTTPClient: ts.Client()},
+			nil,
+			nil,
+		)
+		_, err := e.Extract(context.Background(), ts.URL)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrFetchFailed))
+	})
 
-// TestDefaultExtractor_Step1FetchFails_JinaSucceeds verifies that when the direct fetch
-// fails, the extractor falls back to Jina and returns the Jina title + first image.
-func TestDefaultExtractor_Step1FetchFails_JinaSucceeds(t *testing.T) {
-	// Direct fetch server: always returns 500
-	directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "blocked", http.StatusInternalServerError)
-	}))
-	defer directTS.Close()
+	// step1_fetch_fails_jina_succeeds verifies that when the direct fetch
+	// fails, the extractor falls back to Jina and returns the Jina title + first image.
+	t.Run("step1_fetch_fails_jina_succeeds", func(t *testing.T) {
+		// Direct fetch server: always returns 500
+		directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "blocked", http.StatusInternalServerError)
+		}))
+		defer directTS.Close()
 
-	// Jina server: returns valid product data
-	jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintln(w, `{
-			"code": 200,
-			"data": {
-				"title": "楽天商品名",
-				"content": "商品の詳細説明",
-				"images": {"https://cdn.example.com/product.jpg": "商品画像"}
-			}
-		}`)
-	}))
-	defer jinaTS.Close()
+		// Jina server: returns valid product data
+		jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintln(w, `{
+				"code": 200,
+				"data": {
+					"title": "楽天商品名",
+					"content": "商品の詳細説明",
+					"images": {"https://cdn.example.com/product.jpg": "商品画像"}
+				}
+			}`)
+		}))
+		defer jinaTS.Close()
 
-	jina := &JinaFetcher{
-		HTTPClient: jinaTS.Client(),
-		BaseURL:    jinaTS.URL + "/",
-	}
-	e := NewDefaultExtractorWithDeps(
-		&Fetcher{HTTPClient: directTS.Client()},
-		jina,
-		nil,
-	)
-	got, err := e.Extract(context.Background(), directTS.URL)
-	require.NoError(t, err)
-	assert.Equal(t, "楽天商品名", got.Name)
-	assert.Equal(t, "https://cdn.example.com/product.jpg", got.ImageURL)
-}
+		jina := &JinaFetcher{
+			HTTPClient: jinaTS.Client(),
+			BaseURL:    jinaTS.URL + "/",
+		}
+		e := NewDefaultExtractorWithDeps(
+			&Fetcher{HTTPClient: directTS.Client()},
+			jina,
+			nil,
+		)
+		got, err := e.Extract(context.Background(), directTS.URL)
+		require.NoError(t, err)
+		assert.Equal(t, "楽天商品名", got.Name)
+		assert.Equal(t, "https://cdn.example.com/product.jpg", got.ImageURL)
+	})
 
-// TestDefaultExtractor_Step1FetchFails_JinaFails verifies that when both direct fetch
-// and Jina fail, ErrFetchFailed is returned.
-func TestDefaultExtractor_Step1FetchFails_JinaFails(t *testing.T) {
-	// Direct fetch server: returns 500
-	directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "blocked", http.StatusInternalServerError)
-	}))
-	defer directTS.Close()
+	// step1_fetch_fails_jina_fails verifies that when both direct fetch
+	// and Jina fail, ErrFetchFailed is returned.
+	t.Run("step1_fetch_fails_jina_fails", func(t *testing.T) {
+		// Direct fetch server: returns 500
+		directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "blocked", http.StatusInternalServerError)
+		}))
+		defer directTS.Close()
 
-	// Jina server: also fails
-	jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "jina unavailable", http.StatusServiceUnavailable)
-	}))
-	defer jinaTS.Close()
+		// Jina server: also fails
+		jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "jina unavailable", http.StatusServiceUnavailable)
+		}))
+		defer jinaTS.Close()
 
-	jina := &JinaFetcher{
-		HTTPClient: jinaTS.Client(),
-		BaseURL:    jinaTS.URL + "/",
-	}
-	e := NewDefaultExtractorWithDeps(
-		&Fetcher{HTTPClient: directTS.Client()},
-		jina,
-		nil,
-	)
-	_, err := e.Extract(context.Background(), directTS.URL)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrFetchFailed))
-}
+		jina := &JinaFetcher{
+			HTTPClient: jinaTS.Client(),
+			BaseURL:    jinaTS.URL + "/",
+		}
+		e := NewDefaultExtractorWithDeps(
+			&Fetcher{HTTPClient: directTS.Client()},
+			jina,
+			nil,
+		)
+		_, err := e.Extract(context.Background(), directTS.URL)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrFetchFailed))
+	})
 
-// TestDefaultExtractor_Step1SucceedsButNoMeta_FallsBackToJina verifies that when the direct
-// fetch succeeds but meta extraction yields no product name, the extractor falls back to Jina.
-func TestDefaultExtractor_Step1SucceedsButNoMeta_FallsBackToJina(t *testing.T) {
-	jinaCallCount := 0
-	jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		jinaCallCount++
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintln(w, `{"code":200,"data":{"title":"Jina商品名","content":"商品説明","images":{"https://cdn.example.com/p.jpg":"商品画像"}}}`)
-	}))
-	defer jinaTS.Close()
+	// step1_succeeds_but_no_meta_falls_back_to_jina verifies that when the direct
+	// fetch succeeds but meta extraction yields no product name, the extractor falls back to Jina.
+	t.Run("step1_succeeds_but_no_meta_falls_back_to_jina", func(t *testing.T) {
+		jinaCallCount := 0
+		jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			jinaCallCount++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintln(w, `{"code":200,"data":{"title":"Jina商品名","content":"商品説明","images":{"https://cdn.example.com/p.jpg":"商品画像"}}}`)
+		}))
+		defer jinaTS.Close()
 
-	directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = fmt.Fprintln(w, `<html><body><p>No product here</p></body></html>`)
-	}))
-	defer directTS.Close()
+		directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = fmt.Fprintln(w, `<html><body><p>No product here</p></body></html>`)
+		}))
+		defer directTS.Close()
 
-	jina := &JinaFetcher{
-		HTTPClient: jinaTS.Client(),
-		BaseURL:    jinaTS.URL + "/",
-	}
-	e := NewDefaultExtractorWithDeps(
-		&Fetcher{HTTPClient: directTS.Client()},
-		jina,
-		nil,
-	)
-	got, err := e.Extract(context.Background(), directTS.URL)
-	require.NoError(t, err)
-	assert.Equal(t, "Jina商品名", got.Name)
-	assert.Equal(t, 1, jinaCallCount, "Jina should be called as fallback")
+		jina := &JinaFetcher{
+			HTTPClient: jinaTS.Client(),
+			BaseURL:    jinaTS.URL + "/",
+		}
+		e := NewDefaultExtractorWithDeps(
+			&Fetcher{HTTPClient: directTS.Client()},
+			jina,
+			nil,
+		)
+		got, err := e.Extract(context.Background(), directTS.URL)
+		require.NoError(t, err)
+		assert.Equal(t, "Jina商品名", got.Name)
+		assert.Equal(t, 1, jinaCallCount, "Jina should be called as fallback")
+	})
+
+	// step1_claude_long_name_generates_candidates verifies that when Step 1
+	// Claude returns a name >= 25 runes, GenerateCandidates is called and NameCandidates is set.
+	// Jina should NOT be called when an image is already present.
+	t.Run("step1_claude_long_name_generates_candidates", func(t *testing.T) {
+		jinaCallCount := 0
+		jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			jinaCallCount++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintln(w, `{"code":200,"data":{"title":"短い商品名","content":"","images":{"https://cdn.example.com/p.jpg":"画像"}}}`)
+		}))
+		defer jinaTS.Close()
+
+		directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = fmt.Fprintln(w, `<html><head><meta property="og:title" content="長い商品名 | サイト名 - ブランド名 - カテゴリ名"></head></html>`)
+		}))
+		defer directTS.Close()
+
+		longName := "これは25文字以上の長い商品タイトルですよ追加テキスト" // 26 runes
+		wantCandidates := []string{"候補1", "候補2", "候補3"}
+		fake := &ClaudeExtractor{
+			extractFn: func(_ context.Context, _ string, _ Result) (Result, error) {
+				return Result{Name: longName, ImageURL: "https://meta.example.com/img.jpg"}, nil
+			},
+			generateFn: func(_ context.Context, _ string) ([]string, error) {
+				return wantCandidates, nil
+			},
+		}
+		jina := &JinaFetcher{HTTPClient: jinaTS.Client(), BaseURL: jinaTS.URL + "/"}
+		e := NewDefaultExtractorWithDeps(&Fetcher{HTTPClient: directTS.Client()}, jina, fake)
+
+		got, err := e.Extract(context.Background(), directTS.URL)
+		require.NoError(t, err)
+		assert.Equal(t, longName, got.Name, "original long name is preserved")
+		assert.Equal(t, wantCandidates, got.NameCandidates, "candidates from GenerateCandidates should be set")
+		assert.Equal(t, "https://meta.example.com/img.jpg", got.ImageURL)
+		assert.Equal(t, 0, jinaCallCount, "Jina should NOT be called when image is already present")
+	})
+
+	// step1_claude_no_image_supplements_from_jina verifies that when Step 1
+	// Claude returns no imageURL, the extractor also calls Jina to obtain an image.
+	t.Run("step1_claude_no_image_supplements_from_jina", func(t *testing.T) {
+		jinaCallCount := 0
+		jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			jinaCallCount++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintln(w, `{"code":200,"data":{"title":"商品名","content":"","images":{"https://cdn.example.com/p.jpg":"画像"}}}`)
+		}))
+		defer jinaTS.Close()
+
+		directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = fmt.Fprintln(w, `<html><body>product page</body></html>`)
+		}))
+		defer directTS.Close()
+
+		jina := &JinaFetcher{HTTPClient: jinaTS.Client(), BaseURL: jinaTS.URL + "/"}
+		e := newStubExtractor(directTS, jina, Result{Name: "商品名", ImageURL: ""})
+
+		got, err := e.Extract(context.Background(), directTS.URL)
+		require.NoError(t, err)
+		assert.Equal(t, "商品名", got.Name)
+		assert.Equal(t, "https://cdn.example.com/p.jpg", got.ImageURL, "should use Jina's image")
+		assert.Equal(t, 1, jinaCallCount, "Jina should be called to supplement")
+	})
+
+	// jina_fallback_long_name_generates_candidates verifies that when the direct
+	// fetch fails and the Jina-path Claude extraction returns a name >= 25 runes, GenerateCandidates
+	// is called and NameCandidates is set on the result.
+	t.Run("jina_fallback_long_name_generates_candidates", func(t *testing.T) {
+		directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "blocked", http.StatusInternalServerError)
+		}))
+		defer directTS.Close()
+
+		jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintln(w, `{"code":200,"data":{"title":"Jina商品名","content":"jina page text","images":{}}}`)
+		}))
+		defer jinaTS.Close()
+
+		longName := "これは25文字以上の長い商品タイトルですよJina経由"
+		wantCandidates := []string{"Jina候補1", "Jina候補2"}
+		fake := &ClaudeExtractor{
+			extractFn: func(_ context.Context, _ string, _ Result) (Result, error) {
+				return Result{Name: longName}, nil
+			},
+			generateFn: func(_ context.Context, _ string) ([]string, error) {
+				return wantCandidates, nil
+			},
+		}
+		jina := &JinaFetcher{HTTPClient: jinaTS.Client(), BaseURL: jinaTS.URL + "/"}
+		e := NewDefaultExtractorWithDeps(&Fetcher{HTTPClient: directTS.Client()}, jina, fake)
+
+		got, err := e.Extract(context.Background(), directTS.URL)
+		require.NoError(t, err)
+		assert.Equal(t, longName, got.Name)
+		assert.Equal(t, wantCandidates, got.NameCandidates, "Jina fallback should generate candidates for long names")
+	})
 }
 
 // newStubExtractor builds a DefaultExtractor that uses a stub ClaudeExtractor returning a fixed Result.
@@ -215,72 +317,6 @@ func newStubExtractor(directTS *httptest.Server, jina *JinaFetcher, claudeResult
 	)
 }
 
-// TestDefaultExtractor_Step1ClaudeLongName_GeneratesCandidates verifies that when Step 1
-// Claude returns a name >= 25 runes, GenerateCandidates is called and NameCandidates is set.
-// Jina should NOT be called when an image is already present.
-func TestDefaultExtractor_Step1ClaudeLongName_GeneratesCandidates(t *testing.T) {
-	jinaCallCount := 0
-	jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		jinaCallCount++
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintln(w, `{"code":200,"data":{"title":"短い商品名","content":"","images":{"https://cdn.example.com/p.jpg":"画像"}}}`)
-	}))
-	defer jinaTS.Close()
-
-	directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = fmt.Fprintln(w, `<html><head><meta property="og:title" content="長い商品名 | サイト名 - ブランド名 - カテゴリ名"></head></html>`)
-	}))
-	defer directTS.Close()
-
-	longName := "これは25文字以上の長い商品タイトルですよ追加テキスト" // 26 runes
-	wantCandidates := []string{"候補1", "候補2", "候補3"}
-	fake := &ClaudeExtractor{
-		extractFn: func(_ context.Context, _ string, _ Result) (Result, error) {
-			return Result{Name: longName, ImageURL: "https://meta.example.com/img.jpg"}, nil
-		},
-		generateFn: func(_ context.Context, _ string) ([]string, error) {
-			return wantCandidates, nil
-		},
-	}
-	jina := &JinaFetcher{HTTPClient: jinaTS.Client(), BaseURL: jinaTS.URL + "/"}
-	e := NewDefaultExtractorWithDeps(&Fetcher{HTTPClient: directTS.Client()}, jina, fake)
-
-	got, err := e.Extract(context.Background(), directTS.URL)
-	require.NoError(t, err)
-	assert.Equal(t, longName, got.Name, "original long name is preserved")
-	assert.Equal(t, wantCandidates, got.NameCandidates, "candidates from GenerateCandidates should be set")
-	assert.Equal(t, "https://meta.example.com/img.jpg", got.ImageURL)
-	assert.Equal(t, 0, jinaCallCount, "Jina should NOT be called when image is already present")
-}
-
-// TestDefaultExtractor_Step1ClaudeNoImage_SupplementsFromJina verifies that when Step 1
-// Claude returns no imageURL, the extractor also calls Jina to obtain an image.
-func TestDefaultExtractor_Step1ClaudeNoImage_SupplementsFromJina(t *testing.T) {
-	jinaCallCount := 0
-	jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		jinaCallCount++
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintln(w, `{"code":200,"data":{"title":"商品名","content":"","images":{"https://cdn.example.com/p.jpg":"画像"}}}`)
-	}))
-	defer jinaTS.Close()
-
-	directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = fmt.Fprintln(w, `<html><body>product page</body></html>`)
-	}))
-	defer directTS.Close()
-
-	jina := &JinaFetcher{HTTPClient: jinaTS.Client(), BaseURL: jinaTS.URL + "/"}
-	e := newStubExtractor(directTS, jina, Result{Name: "商品名", ImageURL: ""})
-
-	got, err := e.Extract(context.Background(), directTS.URL)
-	require.NoError(t, err)
-	assert.Equal(t, "商品名", got.Name)
-	assert.Equal(t, "https://cdn.example.com/p.jpg", got.ImageURL, "should use Jina's image")
-	assert.Equal(t, 1, jinaCallCount, "Jina should be called to supplement")
-}
-
 // collectSteps records progress steps emitted by ExtractWithProgress.
 func collectSteps(t *testing.T, e *DefaultExtractor, url string) []string {
 	t.Helper()
@@ -292,106 +328,74 @@ func collectSteps(t *testing.T, e *DefaultExtractor, url string) []string {
 	return steps
 }
 
-// TestDefaultExtractor_JinaFallback_LongName_GeneratesCandidates verifies that when the direct
-// fetch fails and the Jina-path Claude extraction returns a name >= 25 runes, GenerateCandidates
-// is called and NameCandidates is set on the result.
-func TestDefaultExtractor_JinaFallback_LongName_GeneratesCandidates(t *testing.T) {
-	directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "blocked", http.StatusInternalServerError)
-	}))
-	defer directTS.Close()
+func TestExtractWithProgress(t *testing.T) {
+	// normal_path verifies that fetching and extracting steps are reported
+	// when the direct fetch succeeds and og:title is found (no Claude).
+	t.Run("normal_path", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = fmt.Fprintln(w, `<html><head>
+				<meta property="og:title" content="テスト商品">
+				<meta property="og:image" content="https://example.com/img.jpg">
+			</head></html>`)
+		}))
+		defer ts.Close()
 
-	jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintln(w, `{"code":200,"data":{"title":"Jina商品名","content":"jina page text","images":{}}}`)
-	}))
-	defer jinaTS.Close()
+		e := newTestExtractor(ts, nil, nil)
+		steps := collectSteps(t, e, ts.URL)
 
-	longName := "これは25文字以上の長い商品タイトルですよJina経由"
-	wantCandidates := []string{"Jina候補1", "Jina候補2"}
-	fake := &ClaudeExtractor{
-		extractFn: func(_ context.Context, _ string, _ Result) (Result, error) {
-			return Result{Name: longName}, nil
-		},
-		generateFn: func(_ context.Context, _ string) ([]string, error) {
-			return wantCandidates, nil
-		},
-	}
-	jina := &JinaFetcher{HTTPClient: jinaTS.Client(), BaseURL: jinaTS.URL + "/"}
-	e := NewDefaultExtractorWithDeps(&Fetcher{HTTPClient: directTS.Client()}, jina, fake)
+		assert.Contains(t, steps, "fetching")
+	})
 
-	got, err := e.Extract(context.Background(), directTS.URL)
-	require.NoError(t, err)
-	assert.Equal(t, longName, got.Name)
-	assert.Equal(t, wantCandidates, got.NameCandidates, "Jina fallback should generate candidates for long names")
-}
+	// fetching_jina verifies that fetching_jina is reported when step1 fails.
+	t.Run("fetching_jina", func(t *testing.T) {
+		directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "blocked", http.StatusInternalServerError)
+		}))
+		defer directTS.Close()
 
-// TestExtractWithProgress_NormalPath verifies that fetching and extracting steps are reported
-// when the direct fetch succeeds and og:title is found (no Claude).
-func TestExtractWithProgress_NormalPath(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = fmt.Fprintln(w, `<html><head>
-			<meta property="og:title" content="テスト商品">
-			<meta property="og:image" content="https://example.com/img.jpg">
-		</head></html>`)
-	}))
-	defer ts.Close()
+		jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintln(w, `{"code":200,"data":{"title":"Jina商品","content":"","images":{}}}`)
+		}))
+		defer jinaTS.Close()
 
-	e := newTestExtractor(ts, nil, nil)
-	steps := collectSteps(t, e, ts.URL)
+		jina := &JinaFetcher{HTTPClient: jinaTS.Client(), BaseURL: jinaTS.URL + "/"}
+		e := NewDefaultExtractorWithDeps(&Fetcher{HTTPClient: directTS.Client()}, jina, nil)
+		steps := collectSteps(t, e, directTS.URL)
 
-	assert.Contains(t, steps, "fetching")
-}
+		assert.Equal(t, []string{"fetching", "fetching_jina"}, steps)
+	})
 
-// TestExtractWithProgress_FetchingJina verifies that fetching_jina is reported when step1 fails.
-func TestExtractWithProgress_FetchingJina(t *testing.T) {
-	directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "blocked", http.StatusInternalServerError)
-	}))
-	defer directTS.Close()
+	// generating_candidates verifies that generating_candidates is reported
+	// when the name from Claude is >= 25 runes.
+	t.Run("generating_candidates", func(t *testing.T) {
+		directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = fmt.Fprintln(w, `<html><body>product page</body></html>`)
+		}))
+		defer directTS.Close()
 
-	jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintln(w, `{"code":200,"data":{"title":"Jina商品","content":"","images":{}}}`)
-	}))
-	defer jinaTS.Close()
+		jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintln(w, `{"code":200,"data":{"title":"短い名前","content":"","images":{"https://img.example.com/p.jpg":"画像"}}}`)
+		}))
+		defer jinaTS.Close()
 
-	jina := &JinaFetcher{HTTPClient: jinaTS.Client(), BaseURL: jinaTS.URL + "/"}
-	e := NewDefaultExtractorWithDeps(&Fetcher{HTTPClient: directTS.Client()}, jina, nil)
-	steps := collectSteps(t, e, directTS.URL)
+		longName := "これは25文字以上の長い商品タイトルですよ追加テキスト" // >= 25 runes
+		fake := &ClaudeExtractor{
+			extractFn: func(_ context.Context, _ string, _ Result) (Result, error) {
+				return Result{Name: longName}, nil
+			},
+			generateFn: func(_ context.Context, _ string) ([]string, error) {
+				return []string{"候補1"}, nil
+			},
+		}
+		jina := &JinaFetcher{HTTPClient: jinaTS.Client(), BaseURL: jinaTS.URL + "/"}
+		e := NewDefaultExtractorWithDeps(&Fetcher{HTTPClient: directTS.Client()}, jina, fake)
+		steps := collectSteps(t, e, directTS.URL)
 
-	assert.Equal(t, []string{"fetching", "fetching_jina"}, steps)
-}
-
-// TestExtractWithProgress_GeneratingCandidates verifies that generating_candidates is reported
-// when the name from Claude is >= 25 runes.
-func TestExtractWithProgress_GeneratingCandidates(t *testing.T) {
-	directTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = fmt.Fprintln(w, `<html><body>product page</body></html>`)
-	}))
-	defer directTS.Close()
-
-	jinaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintln(w, `{"code":200,"data":{"title":"短い名前","content":"","images":{"https://img.example.com/p.jpg":"画像"}}}`)
-	}))
-	defer jinaTS.Close()
-
-	longName := "これは25文字以上の長い商品タイトルですよ追加テキスト" // >= 25 runes
-	fake := &ClaudeExtractor{
-		extractFn: func(_ context.Context, _ string, _ Result) (Result, error) {
-			return Result{Name: longName}, nil
-		},
-		generateFn: func(_ context.Context, _ string) ([]string, error) {
-			return []string{"候補1"}, nil
-		},
-	}
-	jina := &JinaFetcher{HTTPClient: jinaTS.Client(), BaseURL: jinaTS.URL + "/"}
-	e := NewDefaultExtractorWithDeps(&Fetcher{HTTPClient: directTS.Client()}, jina, fake)
-	steps := collectSteps(t, e, directTS.URL)
-
-	assert.Contains(t, steps, "generating_candidates")
-	assert.Contains(t, steps, "extracting")
+		assert.Contains(t, steps, "generating_candidates")
+		assert.Contains(t, steps, "extracting")
+	})
 }

--- a/backend/urlextract/jina_fetcher_test.go
+++ b/backend/urlextract/jina_fetcher_test.go
@@ -19,53 +19,55 @@ func newTestJinaFetcher(ts *httptest.Server) *JinaFetcher {
 	}
 }
 
-func TestJinaFetcher_SuccessfulParse(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintln(w, `{
-			"code": 200,
-			"data": {
-				"title": "商品名 | 楽天市場",
-				"content": "# 商品名\nこれは商品の説明です。",
-				"images": {
-					"https://example.com/img1.jpg": "商品画像1",
-					"https://example.com/img2.jpg": "商品画像2"
+func TestJinaFetcher(t *testing.T) {
+	t.Run("successful_parse", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintln(w, `{
+				"code": 200,
+				"data": {
+					"title": "商品名 | 楽天市場",
+					"content": "# 商品名\nこれは商品の説明です。",
+					"images": {
+						"https://example.com/img1.jpg": "商品画像1",
+						"https://example.com/img2.jpg": "商品画像2"
+					}
 				}
-			}
-		}`)
-	}))
-	defer ts.Close()
+			}`)
+		}))
+		defer ts.Close()
 
-	f := newTestJinaFetcher(ts)
-	got, err := f.Fetch(context.Background(), "https://product.example.com/item/123")
-	require.NoError(t, err)
-	assert.Equal(t, "商品名 | 楽天市場", got.Title)
-	assert.Contains(t, got.Content, "商品名")
-	assert.Len(t, got.Images, 2)
-	assert.Contains(t, got.Images, "https://example.com/img1.jpg")
-}
+		f := newTestJinaFetcher(ts)
+		got, err := f.Fetch(context.Background(), "https://product.example.com/item/123")
+		require.NoError(t, err)
+		assert.Equal(t, "商品名 | 楽天市場", got.Title)
+		assert.Contains(t, got.Content, "商品名")
+		assert.Len(t, got.Images, 2)
+		assert.Contains(t, got.Images, "https://example.com/img1.jpg")
+	})
 
-func TestJinaFetcher_Non200Response_ReturnsErrFetchFailed(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "rate limited", http.StatusTooManyRequests)
-	}))
-	defer ts.Close()
+	t.Run("non_200_response_returns_err_fetch_failed", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "rate limited", http.StatusTooManyRequests)
+		}))
+		defer ts.Close()
 
-	f := newTestJinaFetcher(ts)
-	_, err := f.Fetch(context.Background(), "https://product.example.com/item/123")
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrFetchFailed))
-}
+		f := newTestJinaFetcher(ts)
+		_, err := f.Fetch(context.Background(), "https://product.example.com/item/123")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrFetchFailed))
+	})
 
-func TestJinaFetcher_MalformedJSON_ReturnsErrFetchFailed(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintln(w, `{not valid json}`)
-	}))
-	defer ts.Close()
+	t.Run("malformed_json_returns_err_fetch_failed", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintln(w, `{not valid json}`)
+		}))
+		defer ts.Close()
 
-	f := newTestJinaFetcher(ts)
-	_, err := f.Fetch(context.Background(), "https://product.example.com/item/123")
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrFetchFailed))
+		f := newTestJinaFetcher(ts)
+		_, err := f.Fetch(context.Background(), "https://product.example.com/item/123")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrFetchFailed))
+	})
 }

--- a/backend/urlextract/meta_parser_test.go
+++ b/backend/urlextract/meta_parser_test.go
@@ -6,96 +6,98 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseMeta_OGTitleAndImage(t *testing.T) {
-	html := []byte(`<html><head>
-		<meta property="og:title" content="テスト商品">
-		<meta property="og:image" content="https://example.com/img.jpg">
-	</head></html>`)
-	got := ParseMeta(html, "https://example.com")
-	assert.Equal(t, "テスト商品", got.Name)
-	assert.Equal(t, "https://example.com/img.jpg", got.ImageURL)
-}
+func TestParseMeta(t *testing.T) {
+	t.Run("og_title_and_image", func(t *testing.T) {
+		html := []byte(`<html><head>
+			<meta property="og:title" content="テスト商品">
+			<meta property="og:image" content="https://example.com/img.jpg">
+		</head></html>`)
+		got := ParseMeta(html, "https://example.com")
+		assert.Equal(t, "テスト商品", got.Name)
+		assert.Equal(t, "https://example.com/img.jpg", got.ImageURL)
+	})
 
-func TestParseMeta_OGTitleOnly(t *testing.T) {
-	html := []byte(`<html><head>
-		<meta property="og:title" content="商品名のみ">
-	</head></html>`)
-	got := ParseMeta(html, "https://example.com")
-	assert.Equal(t, "商品名のみ", got.Name)
-	assert.Equal(t, "", got.ImageURL)
-}
+	t.Run("og_title_only", func(t *testing.T) {
+		html := []byte(`<html><head>
+			<meta property="og:title" content="商品名のみ">
+		</head></html>`)
+		got := ParseMeta(html, "https://example.com")
+		assert.Equal(t, "商品名のみ", got.Name)
+		assert.Equal(t, "", got.ImageURL)
+	})
 
-func TestParseMeta_RelativeImageURL(t *testing.T) {
-	html := []byte(`<html><head>
-		<meta property="og:title" content="相対パス商品">
-		<meta property="og:image" content="/images/product.png">
-	</head></html>`)
-	got := ParseMeta(html, "https://example.com/shop/")
-	assert.Equal(t, "相対パス商品", got.Name)
-	assert.Equal(t, "https://example.com/images/product.png", got.ImageURL)
-}
+	t.Run("relative_image_url", func(t *testing.T) {
+		html := []byte(`<html><head>
+			<meta property="og:title" content="相対パス商品">
+			<meta property="og:image" content="/images/product.png">
+		</head></html>`)
+		got := ParseMeta(html, "https://example.com/shop/")
+		assert.Equal(t, "相対パス商品", got.Name)
+		assert.Equal(t, "https://example.com/images/product.png", got.ImageURL)
+	})
 
-func TestParseMeta_SchemaOrgProduct(t *testing.T) {
-	html := []byte(`<html><head>
-		<script type="application/ld+json">
-		{
-			"@context": "https://schema.org",
-			"@type": "Product",
-			"name": "スキーマ商品",
-			"image": "https://example.com/schema-img.jpg"
-		}
-		</script>
-	</head></html>`)
-	got := ParseMeta(html, "https://example.com")
-	assert.Equal(t, "スキーマ商品", got.Name)
-	assert.Equal(t, "https://example.com/schema-img.jpg", got.ImageURL)
-}
+	t.Run("schema_org_product", func(t *testing.T) {
+		html := []byte(`<html><head>
+			<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "Product",
+				"name": "スキーマ商品",
+				"image": "https://example.com/schema-img.jpg"
+			}
+			</script>
+		</head></html>`)
+		got := ParseMeta(html, "https://example.com")
+		assert.Equal(t, "スキーマ商品", got.Name)
+		assert.Equal(t, "https://example.com/schema-img.jpg", got.ImageURL)
+	})
 
-func TestParseMeta_SchemaOrgImageAsObject(t *testing.T) {
-	html := []byte(`<html><head>
-		<script type="application/ld+json">
-		{
-			"@context": "https://schema.org",
-			"@type": "Product",
-			"name": "オブジェクト画像商品",
-			"image": {"@type": "ImageObject", "url": "https://example.com/obj-img.jpg"}
-		}
-		</script>
-	</head></html>`)
-	got := ParseMeta(html, "https://example.com")
-	assert.Equal(t, "オブジェクト画像商品", got.Name)
-	assert.Equal(t, "https://example.com/obj-img.jpg", got.ImageURL)
-}
+	t.Run("schema_org_image_as_object", func(t *testing.T) {
+		html := []byte(`<html><head>
+			<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "Product",
+				"name": "オブジェクト画像商品",
+				"image": {"@type": "ImageObject", "url": "https://example.com/obj-img.jpg"}
+			}
+			</script>
+		</head></html>`)
+		got := ParseMeta(html, "https://example.com")
+		assert.Equal(t, "オブジェクト画像商品", got.Name)
+		assert.Equal(t, "https://example.com/obj-img.jpg", got.ImageURL)
+	})
 
-func TestParseMeta_SchemaOrgTypeArray(t *testing.T) {
-	html := []byte(`<html><head>
-		<script type="application/ld+json">
-		{
-			"@context": "https://schema.org",
-			"@type": ["Product", "Thing"],
-			"name": "型配列商品",
-			"image": "https://example.com/array-type-img.jpg"
-		}
-		</script>
-	</head></html>`)
-	got := ParseMeta(html, "https://example.com")
-	assert.Equal(t, "型配列商品", got.Name)
-	assert.Equal(t, "https://example.com/array-type-img.jpg", got.ImageURL)
-}
+	t.Run("schema_org_type_array", func(t *testing.T) {
+		html := []byte(`<html><head>
+			<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": ["Product", "Thing"],
+				"name": "型配列商品",
+				"image": "https://example.com/array-type-img.jpg"
+			}
+			</script>
+		</head></html>`)
+		got := ParseMeta(html, "https://example.com")
+		assert.Equal(t, "型配列商品", got.Name)
+		assert.Equal(t, "https://example.com/array-type-img.jpg", got.ImageURL)
+	})
 
-func TestParseMeta_NoMetaTags(t *testing.T) {
-	html := []byte(`<html><head><title>ページタイトル</title></head><body>本文</body></html>`)
-	got := ParseMeta(html, "https://example.com")
-	assert.Equal(t, Result{}, got)
-}
+	t.Run("no_meta_tags", func(t *testing.T) {
+		html := []byte(`<html><head><title>ページタイトル</title></head><body>本文</body></html>`)
+		got := ParseMeta(html, "https://example.com")
+		assert.Equal(t, Result{}, got)
+	})
 
-func TestParseMeta_MalformedJSONLD(t *testing.T) {
-	html := []byte(`<html><head>
-		<script type="application/ld+json">
-		{ this is not valid json !!!
-		</script>
-	</head></html>`)
-	// Must not panic and must return empty Result
-	got := ParseMeta(html, "https://example.com")
-	assert.Equal(t, Result{}, got)
+	t.Run("malformed_jsonld", func(t *testing.T) {
+		html := []byte(`<html><head>
+			<script type="application/ld+json">
+			{ this is not valid json !!!
+			</script>
+		</head></html>`)
+		// Must not panic and must return empty Result
+		got := ParseMeta(html, "https://example.com")
+		assert.Equal(t, Result{}, got)
+	})
 }

--- a/frontend/e2e/health.spec.ts
+++ b/frontend/e2e/health.spec.ts
@@ -1,8 +1,12 @@
 import { expect, test } from "@playwright/test";
 
-test("health check page shows ok and connected", async ({ page }) => {
-  await page.goto("/health");
+test.describe("ヘルスチェック", () => {
+  test("ヘルスチェックページが ok と connected を表示する", async ({
+    page,
+  }) => {
+    await page.goto("/health");
 
-  await expect(page.getByText("ok")).toBeVisible();
-  await expect(page.getByText("connected")).toBeVisible();
+    await expect(page.getByText("ok")).toBeVisible();
+    await expect(page.getByText("connected")).toBeVisible();
+  });
 });

--- a/frontend/e2e/stock-items.spec.ts
+++ b/frontend/e2e/stock-items.spec.ts
@@ -1,140 +1,146 @@
 import { expect, test } from "@playwright/test";
 
-test("商品を登録して削除できる", async ({ page }) => {
-  const itemName = `醤油-${Date.now()}`;
+test.describe("商品管理", () => {
+  test("商品を登録して削除できる", async ({ page }) => {
+    const itemName = `醤油-${Date.now()}`;
 
-  await page.goto("/stock-items");
+    await page.goto("/stock-items");
 
-  // 商品登録
-  await page.getByRole("button", { name: "商品を追加" }).click();
-  const dialog = page.getByRole("dialog");
-  await dialog.getByLabel("名前").fill(itemName);
-  await dialog.getByLabel("カテゴリ", { exact: true }).selectOption("調味料");
-  await dialog.getByRole("button", { name: "追加", exact: true }).click();
+    // 商品登録
+    await page.getByRole("button", { name: "商品を追加" }).click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByLabel("名前").fill(itemName);
+    await dialog.getByLabel("カテゴリ", { exact: true }).selectOption("調味料");
+    await dialog.getByRole("button", { name: "追加", exact: true }).click();
 
-  // 登録した商品が表示されていることを確認
-  await expect(page.getByText(itemName)).toBeVisible();
+    // 登録した商品が表示されていることを確認
+    await expect(page.getByText(itemName)).toBeVisible();
 
-  // 商品を削除
-  await page
-    .getByRole("article", { name: itemName })
-    .getByRole("button", { name: "削除" })
-    .click();
-  // ConfirmDialog opens — click the confirm button
-  await page.getByRole("button", { name: "確認" }).click();
-  // Wait for exit animation to finish
-  await expect(page.getByRole("dialog")).not.toBeAttached();
-
-  // 商品が削除されていることを確認
-  await expect(page.getByText(itemName)).not.toBeVisible();
-});
-
-// Scenario: D-1
-test("商品の名前を編集できる", async ({ page }) => {
-  const itemName = `テスト商品-${Date.now()}`;
-  const newItemName = `編集済み商品-${Date.now()}`;
-
-  await page.goto("/stock-items");
-
-  // 商品登録
-  await page.getByRole("button", { name: "商品を追加" }).click();
-  const createDialog = page.getByRole("dialog");
-  await createDialog.getByLabel("名前").fill(itemName);
-  await createDialog
-    .getByLabel("カテゴリ", { exact: true })
-    .selectOption("調味料");
-  await createDialog.getByRole("button", { name: "追加", exact: true }).click();
-
-  // 登録した商品が表示されていることを確認
-  await expect(page.getByText(itemName)).toBeVisible();
-  // Wait for modal exit animation to finish before opening EditItemModal
-  await expect(page.getByRole("dialog")).not.toBeAttached();
-
-  // 編集ボタン（カテゴリ+名前テキストを含むボタン）をクリック
-  await page
-    .getByRole("article", { name: itemName })
-    .getByRole("button", { name: new RegExp(itemName) })
-    .click();
-
-  // EditItemModal で名前を変更して保存
-  const editDialog = page.getByRole("dialog");
-  await editDialog.getByLabel("名前").fill(newItemName);
-  await editDialog.getByRole("button", { name: "保存" }).click();
-
-  // 新しい名前が表示されていることを確認
-  await expect(page.getByText(newItemName)).toBeVisible();
-
-  // クリーンアップ: 商品を削除
-  await page
-    .getByRole("article", { name: newItemName })
-    .getByRole("button", { name: "削除" })
-    .click();
-  // ConfirmDialog opens — click the confirm button
-  await page.getByRole("button", { name: "確認" }).click();
-  await expect(page.getByRole("dialog")).not.toBeAttached();
-
-  await expect(page.getByText(newItemName)).not.toBeVisible();
-});
-
-// Scenario: D-2
-test("商品のカテゴリを編集できる", async ({ page }) => {
-  const itemName = `カテゴリ変更テスト-${Date.now()}`;
-  const initialCategory = "調味料";
-  const newCategory = "飲み物";
-
-  await page.goto("/stock-items");
-
-  // 商品登録
-  await page.getByRole("button", { name: "商品を追加" }).click();
-  const createDialog = page.getByRole("dialog");
-  await createDialog.getByLabel("名前").fill(itemName);
-  await createDialog
-    .getByLabel("カテゴリ", { exact: true })
-    .selectOption(initialCategory);
-  await createDialog.getByRole("button", { name: "追加", exact: true }).click();
-
-  // 登録した商品が表示されていることを確認
-  await expect(page.getByText(itemName)).toBeVisible();
-  // Wait for modal exit animation to finish before opening EditItemModal
-  await expect(page.getByRole("dialog")).not.toBeAttached();
-
-  // 編集ボタンをクリック
-  await page
-    .getByRole("article", { name: itemName })
-    .getByRole("button", { name: new RegExp(itemName) })
-    .click();
-
-  // EditItemModal でカテゴリを変更して保存
-  const editDialog = page.getByRole("dialog");
-  await editDialog.getByLabel("カテゴリ").selectOption(newCategory);
-  await editDialog.getByRole("button", { name: "保存" }).click();
-
-  // 新しいカテゴリバッジが表示されていることを確認
-  await expect(
-    page
+    // 商品を削除
+    await page
       .getByRole("article", { name: itemName })
-      .getByText(newCategory, { exact: true }),
-  ).toBeVisible();
+      .getByRole("button", { name: "削除" })
+      .click();
+    // ConfirmDialog opens — click the confirm button
+    await page.getByRole("button", { name: "確認" }).click();
+    // Wait for exit animation to finish
+    await expect(page.getByRole("dialog")).not.toBeAttached();
 
-  // クリーンアップ: 商品を削除
-  await page
-    .getByRole("article", { name: itemName })
-    .getByRole("button", { name: "削除" })
-    .click();
-  // ConfirmDialog opens — click the confirm button
-  await page.getByRole("button", { name: "確認" }).click();
-  await expect(page.getByRole("dialog")).not.toBeAttached();
+    // 商品が削除されていることを確認
+    await expect(page.getByText(itemName)).not.toBeVisible();
+  });
 
-  await expect(page.getByText(itemName)).not.toBeVisible();
-});
+  // Scenario: D-1
+  test("商品の名前を編集できる", async ({ page }) => {
+    const itemName = `テスト商品-${Date.now()}`;
+    const newItemName = `編集済み商品-${Date.now()}`;
 
-// Scenario: K-4
-test("ログアウトボタンを押すとログインページに遷移する", async ({ page }) => {
-  await page.goto("/stock-items");
+    await page.goto("/stock-items");
 
-  // サインアウトボタンをクリック
-  await page.getByRole("button", { name: "サインアウト" }).click();
+    // 商品登録
+    await page.getByRole("button", { name: "商品を追加" }).click();
+    const createDialog = page.getByRole("dialog");
+    await createDialog.getByLabel("名前").fill(itemName);
+    await createDialog
+      .getByLabel("カテゴリ", { exact: true })
+      .selectOption("調味料");
+    await createDialog
+      .getByRole("button", { name: "追加", exact: true })
+      .click();
 
-  // ログインページに遷移することを確認
-  await expect(page).toHaveURL(/\/login/);
+    // 登録した商品が表示されていることを確認
+    await expect(page.getByText(itemName)).toBeVisible();
+    // Wait for modal exit animation to finish before opening EditItemModal
+    await expect(page.getByRole("dialog")).not.toBeAttached();
+
+    // 編集ボタン（カテゴリ+名前テキストを含むボタン）をクリック
+    await page
+      .getByRole("article", { name: itemName })
+      .getByRole("button", { name: new RegExp(itemName) })
+      .click();
+
+    // EditItemModal で名前を変更して保存
+    const editDialog = page.getByRole("dialog");
+    await editDialog.getByLabel("名前").fill(newItemName);
+    await editDialog.getByRole("button", { name: "保存" }).click();
+
+    // 新しい名前が表示されていることを確認
+    await expect(page.getByText(newItemName)).toBeVisible();
+
+    // クリーンアップ: 商品を削除
+    await page
+      .getByRole("article", { name: newItemName })
+      .getByRole("button", { name: "削除" })
+      .click();
+    // ConfirmDialog opens — click the confirm button
+    await page.getByRole("button", { name: "確認" }).click();
+    await expect(page.getByRole("dialog")).not.toBeAttached();
+
+    await expect(page.getByText(newItemName)).not.toBeVisible();
+  });
+
+  // Scenario: D-2
+  test("商品のカテゴリを編集できる", async ({ page }) => {
+    const itemName = `カテゴリ変更テスト-${Date.now()}`;
+    const initialCategory = "調味料";
+    const newCategory = "飲み物";
+
+    await page.goto("/stock-items");
+
+    // 商品登録
+    await page.getByRole("button", { name: "商品を追加" }).click();
+    const createDialog = page.getByRole("dialog");
+    await createDialog.getByLabel("名前").fill(itemName);
+    await createDialog
+      .getByLabel("カテゴリ", { exact: true })
+      .selectOption(initialCategory);
+    await createDialog
+      .getByRole("button", { name: "追加", exact: true })
+      .click();
+
+    // 登録した商品が表示されていることを確認
+    await expect(page.getByText(itemName)).toBeVisible();
+    // Wait for modal exit animation to finish before opening EditItemModal
+    await expect(page.getByRole("dialog")).not.toBeAttached();
+
+    // 編集ボタンをクリック
+    await page
+      .getByRole("article", { name: itemName })
+      .getByRole("button", { name: new RegExp(itemName) })
+      .click();
+
+    // EditItemModal でカテゴリを変更して保存
+    const editDialog = page.getByRole("dialog");
+    await editDialog.getByLabel("カテゴリ").selectOption(newCategory);
+    await editDialog.getByRole("button", { name: "保存" }).click();
+
+    // 新しいカテゴリバッジが表示されていることを確認
+    await expect(
+      page
+        .getByRole("article", { name: itemName })
+        .getByText(newCategory, { exact: true }),
+    ).toBeVisible();
+
+    // クリーンアップ: 商品を削除
+    await page
+      .getByRole("article", { name: itemName })
+      .getByRole("button", { name: "削除" })
+      .click();
+    // ConfirmDialog opens — click the confirm button
+    await page.getByRole("button", { name: "確認" }).click();
+    await expect(page.getByRole("dialog")).not.toBeAttached();
+
+    await expect(page.getByText(itemName)).not.toBeVisible();
+  });
+
+  // Scenario: K-4
+  test("ログアウトボタンを押すとログインページに遷移する", async ({ page }) => {
+    await page.goto("/stock-items");
+
+    // サインアウトボタンをクリック
+    await page.getByRole("button", { name: "サインアウト" }).click();
+
+    // ログインページに遷移することを確認
+    await expect(page).toHaveURL(/\/login/);
+  });
 });

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -98,7 +98,7 @@ describe("fetchStockItems", () => {
     );
   });
 
-  it("sends X-Active-Group-ID header when activeGroupId provided", async () => {
+  it("activeGroupId を渡すと X-Active-Group-ID ヘッダーが付加される", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(JSON.stringify([]), { status: 200 }),
     );

--- a/frontend/src/lib/authApi.test.ts
+++ b/frontend/src/lib/authApi.test.ts
@@ -11,7 +11,7 @@ afterEach(() => {
 });
 
 describe("fetchMyGroups", () => {
-  it("returns group list on success", async () => {
+  it("成功時にグループ一覧を返す", async () => {
     const groups = [{ groupId: "g1", name: "我が家", role: "owner" }];
     vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(JSON.stringify(groups), { status: 200 }),
@@ -20,14 +20,14 @@ describe("fetchMyGroups", () => {
     expect(result).toEqual(groups);
   });
 
-  it("returns empty array on 404", async () => {
+  it("404 のとき空配列を返す", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(null, { status: 404 }),
     );
     expect(await fetchMyGroups("token")).toEqual([]);
   });
 
-  it("returns empty array on 403", async () => {
+  it("403 のとき空配列を返す", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(null, { status: 403 }),
     );
@@ -36,7 +36,7 @@ describe("fetchMyGroups", () => {
 });
 
 describe("createGroup", () => {
-  it("sends POST and returns created group", async () => {
+  it("POST を送信して作成されたグループを返す", async () => {
     const created = {
       id: "g1",
       name: "我が家",
@@ -55,7 +55,7 @@ describe("createGroup", () => {
 });
 
 describe("updateGroupName", () => {
-  it("sends PATCH with X-Active-Group-ID header", async () => {
+  it("X-Active-Group-ID ヘッダー付きで PATCH を送信する", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(JSON.stringify({}), { status: 200 }),
     );
@@ -67,7 +67,7 @@ describe("updateGroupName", () => {
     expect(headers["X-Active-Group-ID"]).toBe("g1");
   });
 
-  it("throws on error response", async () => {
+  it("エラーレスポンス時に throw する", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(null, { status: 403 }),
     );
@@ -78,7 +78,7 @@ describe("updateGroupName", () => {
 });
 
 describe("createInvitation", () => {
-  it("sends X-Active-Group-ID header", async () => {
+  it("X-Active-Group-ID ヘッダーを送信する", async () => {
     const inv = {
       token: "t1",
       groupId: "g1",


### PR DESCRIPTION
Closes #175

## Summary

- **Frontend (Vitest)**: `authApi.test.ts` の全テスト名を英語→日本語に統一。`api.test.ts` の混在していた 1 件も日本語に
- **E2E (Playwright)**: `health.spec.ts` のテスト名を日本語化 + `test.describe` ラッパー追加。`stock-items.spec.ts` に `test.describe("商品管理")` ラッパーを追加
- **Backend (Go)**: `handler/`, `middleware/`, `urlextract/`, `imagesearch/`, `repository/`, `learning/websocket/` の flat 関数羅列を `t.Run` グルーピングに統一

## Test plan

- [ ] `cd frontend && npx vitest run` が pass する
- [ ] `cd backend && go test ./...` が pass する
- [ ] CI (golangci-lint / Vitest / go test) が pass する

🤖 Generated with [Claude Code](https://claude.com/claude-code)