### PR TITLE
perf(frontend): 起動時の過剰フェッチを解消（groups ×6→1, stock-items ×4→1）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 # Serena MCP (local state)
 .serena/
 
+# Performance captures (may contain auth tokens/session data — never commit)
+measurement/
+*.har
+
 # Next.js
 .next/
 out/

--- a/frontend/src/app/stock-items/page.test.tsx
+++ b/frontend/src/app/stock-items/page.test.tsx
@@ -42,8 +42,8 @@ vi.mock("@/contexts/AuthContext", () => ({
     // biome-ignore lint/suspicious/noExplicitAny: minimal mock; full Session type not needed in tests
     session: { access_token: "test-token" } as any,
     user: null,
-    group: null,
-    groups: [],
+    group: { groupId: "group-1", name: "我が家", role: "owner" },
+    groups: [{ groupId: "group-1", name: "我が家", role: "owner" }],
     loading: false,
     signInWithGoogle: vi.fn(),
     signOut: mockSignOut,
@@ -151,7 +151,7 @@ describe("StockItemsPage", () => {
       expect(deleteStockItem).toHaveBeenCalledWith(
         "1",
         "test-token",
-        undefined,
+        "group-1",
       );
       expect(screen.queryByText("醤油")).not.toBeInTheDocument();
     });
@@ -210,7 +210,7 @@ describe("StockItemsPage", () => {
           category: "調味料",
         },
         "test-token",
-        undefined,
+        "group-1",
       );
       expect(screen.getByText("濃口醤油")).toBeInTheDocument();
     });
@@ -241,7 +241,7 @@ describe("StockItemsPage", () => {
         "1",
         { wantToBuy: true },
         "test-token",
-        undefined,
+        "group-1",
       );
     });
 
@@ -382,7 +382,7 @@ describe("StockItemsPage", () => {
         "1",
         { wantToBuy: true },
         "test-token",
-        undefined,
+        "group-1",
       );
     });
   });
@@ -516,7 +516,7 @@ describe("StockItemsPage", () => {
         "1",
         expect.not.objectContaining({ sortedAt: expect.anything() }),
         "test-token",
-        undefined,
+        "group-1",
       );
     });
   });
@@ -547,7 +547,7 @@ describe("StockItemsPage", () => {
         "2",
         expect.not.objectContaining({ sortedAt: expect.anything() }),
         "test-token",
-        undefined,
+        "group-1",
       );
     });
   });

--- a/frontend/src/app/stock-items/startupFetch.integration.test.tsx
+++ b/frontend/src/app/stock-items/startupFetch.integration.test.tsx
@@ -1,0 +1,100 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider, useAuth } from "@/contexts/AuthContext";
+import type { GroupInfo } from "@/types/group";
+import { useStockItems } from "./useStockItems";
+
+// Integration test: REAL AuthProvider + REAL useStockItems wired exactly like
+// StockItemsClient. Reproduces the startup timing race where onAuthStateChange
+// flips authLoading=false (INITIAL_SESSION) while groups are still in flight,
+// causing useStockItems to fetch twice (once with activeGroupId === undefined).
+
+const mockGetSession = vi.fn();
+const mockOnAuthStateChange = vi.fn();
+const mockClient = {
+  auth: {
+    getSession: mockGetSession,
+    onAuthStateChange: mockOnAuthStateChange,
+    signInWithOAuth: vi.fn(),
+    signOut: vi.fn(),
+  },
+};
+
+vi.mock("@/lib/supabaseClient", () => ({
+  getSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/authApi");
+vi.mock("@/lib/api");
+vi.mock("@/lib/useStockItemsRealtime");
+
+import { fetchStockItems } from "@/lib/api";
+import { fetchMyGroups } from "@/lib/authApi";
+import { getSupabaseClient } from "@/lib/supabaseClient";
+
+// Mirrors StockItemsClient.tsx wiring.
+function Harness() {
+  const { session, group, loading, refreshGroup } = useAuth();
+  useStockItems(session?.access_token, group?.groupId, refreshGroup, loading);
+  return null;
+}
+
+beforeEach(() => {
+  vi.mocked(getSupabaseClient).mockReturnValue(mockClient as never);
+  vi.mocked(fetchStockItems).mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe("startup stock-items fetch", () => {
+  it("fetches stock-items exactly once and never with undefined group despite the auth-event/group timing race", async () => {
+    const session = { access_token: "tok", user: { id: "u1" } };
+    mockGetSession.mockResolvedValue({ data: { session } });
+
+    // onAuthStateChange emits INITIAL_SESSION asynchronously after subscribe,
+    // as the real Supabase client does.
+    let stateCallback: (event: string, s: unknown) => void = () => {};
+    mockOnAuthStateChange.mockImplementation((cb) => {
+      stateCallback = cb;
+      queueMicrotask(() => cb("INITIAL_SESSION", session));
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
+    });
+
+    // Controllable deferred so the group fetch is genuinely in flight while the
+    // INITIAL_SESSION event fires (this is what exposes the race).
+    let resolveGroups: (gs: GroupInfo[]) => void = () => {};
+    vi.mocked(fetchMyGroups).mockReturnValue(
+      new Promise<GroupInfo[]>((r) => {
+        resolveGroups = r;
+      }),
+    );
+
+    render(
+      <AuthProvider>
+        <Harness />
+      </AuthProvider>,
+    );
+
+    // Let getSession + INITIAL_SESSION settle while groups are still pending.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Now resolve groups — the active group becomes known.
+    await act(async () => {
+      resolveGroups([{ groupId: "g1", name: "我が家", role: "owner" }]);
+    });
+
+    await waitFor(() => {
+      expect(fetchStockItems).toHaveBeenCalledTimes(1);
+    });
+
+    // Never fetched with an undefined active group.
+    for (const call of vi.mocked(fetchStockItems).mock.calls) {
+      expect(call[1]).toBe("g1");
+    }
+    expect(stateCallback).toBeTypeOf("function");
+  });
+});

--- a/frontend/src/app/stock-items/useStockItems.ts
+++ b/frontend/src/app/stock-items/useStockItems.ts
@@ -79,7 +79,11 @@ export function useStockItems(
   );
 
   useEffect(() => {
-    if (authLoading) return;
+    // アクティブグループが未確定のうちは fetch しない。起動時に authLoading が
+    // groups 取得完了より先に false になっても、activeGroupId=undefined での
+    // 無駄な fetch を防ぎ、グループ確定後に 1 回だけ取得する。グループ未所属の
+    // ユーザーは AuthGuard が /no-group へ遷移させるため、ここで取得しなくてよい。
+    if (authLoading || !activeGroupId) return;
     setLoading(true);
     setError(null);
     fetchStockItems(accessToken, activeGroupId)

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GroupInfo } from "@/types/group";
 import { AuthProvider, useAuth } from "./AuthContext";
 
 // Supabase client のモック
@@ -230,6 +231,53 @@ describe("AuthContext", () => {
 
     // dedup ガードがあっても refreshGroup は強制再取得する
     expect(fetchMyGroups).toHaveBeenCalledTimes(2);
+  });
+
+  it("起動時、永続セッション復元中は groups 解決まで loading=true を維持する（早期 no-group 取りこぼし防止）", async () => {
+    // getSession は永続セッションを返す（null ではない）。これが本リグレッションの肝。
+    const session = { access_token: "tok", user: { id: "u1" } };
+    mockGetSession.mockResolvedValue({ data: { session } });
+
+    // fetchMyGroups を手動制御の deferred にして、解決前に loading を観測する。
+    let resolveGroups: (gs: GroupInfo[]) => void = () => {};
+    vi.mocked(fetchMyGroups).mockReturnValue(
+      new Promise<GroupInfo[]>((resolve) => {
+        resolveGroups = resolve;
+      }),
+    );
+
+    let stateCallback: (event: string, session: unknown) => void = () => {};
+    mockOnAuthStateChange.mockImplementation((cb) => {
+      stateCallback = cb;
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
+    });
+
+    renderWithAuth();
+
+    // getSession が解決し loadGroups が起動するのを待つ。
+    await waitFor(() => expect(fetchMyGroups).toHaveBeenCalledTimes(1));
+
+    // INITIAL_SESSION が fetch 進行中に発火（同一トークン → dedup される）。
+    // 修正前はここで onAuthStateChange の無条件 setLoading(false) が走り、
+    // group=null のまま loading が false になって AuthGuard が誤って /no-group へ飛ばす。
+    act(() => {
+      stateCallback("INITIAL_SESSION", session);
+    });
+
+    // groups 未解決の間は loading=true を維持していること（= no-group 表示を出さない）。
+    expect(screen.getByText("loading")).toBeInTheDocument();
+    expect(
+      screen.queryByText("authenticated:no-group"),
+    ).not.toBeInTheDocument();
+
+    // groups が解決したら通常通り表示される。
+    await act(async () => {
+      resolveGroups([{ groupId: "g1", name: "我が家", role: "owner" }]);
+    });
+    await waitFor(() =>
+      expect(screen.getByText("authenticated:我が家")).toBeInTheDocument(),
+    );
+    expect(fetchMyGroups).toHaveBeenCalledTimes(1);
   });
 
   it("localStorage に保存された active group id を復元する", async () => {

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -43,6 +43,18 @@ function TestConsumer() {
   );
 }
 
+type AuthContextHandle = { refreshGroup: () => Promise<void> };
+
+function RefreshCapture({
+  onReady,
+}: {
+  onReady: (handle: AuthContextHandle) => void;
+}) {
+  const { refreshGroup } = useAuth();
+  onReady({ refreshGroup });
+  return null;
+}
+
 function renderWithAuth() {
   return render(
     <AuthProvider>
@@ -152,6 +164,72 @@ describe("AuthContext", () => {
     );
 
     expect(localStorage.getItem("pantry-panel:active-group-id")).toBe("g2");
+  });
+
+  it("初期ロードで getSession と INITIAL_SESSION が同じトークンを返しても groups 取得は 1 回だけ", async () => {
+    const session = { access_token: "tok", user: { id: "u1" } };
+    mockGetSession.mockResolvedValue({ data: { session } });
+    let stateCallback: (event: string, session: unknown) => void = () => {};
+    mockOnAuthStateChange.mockImplementation((cb) => {
+      stateCallback = cb;
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
+    });
+    vi.mocked(fetchMyGroups).mockResolvedValue([
+      { groupId: "g1", name: "我が家", role: "owner" },
+    ]);
+
+    renderWithAuth();
+    await waitFor(() =>
+      expect(screen.getByText("authenticated:我が家")).toBeInTheDocument(),
+    );
+
+    // onAuthStateChange が起動時に発する一連のイベント（INITIAL_SESSION →
+    // SIGNED_IN → TOKEN_REFRESHED）は同じトークンを運ぶ。getSession 経路と
+    // 合わせても fetchMyGroups は 1 回だけであるべき。
+    act(() => {
+      stateCallback("INITIAL_SESSION", session);
+      stateCallback("SIGNED_IN", session);
+      stateCallback("TOKEN_REFRESHED", session);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("authenticated:我が家")).toBeInTheDocument(),
+    );
+    expect(fetchMyGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it("Supabase 未設定でも loading=false になる", async () => {
+    vi.mocked(getSupabaseClient).mockReturnValue(null);
+    renderWithAuth();
+    // loading フォールバックが消えて中身が描画されること
+    await waitFor(() =>
+      expect(screen.queryByText("loading")).not.toBeInTheDocument(),
+    );
+    expect(fetchMyGroups).not.toHaveBeenCalled();
+  });
+
+  it("refreshGroup は同じトークンでも groups を再取得する", async () => {
+    const session = { access_token: "tok", user: { id: "u1" } };
+    mockGetSession.mockResolvedValue({ data: { session } });
+    vi.mocked(fetchMyGroups).mockResolvedValue([
+      { groupId: "g1", name: "我が家", role: "owner" },
+    ]);
+
+    let captured: AuthContextHandle | null = null;
+    render(
+      <AuthProvider>
+        <RefreshCapture onReady={(h) => (captured = h)} />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(fetchMyGroups).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await captured?.refreshGroup();
+    });
+
+    // dedup ガードがあっても refreshGroup は強制再取得する
+    expect(fetchMyGroups).toHaveBeenCalledTimes(2);
   });
 
   it("localStorage に保存された active group id を復元する", async () => {

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -71,6 +71,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       loadedTokenRef.current = accessToken;
       const gs = await fetchMyGroups(accessToken).catch(() => []);
       applyGroups(gs);
+      // groups が確定してから loading を解除する。dedup の早期 return より後に
+      // あるため、同一トークンの重複呼び出しは loading を倒さない（実 fetch のみ）。
+      setLoading(false);
     },
     [applyGroups],
   );
@@ -85,7 +88,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setSession(s);
       setUser(s?.user ?? null);
       if (s) {
-        loadGroups(s.access_token).finally(() => setLoading(false));
+        // loadGroups が applyGroups 後に loading を解除する。
+        loadGroups(s.access_token);
       } else {
         setLoading(false);
       }
@@ -98,16 +102,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const {
       data: { subscription },
     } = client.auth.onAuthStateChange((_event, s) => {
-      setSession(s);
-      setUser(s?.user ?? null);
       if (s) {
+        setSession(s);
+        setUser(s.user ?? null);
+        // セッションありの場合は loadGroups が applyGroups 後に loading を解除する。
+        // ここで無条件に setLoading(false) すると group=null のまま loading が
+        // 倒れ、AuthGuard が起動時の group 取得待ち中に誤って /no-group へ飛ばす。
         loadGroups(s.access_token);
       } else {
+        setSession(null);
+        setUser(null);
         loadedTokenRef.current = null;
         setGroups([]);
         setGroup(null);
+        setLoading(false);
       }
-      setLoading(false);
     });
     return () => subscription.unsubscribe();
   }, [loadGroups]);

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import { fetchMyGroups } from "@/lib/authApi";
@@ -44,6 +45,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [groups, setGroups] = useState<GroupInfo[]>([]);
   const [group, setGroup] = useState<GroupInfo | null>(null);
   const [loading, setLoading] = useState(true);
+  // 直近に groups を取得したアクセストークン。起動時に getSession と
+  // onAuthStateChange(INITIAL_SESSION/SIGNED_IN/TOKEN_REFRESHED) が同じ
+  // トークンで重複発火しても /api/groups/me を 1 回に抑えるためのガード。
+  const loadedTokenRef = useRef<string | null>(null);
 
   const applyGroups = useCallback((gs: GroupInfo[]) => {
     setGroups(gs);
@@ -59,7 +64,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const loadGroups = useCallback(
-    async (accessToken: string) => {
+    async (accessToken: string, options?: { force?: boolean }) => {
+      // ガードは await の前に同期的に立てる。getSession と
+      // onAuthStateChange がほぼ同時に発火しても二重 fetch しないため。
+      if (!options?.force && loadedTokenRef.current === accessToken) return;
+      loadedTokenRef.current = accessToken;
       const gs = await fetchMyGroups(accessToken).catch(() => []);
       applyGroups(gs);
     },
@@ -94,9 +103,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (s) {
         loadGroups(s.access_token);
       } else {
+        loadedTokenRef.current = null;
         setGroups([]);
         setGroup(null);
       }
+      setLoading(false);
     });
     return () => subscription.unsubscribe();
   }, [loadGroups]);
@@ -120,6 +131,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const client = getSupabaseClient();
     if (!client) return;
     await client.auth.signOut();
+    loadedTokenRef.current = null;
     setSession(null);
     setUser(null);
     setGroups([]);
@@ -131,7 +143,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const refreshGroup = useCallback(async () => {
     if (!session) return;
-    await loadGroups(session.access_token);
+    // 同じトークンでもグループの作成/改名後は強制再取得する。
+    await loadGroups(session.access_token, { force: true });
   }, [session, loadGroups]);
 
   const switchGroup = useCallback(

--- a/frontend/src/lib/useStockItemsRealtime.test.tsx
+++ b/frontend/src/lib/useStockItemsRealtime.test.tsx
@@ -50,16 +50,50 @@ describe("useStockItemRealtime", () => {
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
-  it("SUBSCRIBED ステータスで onChange が呼ばれる（再接続修復）", () => {
+  it("SUBSCRIBED ステータスでは onChange を呼ばない（初期 fetch は useStockItems が担う）", () => {
     const onChange = vi.fn();
     renderHook(() => useStockItemsRealtime(onChange));
 
-    const statusCallback = mockChannel.subscribe.mock.calls[0][0] as (
-      s: string,
-    ) => void;
-    statusCallback("SUBSCRIBED");
+    const statusCallback = mockChannel.subscribe.mock.calls[0][0] as
+      | ((s: string) => void)
+      | undefined;
+    statusCallback?.("SUBSCRIBED");
 
-    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("onChange の identity が変わっても再 subscribe しない（チャンネルは 1 度だけ）", () => {
+    const onChangeA = vi.fn();
+    const onChangeB = vi.fn();
+    const { rerender } = renderHook(({ cb }) => useStockItemsRealtime(cb), {
+      initialProps: { cb: onChangeA },
+    });
+
+    expect(mockClient.channel).toHaveBeenCalledTimes(1);
+    expect(mockChannel.subscribe).toHaveBeenCalledTimes(1);
+
+    rerender({ cb: onChangeB });
+
+    // 再 subscribe / チャンネル再生成は起きない
+    expect(mockClient.channel).toHaveBeenCalledTimes(1);
+    expect(mockChannel.subscribe).toHaveBeenCalledTimes(1);
+    expect(mockClient.removeChannel).not.toHaveBeenCalled();
+  });
+
+  it("postgres_changes ハンドラは最新の onChange を呼ぶ", () => {
+    const onChangeA = vi.fn();
+    const onChangeB = vi.fn();
+    const { rerender } = renderHook(({ cb }) => useStockItemsRealtime(cb), {
+      initialProps: { cb: onChangeA },
+    });
+
+    rerender({ cb: onChangeB });
+
+    const onCallback = mockChannel.on.mock.calls[0][2] as () => void;
+    onCallback();
+
+    expect(onChangeA).not.toHaveBeenCalled();
+    expect(onChangeB).toHaveBeenCalledTimes(1);
   });
 
   it("アンマウント時に removeChannel が呼ばれる", () => {

--- a/frontend/src/lib/useStockItemsRealtime.ts
+++ b/frontend/src/lib/useStockItemsRealtime.ts
@@ -1,7 +1,14 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { getSupabaseClient } from "./supabaseClient";
 
 export function useStockItemsRealtime(onChange: () => void): void {
+  // 常に最新の onChange を参照するための ref。これによりチャンネルを
+  // 1 度だけ生成し、accessToken / activeGroupId 変更で再 subscribe しない。
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  // deps は [] 固定。チャンネルはマウント時に 1 度だけ生成し、
+  // アンマウント時にのみ片付ける。
   useEffect(() => {
     const client = getSupabaseClient();
     if (!client) return;
@@ -11,14 +18,12 @@ export function useStockItemsRealtime(onChange: () => void): void {
       .on(
         "postgres_changes",
         { event: "*", schema: "public", table: "stock_items" },
-        onChange, // INSERT/UPDATE/DELETE で onChange を呼ぶ
+        () => onChangeRef.current(), // INSERT/UPDATE/DELETE で最新 onChange を呼ぶ
       )
-      .subscribe((status) => {
-        if (status === "SUBSCRIBED") onChange();
-      });
+      .subscribe();
 
     return () => {
       client.removeChannel(channel);
     };
-  }, [onChange]);
+  }, []);
 }


### PR DESCRIPTION
Closes #216

## 背景（HAR 実測）
ログイン済み `/stock-items` の1回の読み込みで `GET /api/groups/me` ×6・`GET /api/stock-items` ×4 が発火していた（warm でも mobile RTT 増幅で「サインイン後が長い」体感の主因、Lambda/DB の無駄負荷）。

## 修正（4機構）
1. **groups dedup**: `loadGroups` に `loadedTokenRef` ガード（await 前に同期セット）→ getSession と onAuthStateChange の同一トークン重複を1回に collapse
2. **loading 配置**: `setLoading(false)` を `applyGroups` 後（`loadGroups` 内）へ移動 → 早期 return では loading を倒さず、groups 解決まで `authLoading=true` を維持
3. **stock-items guard**: `if (authLoading || !activeGroupId) return;` → group 未確定での undefined fetch と二重 fetch を防止
4. **realtime 単一購読**: `onChangeRef` で `useEffect([])` 化 → 依存変化での再購読ループと SUBSCRIBED 初回 fetch を除去

## 防いだ回帰（レビューで検出→本PRで修正）
- 起動時 stock-items 二重 fetch（1回目が `activeGroupId=undefined`）
- **`/no-group` stranding**: group 保有ユーザーがレース窓で `/no-group` に飛ばされ復帰不能 → loading 配置修正で解消

## テスト
- groups ×1 / stock-items ×1（実 AuthProvider+useStockItems 統合）/ no-group stranding / realtime 単一購読 — いずれも旧コードで fail する discriminator
- vitest 298 pass・tsc clean・biome clean

## スコープ外（follow-up 候補）
#2 直列ゲートの並行化（cached group で items 先行 fetch）・CORS preflight キャッシュ・起動JS削減（LazyMotion/realtime 遅延）

🤖 Generated with [Claude Code](https://claude.com/claude-code)