### PR TITLE
ci: track Playwright container image in workflows via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,17 @@ updates:
         update-types:
           - minor
           - patch
+
+  - package-ecosystem: docker
+    directory: /.github/workflows
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

- `dependabot.yml` に `package-ecosystem: docker` + `directory: /.github/workflows` エントリを追加
- これにより Dependabot がワークフロー内の `container: image:` タグ（Playwright など）を自動追跡し、npm パッケージの更新と同期した PR を作成する

## 背景

PR #188 で Dependabot が `@playwright/test` を `1.59.1 → 1.60.0` に更新したが、`.github/workflows/` の Docker image タグは自動更新されず、E2E が全滅した。今後は Dependabot が image タグの更新 PR も作成するため、手動修正が不要になる。

Closes #189