### PR TITLE
fix(e2e): disable framer-motion animations via prefers-reduced-motion

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -144,3 +144,15 @@ proposal.md の「ユーザーシナリオとテスト設計」セクション�
   2. SW E2E は `npm run test:e2e:sw`（`sw` project, 本番ビルド, port 3001）で opt-in 実行し pass を確認する。`mock`/`preview` project は SW を block するため SW 挙動の検証には使えない
   3. E2E アサートは「新戦略でしか通らない」discriminator になっているか（旧戦略では落ちるか）を確認する
   4. ChunkLoadError 自己回復のような副作用ロジックは実ブラウザ再現が高コスト/flaky なため、mock したグローバル（`caches`/`serviceWorker`/`sessionStorage`/`location.reload`）への unit で担保し E2E を増やさない
+
+### 2026-06-18: AnimatePresence 由来の E2E flaky はテスト環境で reducedMotion により無効化する（アサート whack-a-mole より優先）
+
+- **対象シナリオ:** filter.spec.ts F-3（買いたいものだけフィルター）ほか filter/modal の AnimatePresence 干渉クラス全般
+- **変更前:** flaky が出るたびに該当アサートへ `not.toBeAttached()` 待機を個別追加（whack-a-mole）
+- **変更後:** アプリを `<MotionConfig reducedMotion="user">` で包み、Playwright の `mock`/`preview` project に `contextOptions: { reducedMotion: "reduce" }` を設定して、テスト環境で framer-motion の transform/layout アニメをまとめて無効化する
+- **理由:** flaky の真因は exit fade のレースではなく、`layout`/`popLayout` の **transform/layout churn でカード位置が動き locator/click が moving target になる**こと（`toBeVisible` は opacity を見ず、解消は AnimatePresence の unmount で起きる）。reducedMotion="user" は本番では prefers-reduced-motion を尊重する a11y 改善になり、テスト専用フラグを増やさない
+- **一般化した基準:**
+  1. framer-motion の `layout`/`AnimatePresence`/transform アニメ起因の E2E flaky は、まず**テスト環境での reducedMotion 無効化**で対処する（個別アサート待機の追加は補助）
+  2. `reducedMotion` は @playwright/test では top-level `use` ではなく **`contextOptions: { reducedMotion: "reduce" }`** に置く。`sw` project には付けない
+  3. reducedMotion は transform/layout を無効化するが **opacity exit は残る**ため、unmount を待つ既存の `not.toBeAttached()` 待機は引き続き load-bearing。除去しない
+  4. flaky fix は「1回 green」では不十分。ローカル `--repeat-each` が不可なら CI の該当ジョブを複数回再実行して連続 green を確認する

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -50,6 +50,10 @@ export default defineConfig({
       name: "preview",
       retries: 1,
       use: {
+        // Emulate prefers-reduced-motion so framer-motion (via MotionConfig
+        // reducedMotion="user") disables transform/layout animations, which
+        // otherwise destabilize locator/click resolution.
+        contextOptions: { reducedMotion: "reduce" },
         storageState: ".auth/user.json",
         baseURL: process.env.PREVIEW_URL,
         extraHTTPHeaders: process.env.VERCEL_BYPASS_TOKEN
@@ -63,6 +67,8 @@ export default defineConfig({
       name: "mock",
       retries: 1,
       use: {
+        // See preview project: disable animations via reduced-motion emulation.
+        contextOptions: { reducedMotion: "reduce" },
         storageState: ".auth/user.json",
         baseURL: "http://localhost:3000",
         serviceWorkers: "block",

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { ChunkLoadRecovery } from "@/components/ChunkLoadRecovery";
+import { MotionProvider } from "@/components/MotionProvider";
 import { PreconnectLinks } from "@/components/PreconnectLinks";
 import { ServiceWorkerRegister } from "@/components/ServiceWorkerRegister";
 import { AuthProvider } from "@/contexts/AuthContext";
@@ -45,7 +46,9 @@ export default function RootLayout({
       <body className="min-h-full flex flex-col">
         <ServiceWorkerRegister />
         <ChunkLoadRecovery />
-        <AuthProvider>{children}</AuthProvider>
+        <MotionProvider>
+          <AuthProvider>{children}</AuthProvider>
+        </MotionProvider>
       </body>
     </html>
   );

--- a/frontend/src/components/MotionProvider.test.tsx
+++ b/frontend/src/components/MotionProvider.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { motion } from "framer-motion";
+import { describe, expect, it } from "vitest";
+import { MotionProvider } from "./MotionProvider";
+
+function setReducedMotion(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes("prefers-reduced-motion") ? matches : false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+describe("MotionProvider", () => {
+  it("子要素を描画する", () => {
+    render(
+      <MotionProvider>
+        <span>child content</span>
+      </MotionProvider>,
+    );
+    expect(screen.getByText("child content")).toBeInTheDocument();
+  });
+
+  it("reduced-motion 要求時は transform tween をスキップし終了値を即適用する", async () => {
+    setReducedMotion(true);
+    render(
+      <MotionProvider>
+        <motion.div
+          data-testid="box"
+          animate={{ x: 100 }}
+          transition={{ duration: 10 }}
+        />
+      </MotionProvider>,
+    );
+    // reducedMotion="user" を MotionConfig が設定しているため、reduce 要求下では
+    // framer-motion は transform tween をスキップし終了値 (translateX(100px)) を
+    // 即適用する。MotionProvider で包まない場合 framer-motion の既定は
+    // reducedMotion="never" となり、10s tween は waitFor の既定タイムアウト内に
+    // 終了値へ到達しない。よってこのアサートは provider 由来の挙動の discriminator。
+    await waitFor(() =>
+      expect(screen.getByTestId("box").style.transform).toContain("100px"),
+    );
+  });
+});

--- a/frontend/src/components/MotionProvider.tsx
+++ b/frontend/src/components/MotionProvider.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { MotionConfig } from "framer-motion";
+
+/**
+ * Wraps the app tree so framer-motion honors the user's
+ * `prefers-reduced-motion` setting. Users (and automated agents such as
+ * Playwright emulating `reducedMotion: "reduce"`) that request reduced motion
+ * get transform/layout animations disabled — an accessibility improvement that
+ * also stabilizes E2E locator/click resolution.
+ */
+export function MotionProvider({ children }: { children: React.ReactNode }) {
+  return <MotionConfig reducedMotion="user">{children}</MotionConfig>;
+}


### PR DESCRIPTION
## 概要

`filter.spec.ts` F-3 をはじめとする framer-motion アニメ起因の flaky E2E（"waiting for element to be ... stable" タイムアウト、フィルタ除外された `<article>` の残存）を解消する。テスト専用 env フラグではなく `prefers-reduced-motion` チャネル経由で無効化する。

## 変更

1. **`MotionProvider`**（`"use client"`）を追加し、アプリツリーを framer-motion の `<MotionConfig reducedMotion="user">` で包む。これにより framer-motion が全環境でユーザーの `prefers-reduced-motion` 設定を尊重するようになる（本番でも正当なアクセシビリティ改善。reduced motion を要求するユーザー/エージェントのみ挙動が変わる）。`layout.tsx`（Server Component）は維持したまま `<AuthProvider>` を包む。
2. **`playwright.config.ts`**: `mock` / `preview` project に `contextOptions: { reducedMotion: "reduce" }` を設定（`sw` project は除外）。Playwright が `prefers-reduced-motion: reduce` をエミュレートし、E2E 中の transform / layout アニメが無効化される。

> 注: タスク指示の `use: { reducedMotion }` は @playwright/test 1.59.1 では top-level test option ではなく tsc が通らないため、機能的に等価な `contextOptions.reducedMotion`（全 `newContext()` に spread される）を使用。

## 検証

- Vitest 291 件 pass（新規 `MotionProvider.test.tsx` 含む）。新規テストは `MotionConfig reducedMotion="user"` 配下で reduce 要求時に 10s transform tween がスキップされ終了値が即適用されることをアサート（provider 無しでは到達しない discriminator）。
- tsc / Biome lint clean。
- ブラウザレベルで Playwright `reducedMotion: "reduce"` → `prefers-reduced-motion: reduce` matches=true を確認。
- **F-3 の `--repeat-each` による flaky 検証はローカルの E2E テストアカウント creds（`E2E_SUPABASE_URL`/`E2E_TEST_EMAIL` 等）が未設定のため未実施。この PR の CI E2E で確認する。**

## 残課題（既存 wait は維持）

`reducedMotion` は transform / layout アニメのみ無効化する（`layout`/`popLayout` は対象）。`AnimatePresence` exit の opacity フェード（`duration:0.5`）は無効化されないため、フィルタ除外 `<article>` の opacity exit 中の残存は引き続き既存の `not.toBeAttached()` 待機（testing.md 2026-05-26）でカバーする。本 PR は支配的な flaky 要因を狙う。

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)