### PR TITLE
perf(pwa): SW navigation preload で起動時の白画面を短縮

### DIFF
--- a/frontend/src/sw.config.test.ts
+++ b/frontend/src/sw.config.test.ts
@@ -74,6 +74,22 @@ describe("Service Worker source guards", () => {
     });
   });
 
+  describe("S-8 guard: navigation preload + document network timeout", () => {
+    it("sw.ts enables navigationPreload on the Serwist constructor", () => {
+      // navigationPreload lets the browser start the document fetch in parallel
+      // with SW boot, removing the white-screen-on-relaunch serialization.
+      expect(swSource).toMatch(/navigationPreload:\s*true/);
+    });
+
+    it("sw.ts gives the document NetworkFirst handler a networkTimeoutSeconds fallback", () => {
+      // The document NetworkFirst handler must fall back to cache on a slow
+      // network instead of hanging on the navigation fetch.
+      const documentHandler =
+        /request\.destination\s*===\s*["']document["'][\s\S]{0,400}?new\s+NetworkFirst\(\{[\s\S]{0,400}?networkTimeoutSeconds:\s*3/;
+      expect(swSource).toMatch(documentHandler);
+    });
+  });
+
   describe("S-9: SW skipWaiting", () => {
     it("sw.ts (or @serwist/next config) sets skipWaiting: true", () => {
       expect(swSource).toMatch(/skipWaiting:\s*true/);

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -63,6 +63,11 @@ const runtimeCaching: RuntimeCaching[] = [
     matcher: ({ request }) => request.destination === "document",
     handler: new NetworkFirst({
       cacheName: "pantry-document-pages",
+      // Fall back to the cached document if the network is slow. Paired with
+      // navigationPreload below, the browser starts the document fetch in
+      // parallel with SW boot; this timeout bounds the worst-case wait before
+      // serving the last-known-good shell from cache.
+      networkTimeoutSeconds: 3,
     }),
     method: "GET",
   },
@@ -80,7 +85,12 @@ const serwist = new Serwist({
   precacheEntries: self.__SW_MANIFEST,
   skipWaiting: true,
   clientsClaim: true,
-  navigationPreload: false,
+  // Let the browser kick off the navigation (document) fetch in parallel with
+  // SW boot instead of waiting for the worker to evaluate before fetching.
+  // This removes the SW-boot serialization that caused a 2-3s white screen on
+  // every PWA relaunch. Serwist calls enableNavigationPreload() for this flag,
+  // and the NetworkFirst strategy automatically consumes event.preloadResponse.
+  navigationPreload: true,
   runtimeCaching,
 });
 


### PR DESCRIPTION
## 概要

モバイルPWAをホーム画面アイコンから**毎回（再起動のたび）**起動すると白画面が2-3秒続いてからスケルトンが表示される問題を改善する。

## 原因

- スケルトンは `/stock-items` の**静的プレレンダリングHTMLに既に含まれる**（白画面はJSのDL/パース待ちではない。JS/CSSはCacheFirstでキャッシュ済み）
- 唯一ネットワーク待ちなのが **document（`sw.ts` の NetworkFirst）**
- `Serwist` の `navigationPreload: false` のため、再起動のたびに **SW起動＆serwistバンドル評価が終わるまでナビゲーションの fetch が始められず直列化**していた（「毎回」発生する症状と一致）

## 変更

- `src/sw.ts` の `Serwist` に `navigationPreload: true`（SWブート中にブラウザが並行して document を先読み。serwistの network 戦略は `event.preloadResponse` を自動消費）
- document の `NetworkFirst` に `networkTimeoutSeconds: 3`（低速時にキャッシュへフォールバック）
- `sw.config.test.ts` にソース検査ガード2件を追加

キャッシュ戦略（NetworkFirst）自体は不変のため、過去に記録された失敗モード（古い chunk ハッシュ 404 → Suspense ハング）には触れない。shellのSWR/precache化（案B）は document fetch 自体が支配的と計測で判明した場合の follow-up。

## 検証

- Biome lint / tsc / Vitest（300 passed、新ガード2件含む）/ build すべて pass
- 生成 `sw.js` に `navigationPreload:!0` と `networkTimeoutSeconds:3`（documentハンドラ）を確認
- SW E2E（`sw` project）6 passed。S-8（NetworkFirst document 配信）の非回帰を確認

## 残部分（softwareで消せない）

manifest の `background_color: #ffffff` による OS 起動スプラッシュの白は software では制御不可。

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)