### PR TITLE
fix: scope stock_items name uniqueness to group and propagate create errors

### DIFF
--- a/backend/db/migrations/011_fix_stock_items_name_unique_scope.sql
+++ b/backend/db/migrations/011_fix_stock_items_name_unique_scope.sql
@@ -1,0 +1,5 @@
+-- Scope the name uniqueness constraint to within a group instead of globally.
+-- Before: UNIQUE(name) — prevented same name across different groups (wrong)
+-- After:  UNIQUE(name, group_id) — allows same name in different groups
+ALTER TABLE stock_items DROP CONSTRAINT stock_items_name_key;
+ALTER TABLE stock_items ADD CONSTRAINT stock_items_name_group_id_key UNIQUE (name, group_id);

--- a/backend/repository/stock_item_test.go
+++ b/backend/repository/stock_item_test.go
@@ -52,7 +52,9 @@ func TestMain(m *testing.M) {
 		"../db/migrations/004_add_sorted_at_to_stock_items.sql",
 		"../db/migrations/005_add_groups.sql",
 		"../db/migrations/006_add_group_id_to_stock_items.sql",
+		"../db/migrations/008_stock_items_group_id_not_null.sql",
 		"../db/migrations/009_add_source_url_to_stock_items.sql",
+		"../db/migrations/011_fix_stock_items_name_unique_scope.sql",
 	} {
 		sqlBytes, err := os.ReadFile(migration)
 		if err != nil {
@@ -363,6 +365,22 @@ func TestDelete_NotFound(t *testing.T) {
 
 	err := repo.Delete(context.Background(), uuid.New(), groupID)
 	assert.Error(t, err, "should return error when deleting non-existent item")
+}
+
+func TestCreate_SameNameDifferentGroup(t *testing.T) {
+	pool, groupAID := setupTestDB(t)
+	repo := NewPgStockItemRepository(pool)
+
+	_, err := repo.Create(context.Background(), groupAID, "醤油", "調味料", nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	var groupBID uuid.UUID
+	err = pool.QueryRow(ctx, "INSERT INTO groups (name) VALUES ('グループB') RETURNING id").Scan(&groupBID)
+	require.NoError(t, err)
+
+	_, err = repo.Create(ctx, groupBID, "醤油", "調味料", nil, nil)
+	require.NoError(t, err, "same name in a different group should be allowed")
 }
 
 func TestList_OtherGroupItemsNotVisible(t *testing.T) {

--- a/frontend/src/app/stock-items/useStockItems.test.ts
+++ b/frontend/src/app/stock-items/useStockItems.test.ts
@@ -122,7 +122,7 @@ describe("useStockItems", () => {
       expect(result.current.items).toHaveLength(3);
     });
 
-    it("handleCreate が API エラーで error をセットする", async () => {
+    it("handleCreate が API エラーを caller に re-throw する（ページレベル error はセットしない）", async () => {
       vi.mocked(fetchStockItems).mockResolvedValue(mockItems);
       vi.mocked(createStockItem).mockRejectedValue(
         new Error("商品の追加に失敗しました"),
@@ -132,10 +132,13 @@ describe("useStockItems", () => {
       await waitFor(() => expect(result.current.loading).toBe(false));
 
       await act(async () => {
-        await result.current.handleCreate("塩", "調味料", false, null, null);
+        await expect(
+          result.current.handleCreate("塩", "調味料", false, null, null),
+        ).rejects.toThrow("商品の追加に失敗しました");
       });
 
-      expect(result.current.error).toBe("商品の追加に失敗しました");
+      // ページレベルエラー state は変更されない。モーダル側がエラーを表示する責務を持つ
+      expect(result.current.error).toBeNull();
       expect(result.current.items).toEqual(mockItems);
     });
   });

--- a/frontend/src/app/stock-items/useStockItems.ts
+++ b/frontend/src/app/stock-items/useStockItems.ts
@@ -105,26 +105,21 @@ export function useStockItems(
     imageUrl: string | null,
     sourceUrl: string | null,
   ): Promise<void> => {
-    try {
-      const created = await createStockItem(
-        { name, category, wantToBuy, sourceUrl: sourceUrl ?? undefined },
+    const created = await createStockItem(
+      { name, category, wantToBuy, sourceUrl: sourceUrl ?? undefined },
+      accessToken,
+      activeGroupId,
+    );
+    if (imageUrl) {
+      await updateStockItem(
+        created.id,
+        { imageUrl },
         accessToken,
         activeGroupId,
       );
-      if (imageUrl) {
-        await updateStockItem(
-          created.id,
-          { imageUrl },
-          accessToken,
-          activeGroupId,
-        );
-      }
-      const data = await fetchStockItems(accessToken, activeGroupId);
-      setItems(data);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "操作に失敗しました");
     }
+    const data = await fetchStockItems(accessToken, activeGroupId);
+    setItems(data);
   };
 
   const handleSave = async (name: string, category: string): Promise<void> => {


### PR DESCRIPTION
## Summary

- DB: `UNIQUE(name)` constraint (global) を `UNIQUE(name, group_id)` に変更する migration 011 を追加。別グループで同名商品の登録を許可
- Backend: `TestCreate_SameNameDifferentGroup` テストを追加。migration リストに 008・011 を追加
- Frontend: `handleCreate` の try/catch を除去。エラーを呼び出し元 (`CreateItemModal`) に伝播させることで、409 時に「その商品は登録済みです」がモーダル内に表示されるよう修正

## Root Cause

2 つのバグが複合していた:
1. `001_create_stock_items.sql` の `name TEXT NOT NULL UNIQUE` はグローバル制約。`group_id` 追加時に更新されなかった
2. `handleCreate` がエラーを catch して `setError()` に振り、Promise を常に resolved で返していた。その結果モーダルが閉じ、商品リストが「商品を取得できませんでした」に置き換わっていた

## Test plan

- [ ] `go test ./repository/` がすべて pass すること
- [ ] `npx vitest run` がすべて pass すること
- [ ] CI (GitHub Actions) がすべて green になること
- [ ] 本番 Supabase に migration 011 を手動適用すること（SQL Editor）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #192