### PR TITLE
test(e2e): isolate E2E test data per CI run with ephemeral group

### DIFF
--- a/.github/workflows/e2e-preview.yml
+++ b/.github/workflows/e2e-preview.yml
@@ -111,7 +111,8 @@ jobs:
           E2E_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
           E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
-          E2E_TEST_GROUP_ID: ${{ secrets.E2E_TEST_GROUP_ID }}
+          # E2E_TEST_GROUP_ID は渡さず global-setup で run ごとに新規 group を作る。
+          # 並走 PR 同士のテストデータ衝突を避けるため。
           VERCEL_BYPASS_TOKEN: ${{ secrets.VERCEL_BYPASS_TOKEN }}
 
       - name: Write test summary

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,7 +78,8 @@ jobs:
           E2E_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
           E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
-          E2E_TEST_GROUP_ID: ${{ secrets.E2E_TEST_GROUP_ID }}
+          # E2E_TEST_GROUP_ID は渡さず global-setup で run ごとに新規 group を作る。
+          # 並走 PR 同士のテストデータ衝突を避けるため。
 
       - name: Write test summary
         if: always()

--- a/frontend/.env.e2e.example
+++ b/frontend/.env.e2e.example
@@ -3,16 +3,18 @@
 # .env.e2e は git 管理外 (.gitignore 済)
 #
 # ローカルでの使い方:
-#   # 1. E2E_TEST_GROUP_ID 以外を埋めた .env.e2e を用意
+#   # 1. .env.e2e を用意（E2E_TEST_GROUP_ID は任意）
 #   # 2. バックエンドを起動
 #   source frontend/.env.e2e && cd backend && go run .
-#   # 3. テストグループを作成（初回のみ）
-#   cd frontend && npm run setup:e2e
-#   # → 出力された UUID を E2E_TEST_GROUP_ID に設定する
-#   # 4. E2E テスト実行
+#   # 3. E2E テスト実行
 #   cd frontend && npm run test:e2e
 #   # playwright.config.ts が .env.e2e を自動読み込みするため
 #   # NEXT_PUBLIC_* と E2E_* は自動で設定される
+#
+# E2E_TEST_GROUP_ID について:
+#   - 未指定 → run ごとに新規 group が作成される（CI と同じ動作、データが衝突しない）
+#   - 指定済み → その group を毎回再利用（ローカルで UI からも見たいときに便利）
+#   固定 ID を使いたい場合のみ npm run setup:e2e で作成して下記に貼る
 
 # ─── Supabase 認証情報 ──────────────────────────────────────────────────────────
 # Supabase Dashboard → Project Settings → API から取得
@@ -28,11 +30,11 @@ E2E_SUPABASE_ANON_KEY=<anon-key>
 E2E_TEST_EMAIL=e2e-test@example.com
 E2E_TEST_PASSWORD=<password>
 
-# ─── E2E テストグループ ────────────────────────────────────────────────────────
-# 事前に作成したテスト専用グループの UUID
-# テストユーザーでログイン後 /join または API 経由で作成し、UUID を記録する
+# ─── E2E テストグループ (任意) ────────────────────────────────────────────────
+# 指定すると毎 run その group を再利用。未指定なら run ごとに新規 group を作成。
+# 固定 ID を作るには: cd frontend && npm run setup:e2e
 
-E2E_TEST_GROUP_ID=<group-uuid>
+E2E_TEST_GROUP_ID=
 
 # ─── バックエンド（go run . に渡す env vars）───────────────────────────────────
 # Supabase Dashboard → Project Settings → Database

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -8,18 +8,13 @@ async function globalSetup() {
   const supabaseAnonKey = process.env.E2E_SUPABASE_ANON_KEY;
   const testEmail = process.env.E2E_TEST_EMAIL;
   const testPassword = process.env.E2E_TEST_PASSWORD;
-  const testGroupId = process.env.E2E_TEST_GROUP_ID;
+  let testGroupId = process.env.E2E_TEST_GROUP_ID;
+  const backendUrl = process.env.PREVIEW_BACKEND_URL || "http://localhost:8080";
 
-  if (
-    !supabaseUrl ||
-    !supabaseAnonKey ||
-    !testEmail ||
-    !testPassword ||
-    !testGroupId
-  ) {
+  if (!supabaseUrl || !supabaseAnonKey || !testEmail || !testPassword) {
     throw new Error(
       "E2E env vars not set: E2E_SUPABASE_URL, E2E_SUPABASE_ANON_KEY, " +
-        "E2E_TEST_EMAIL, E2E_TEST_PASSWORD, E2E_TEST_GROUP_ID",
+        "E2E_TEST_EMAIL, E2E_TEST_PASSWORD",
     );
   }
 
@@ -32,6 +27,32 @@ async function globalSetup() {
     throw new Error(
       `Supabase sign-in failed: ${error?.message ?? "no session returned"}`,
     );
+  }
+
+  // E2E_TEST_GROUP_ID 未指定時は CI run 毎に新規 group を作る。
+  // 並走する PR 同士で同じグループに書き込んで衝突するのを防ぐため。
+  // ローカル開発は .env.e2e に固定 ID を入れて従来通り再利用できる。
+  const ephemeral = !testGroupId;
+  if (!testGroupId) {
+    const runId = process.env.GITHUB_RUN_ID ?? `local-${Date.now()}`;
+    const runAttempt = process.env.GITHUB_RUN_ATTEMPT ?? "1";
+    const groupName = `e2e-${runId}-${runAttempt}`;
+    const createResp = await fetch(`${backendUrl}/api/groups`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${data.session.access_token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ name: groupName }),
+    });
+    if (!createResp.ok) {
+      throw new Error(
+        `POST /api/groups failed: ${createResp.status} ${await createResp.text()}`,
+      );
+    }
+    const group = (await createResp.json()) as { id: string };
+    testGroupId = group.id;
+    console.log(`globalSetup: created ephemeral test group ${testGroupId}`);
   }
 
   // Supabase JS v2 のローカルストレージキー: sb-{project-ref}-auth-token
@@ -58,6 +79,14 @@ async function globalSetup() {
   fs.writeFileSync(
     path.join(authDir, "user.json"),
     JSON.stringify(storageState, null, 2),
+  );
+
+  // teardown が group ID を参照できるよう書き出す。
+  // ephemeral フラグは将来 DELETE /api/groups/:id が実装されたときに
+  // 動的作成 group のみ削除するための識別に使う。
+  fs.writeFileSync(
+    path.join(authDir, "group.json"),
+    JSON.stringify({ id: testGroupId, ephemeral }),
   );
 }
 

--- a/frontend/e2e/global-teardown.ts
+++ b/frontend/e2e/global-teardown.ts
@@ -8,8 +8,22 @@ async function globalTeardown() {
   const supabaseAnonKey = process.env.E2E_SUPABASE_ANON_KEY;
   const testEmail = process.env.E2E_TEST_EMAIL;
   const testPassword = process.env.E2E_TEST_PASSWORD;
-  const testGroupId = process.env.E2E_TEST_GROUP_ID;
   const backendUrl = process.env.PREVIEW_BACKEND_URL || "http://localhost:8080";
+
+  // 動的作成された group の ID は global-setup が .auth/group.json に書き出す。
+  // env 指定（ローカル開発の固定 ID）でも setup が同じファイルに書く。
+  // ephemeral フラグは将来 DELETE /api/groups/:id が実装されたとき、
+  // 動的作成 group のみ削除するために setup 側で永続化している。
+  const groupFile = path.join(process.cwd(), ".auth", "group.json");
+  let testGroupId: string | undefined;
+  if (fs.existsSync(groupFile)) {
+    const parsed = JSON.parse(fs.readFileSync(groupFile, "utf8")) as {
+      id: string;
+    };
+    testGroupId = parsed.id;
+  } else {
+    testGroupId = process.env.E2E_TEST_GROUP_ID;
+  }
 
   if (
     !supabaseUrl ||


### PR DESCRIPTION
## Summary

- `global-setup.ts`: `E2E_TEST_GROUP_ID` 未指定なら POST /api/groups で run 毎に新規 group を作成し、その ID を storage state に注入
- `global-teardown.ts`: setup が `.auth/group.json` に書き出した group ID を使い、stock-items を掃除（既存ロジック）
- `e2e.yml` / `e2e-preview.yml`: secret `E2E_TEST_GROUP_ID` を渡すのをやめる
- `.env.e2e.example`: 任意項目として記述を更新（ローカル開発で固定 ID 再利用も可）

## なぜ

並走する PR の E2E が同じ `E2E_TEST_GROUP_ID` を共有していたため、Renovate batch や同時 push でテストデータが衝突し失敗していた。各 CI run が独自の group を持てば衝突しない。

## Group cleanup について

backend に DELETE /api/groups/:id が未実装のため、現状は group 行自体は残す方針 (cleanup なし)。
- 影響: 週 1 Renovate run で年 ~52 行。実害なし
- 将来 DELETE エンドポイントが追加されたら teardown 側で削除に切り替える（global-setup が永続化する `ephemeral: true` フラグでマーキング済み）

## 後方互換

`E2E_TEST_GROUP_ID` が env に設定されていれば従来通りその group を再利用。ローカル開発で「常に同じ group を UI で見たい」ケースを壊さない。

## Test plan

- [ ] CI の e2e と e2e-preview が新規 group 作成パスでパス
- [ ] Mend Dashboard で次回 Renovate batch (月曜) の複数 PR が並走しても e2e が衝突しない
- [ ] ローカル: `.env.e2e` の `E2E_TEST_GROUP_ID` を空にして `npm run test:e2e` で新規 group 作成して pass

Closes #207